### PR TITLE
Migrate admin to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/admin/acpmanage.php
+++ b/admin/acpmanage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Pu239\Database;
 
 require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 require_once INCL_DIR . 'function_users.php';
 require_once INCL_DIR . 'function_html.php';
 require_once INCL_DIR . 'function_pager.php';
@@ -35,15 +36,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['ids'])) {
     }
     $do = isset($_POST['do']) ? htmlsafechars($_POST['do']) : '';
     if ($do == 'enabled') {
-        sql_query('UPDATE users SET status = 0 WHERE id IN (' . implode(', ', array_map('sqlesc', $ids)) . ') AND status = 2') or sqlerr(__FILE__, __LINE__);
-        $cache->update_row('user_' . $id, [
-            'status' => 0,
-        ], $site_config['expires']['user_cache']);
+        $placeholders = [];
+        $params = [];
+        foreach ($ids as $i => $id) {
+            $placeholders[] = ':id' . $i;
+            $params[':id' . $i] = $id;
+        }
+        $db->run('UPDATE users SET status = 0 WHERE id IN (' . implode(',', $placeholders) . ') AND status = 2', $params);
+        foreach ($ids as $id) {
+            $cache->update_row('user_' . $id, [
+                'status' => 0,
+            ], $site_config['expires']['user_cache']);
+        }
     } elseif ($do == 'confirm') {
-        sql_query('UPDATE users SET verified = 1 WHERE id IN (' . implode(', ', array_map('sqlesc', $ids)) . ') AND verified = 0') or sqlerr(__FILE__, __LINE__);
-        $cache->update_row('user_' . $id, [
-            'status' => 'confirmed',
-        ], $site_config['expires']['user_cache']);
+        $placeholders = [];
+        $params = [];
+        foreach ($ids as $i => $id) {
+            $placeholders[] = ':id' . $i;
+            $params[':id' . $i] = $id;
+        }
+        $db->run('UPDATE users SET verified = 1 WHERE id IN (' . implode(',', $placeholders) . ') AND verified = 0', $params);
+        foreach ($ids as $id) {
+            $cache->update_row('user_' . $id, [
+                'status' => 'confirmed',
+            ], $site_config['expires']['user_cache']);
+        }
     } elseif ($do == 'delete' && ($CURUSER['class'] >= UC_MAX)) {
         foreach ($ids as $id) {
             $username = account_delete((int) $id);

--- a/admin/bannedemails.php
+++ b/admin/bannedemails.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Pu239\Database;
 
 require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 require_once INCL_DIR . 'function_users.php';
 require_once INCL_DIR . 'function_html.php';
 require_once INCL_DIR . 'function_pager.php';
@@ -12,6 +13,7 @@ require_once CLASS_DIR . 'class_check.php';
 global $container, $CURUSER, $site_config;
 
 $db = $container->get(Database::class);
+$fluent = $db;
 
 $class = get_access(basename($_SERVER['REQUEST_URI']));
 class_check($class);
@@ -28,7 +30,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$email || !$comment) {
         stderr(_('Error'), _('Missing Form Data.'));
     }
-    sql_query('INSERT INTO bannedemails (added, addedby, comment, email) VALUES(' . TIME_NOW . ', ' . sqlesc($CURUSER['id']) . ', ' . sqlesc($comment) . ', ' . sqlesc($email) . ')') or sqlerr(__FILE__, __LINE__);
+    $db->run(
+        'INSERT INTO bannedemails (added, addedby, comment, email) VALUES (:added, :addedby, :comment, :email)',
+        [
+            ':added' => TIME_NOW,
+            ':addedby' => $CURUSER['id'],
+            ':comment' => $comment,
+            ':email' => $email,
+        ],
+    );
     header('Location: ' . $_SERVER['PHP_SELF'] . '?tool=bannedemails');
     app_halt('Exit called');
 }
@@ -52,15 +62,15 @@ $body = "
         </tr>";
 $HTMLOUT .= main_table($body) . '
     </form>';
-$db = $container->get(Database::class);
-$fluent = $db;
 $count1 = $fluent->from('bannedemails')
                  ->select(null)
                  ->select('COUNT(id) AS count')
-                 ->fetch("count");
+                 ->fetch('count');
 $perpage = 15;
 $pager = pager($perpage, $count1, 'staffpanel.php?tool=bannedemails&amp;');
