### PR TITLE
bin: swap legacy bootstrap

### DIFF
--- a/bin/clear_cache.php
+++ b/bin/clear_cache.php
@@ -1,15 +1,11 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once BIN_DIR . 'functions.php';
 
 global $site_config;
-
-require_once __DIR__ . '/../include/bittorrent.php';
-require_once BIN_DIR . 'functions.php';
 $database = '';
 clear_di_cache();
 cleanup(get_webserver_user());

--- a/bin/jobby.php
+++ b/bin/jobby.php
@@ -1,16 +1,11 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Jobby\Jobby;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container, $site_config;
 
 $jobby = $container->get(Jobby::class);

--- a/bin/mysql_drop_fks.php
+++ b/bin/mysql_drop_fks.php
@@ -1,24 +1,23 @@
 <?php
-$db = $container->get(Database::class);
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Pu239\Database;
-require_once __DIR__ . '/../include/runtime_safe.php';
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+global $container, $site_config;
 
-require_once __DIR__ . '/../include/bittorrent.php';
-global $site_config;
-$sql = "SELECT TABLE_NAME, CONSTRAINT_NAME 
-    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS 
-    WHERE CONSTRAINT_NAME LIKE '%_ibfk_%' AND CONSTRAINT_TYPE = 'FOREIGN KEY' AND TABLE_SCHEMA = " . sqlesc($site_config['db']['database']);
-$rs = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-while ($row = mysqli_fetch_assoc($rs)) {
+$db = $container->get(Database::class);
+
+$sql = "SELECT TABLE_NAME, CONSTRAINT_NAME
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_NAME LIKE '%_ibfk_%' AND CONSTRAINT_TYPE = 'FOREIGN KEY' AND TABLE_SCHEMA = :schema";
+$rows = $db->fetchAll($sql, ['schema' => $site_config['db']['database']]);
+foreach ($rows as $row) {
     $tbl = $row['TABLE_NAME'];
     $fk = $row['CONSTRAINT_NAME'];
-    $sql = "ALTER TABLE `" . $site_config['db']['database'] . "`.`$tbl` DROP FOREIGN KEY `$fk`";
+    $sql = "ALTER TABLE `{$site_config['db']['database']}`.`$tbl` DROP FOREIGN KEY `$fk`";
     echo $sql . "\n";
-    sql_query($sql);
+    $db->run($sql);
 }

--- a/bin/optimize_resize_images.php
+++ b/bin/optimize_resize_images.php
@@ -1,12 +1,5 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use DI\DependencyException;
 use DI\NotFoundException;
@@ -16,8 +9,12 @@ use Pu239\ImageProxy;
 use Pu239\Person;
 use Spatie\Image\Exceptions\InvalidManipulation;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container;
+
+$db = $container->get(Database::class);
 
 $limit = isset($argv[1]) && is_numeric($argv[1]) ? $argv[1] : 500;
 $offset = isset($argv[2]) && is_numeric($argv[2]) ? $argv[2] : 0;

--- a/bin/remove_altered_images.php
+++ b/bin/remove_altered_images.php
@@ -1,17 +1,11 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
-
-use Pu239\Database;
 use Pu239\ImageProxy;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container;
 
 set_time_limit(18000);

--- a/bin/remove_torrents.php
+++ b/bin/remove_torrents.php
@@ -1,17 +1,11 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
-
-use Pu239\Database;
 use Pu239\Torrent;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container;
 
 $time_start = microtime(true);

--- a/bin/rename_image_hashes.php
+++ b/bin/rename_image_hashes.php
@@ -1,15 +1,14 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Pu239\Database;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container;
+
+$db = $container->get(Database::class);
 
 if (!isset($argv[1]) || $argv[1] !== 'rehash') {
     app_halt("This script will rehash and rename all images in public/images/proxy directory\n\nTo run:\n{$argv[0]} rehash\n\n");

--- a/bin/resize_multi_threads.php
+++ b/bin/resize_multi_threads.php
@@ -1,15 +1,11 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Pu239\Cache;
-use Pu239\Database;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container;
 
 set_time_limit(18000);

--- a/bin/set_perms.php
+++ b/bin/set_perms.php
@@ -1,14 +1,11 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
-
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 require_once BIN_DIR . 'functions.php';
-global $site_config, $site_config;
+
+global $site_config, $BLOCKS;
 
 if (empty($BLOCKS)) {
     app_halt('BLOCKS are empty');

--- a/bin/uglify.php
+++ b/bin/uglify.php
@@ -1,10 +1,5 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Delight\Auth\AuthError;
 use Delight\Auth\NotLoggedInException;
@@ -13,7 +8,8 @@ use DI\NotFoundException;
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
 use Spatie\Image\Exceptions\InvalidManipulation;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 require_once INCL_DIR . 'function_users.php';
 require_once INCL_DIR . 'function_html.php';
 require_once BIN_DIR . 'functions.php';

--- a/bin/usersfix.php
+++ b/bin/usersfix.php
@@ -1,20 +1,16 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Pu239\Database;
 use Pu239\Userblock;
 use Pu239\Usersachiev;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 global $container;
+
+$db = $container->get(Database::class);
 
 // $fluent removed — use $this->db (ExtendedPdo)
 $users = $fluent->from('users')

--- a/bin/validate_images.php
+++ b/bin/validate_images.php
@@ -1,16 +1,15 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Pu239\Database;
 use Pu239\ImageProxy;
 
-require_once __DIR__ . '/../include/bittorrent.php';
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
 global $container, $site_config;
+
+$db = $container->get(Database::class);
 
 set_time_limit(18000);
 if (!isset($argv[1]) || ($argv[1] !== 'validate' && $argv[1] !== 'optimize' && $argv[1] !== 'purge')) {

--- a/migration-report.md
+++ b/migration-report.md
@@ -8,3 +8,23 @@
 $ rg "mysqli_|sql_query\(|sqlesc\(" public/tenpercent.php
 ```
 No matches.
+
+## bin
+- `bin/validate_images.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/optimize_resize_images.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/usersfix.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/uglify.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/clear_cache.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/mysql_drop_fks.php`: switched to `bootstrap_pdo.php`, migrated to `Pu239\Database` with bound parameters, and added strict typing.
+- `bin/jobby.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/rename_image_hashes.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/remove_torrents.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/set_perms.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/resize_multi_threads.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+- `bin/remove_altered_images.php`: switched to `bootstrap_pdo.php`, added strict typing, and removed legacy bootstrap scaffolding.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\(|sqlesc\(" bin
+```
+No matches.


### PR DESCRIPTION
## Summary
- replace legacy bittorrent bootstrap includes with `bootstrap_pdo.php`
- clean up obsolete bootstrap scaffolding and add strict types
- convert `mysql_drop_fks.php` to `Pu239\Database`

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: Required package mismatch in composer.lock)*
- `make qa` *(fails: vendor/bin/pint: No such file or directory)*
- `php -l bin/clear_cache.php bin/jobby.php bin/mysql_drop_fks.php bin/optimize_resize_images.php bin/remove_altered_images.php bin/remove_torrents.php bin/rename_image_hashes.php bin/resize_multi_threads.php bin/set_perms.php bin/uglify.php bin/usersfix.php bin/validate_images.php`


------
https://chatgpt.com/codex/tasks/task_e_68bddbb674748325bbeefe07c552872e