-$res = sql_query('SELECT b.id, b.added, b.addedby, b.comment, b.email, u.username FROM bannedemails AS b LEFT JOIN users AS u ON b.addedby=u.id ORDER BY added DESC ' . $pager['limit']) or sqlerr(__FILE__, __LINE__);
+$rows = $db->fetchAll(
+    'SELECT b.id, b.added, b.addedby, b.comment, b.email, u.username FROM bannedemails AS b LEFT JOIN users AS u ON b.addedby = u.id ORDER BY added DESC ' . $pager['limit']
+);
 $HTMLOUT .= "<h1 class='has-text-centered'>" . _('Current Banned Emails') . '</h1>';
 if ($count1 > $perpage) {
     $HTMLOUT .= $pager['pagertop'];

--- a/admin/user_hits.php
+++ b/admin/user_hits.php
@@ -24,18 +24,17 @@ $id = (int) $_GET['id'];
 if (!is_valid_id($id) || $CURUSER['id'] != $id && $CURUSER['class'] < UC_STAFF) {
     $id = $CURUSER['id'];
 }
-$rows = $db->fetchAll('SELECT COUNT(id) FROM userhits WHERE hitid = ' . sqlesc($id)) or sqlerr(__FILE__, __LINE__);
-$row = mysqli_fetch_row($res);
-$count = $row[0];
+$count = (int) $db->fetch(
+    'SELECT COUNT(id) AS count FROM userhits WHERE hitid = :id',
+    [':id' => $id],
+)['count'];
 $perpage = 15;
 $pager = pager($perpage, $count, "staffpanel.php?tool=user_hits&amp;id=$id&amp;");
 if (!$count) {
     stderr(_('No views'), _('This user has had no profile views yet.'));
 }
 $users_class = $container->get(User::class);
-$user = $users_class->getUserFromId($id);
-$res = sql_query('SELECT username FROM users WHERE id=' . sqlesc($id)) or sqlerr(__FILE__, __LINE__);
-$user = mysqli_fetch_assoc($res);
+$user = $db->fetch('SELECT username FROM users WHERE id = :id', [':id' => $id]);
 $HTMLOUT .= '<h1>' . _('Profile views of ') . '' . format_username((int) $id) . '</h1>
 <h2>' . _('In total ') . '' . htmlsafechars($count) . '' . _(' views') . '</h2>';
 if ($count > $perpage) {
@@ -48,7 +47,10 @@ $HTMLOUT .= "
 <td class='colhead'>" . _('Username') . "</td>
 <td class='colhead'>" . _('Viewed at') . "</td>
 </tr>\n";
-$res = sql_query('SELECT uh.*, username, users.id AS uid FROM userhits uh LEFT JOIN users ON uh.userid=users.id WHERE hitid =' . sqlesc($id) . ' ORDER BY uh.id DESC ' . $pager['limit']);
+$rows = $db->fetchAll(
+    'SELECT uh.*, username, users.id AS uid FROM userhits AS uh LEFT JOIN users ON uh.userid = users.id WHERE hitid = :id ORDER BY uh.id DESC ' . $pager['limit'],
+    [':id' => $id],
+);
 foreach ($rows as $arr) {
     $HTMLOUT .= '
 <tr><td>' . number_format($arr['number']) . '</td>

--- a/migration-report.md
+++ b/migration-report.md
@@ -42,3 +42,14 @@ No matches.
 $ rg "mysqli_|sql_query\(|sqlesc\(" include
 ```
 No matches.
+
+## admin
+- `admin/bannedemails.php`: switched to `bootstrap_pdo.php` and migrated from legacy `sql_query`/`sqlesc` to `$db->run`/`fetchAll` with bound parameters.
+- `admin/user_hits.php`: removed `sql_query`, `mysqli_fetch_*`, and `sqlesc` in favor of `$db->fetch`/`fetchAll` with bound parameters.
+- `admin/acpmanage.php`: added `bootstrap_pdo.php` and converted bulk updates from `sql_query`/`sqlesc` to `$db->run` with named placeholders.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\(|sqlesc\(" admin/bannedemails.php admin/user_hits.php admin/acpmanage.php
+```
+No matches in modified files.


### PR DESCRIPTION
## Summary
- migrate select admin scripts to `Pu239\Database` with bound parameters
- standardize bootstrap to `bootstrap_pdo.php`
- document admin migration steps

## Testing
- `php -l admin/bannedemails.php admin/user_hits.php admin/acpmanage.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" admin/bannedemails.php admin/user_hits.php admin/acpmanage.php`


------
https://chatgpt.com/codex/tasks/task_e_68bde7c589c8832589d3cc95eff4f180