### PR TITLE
Migrate Blocks to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/blocks/global/demotion.php
+++ b/blocks/global/demotion.php
@@ -1,15 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
+use Pu239\Database;
 
 $user = check_user_status();
 global $site_config;
+
+$db = $container->get(Database::class);
 
 if ($user && $user['override_class'] != 255) {
     $htmlout .= "

--- a/blocks/global/freeleech.php
+++ b/blocks/global/freeleech.php
@@ -1,18 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Cache;
 
 $user = check_user_status();
 global $container;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $free = $cache->get('site_events_');
 if ($user) {

--- a/blocks/global/happyhour.php
+++ b/blocks/global/happyhour.php
@@ -1,15 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
+use Pu239\Database;
 
 $user = check_user_status();
 global $site_config;
+
+$db = $container->get(Database::class);
 
 if ($site_config['bonus']['happy_hour'] && !empty($user)) {
     require_once INCL_DIR . 'function_happyhour.php';

--- a/blocks/global/message.php
+++ b/blocks/global/message.php
@@ -1,17 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Message;
 
 $user = check_user_status();
 global $container, $site_config;
+
+$db = $container->get(Database::class);
 
 if ($site_config['alerts']['message'] && !empty($user)) {
     $messages_class = $container->get(Message::class);

--- a/blocks/index/advertise.php
+++ b/blocks/index/advertise.php
@@ -1,14 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
+use Pu239\Database;
 
 global $site_config;
+
+$db = $container->get(Database::class);
 
 $advertise .= "
     <a id='advertise-hash'></a>

--- a/blocks/index/ajaxchat.php
+++ b/blocks/index/ajaxchat.php
@@ -1,14 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
+use Pu239\Database;
 
 global $site_config;
+
+$db = $container->get(Database::class);
 
 $ajaxchat .= "
     <a id='ajaxchat-hash'></a>

--- a/blocks/index/comments.php
+++ b/blocks/index/comments.php
@@ -1,14 +1,11 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 require_once INCL_DIR . 'function_html.php';
 
+use Pu239\Database;
 use Pu239\Comment;
 use Pu239\Image;
 use Pu239\User;
@@ -16,6 +13,7 @@ use Pu239\User;
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $comment = $container->get(Comment::class);
 $comments = $comment->get_comments();
 $posted_comments .= "

--- a/blocks/index/cooker.php
+++ b/blocks/index/cooker.php
@@ -1,13 +1,10 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 use Pu239\Upcoming;
@@ -16,6 +13,7 @@ require_once INCL_DIR . 'function_torrent_hover.php';
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cooker_class = $container->get(Upcoming::class);
 $recipes = $cooker_class->get_all($site_config['latest']['recipes_limit'], 0, 'expected', false, false, true, (bool) $user['hidden']);
 $torrent_class = $container->get(Torrent::class);

--- a/blocks/index/disclaimer.php
+++ b/blocks/index/disclaimer.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
 global $site_config;
+
+$db = $container->get(Database::class);
 
 $disclaimer .= "
     <a id='disclaimer-hash'></a>

--- a/blocks/index/gift.php
+++ b/blocks/index/gift.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
 global $CURUSER, $site_config;
+
+$db = $container->get(Database::class);
 
 if ($CURUSER['gotgift'] === 'no') {
     $christmas_gift .= "

--- a/blocks/index/latest_movies.php
+++ b/blocks/index/latest_movies.php
@@ -1,13 +1,10 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 
@@ -15,6 +12,7 @@ require_once PARTIALS_DIR . 'torrent_table.php';
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $torrent = $container->get(Torrent::class);
 $last5movietorrents = $torrent->get_latest($site_config['categories']['movie']);
 

--- a/blocks/index/latest_torrents.php
+++ b/blocks/index/latest_torrents.php
@@ -1,19 +1,17 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $torrent = $container->get(Torrent::class);
 $last5torrents = $torrent->get_latest([]);
 

--- a/blocks/index/latest_torrents_glide.php
+++ b/blocks/index/latest_torrents_glide.php
@@ -1,18 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Cache;
 use Pu239\Torrent;
 
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $torrents = $cache->get('torrent_slider_block_');
 if ($torrents === false || is_null($torrents)) {

--- a/blocks/index/latest_torrents_scroll.php
+++ b/blocks/index/latest_torrents_scroll.php
@@ -1,18 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Cache;
 use Pu239\Torrent;
 
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $torrents = $cache->get('torrent_scroller_block_');
 if ($torrents === false || is_null($torrents)) {

--- a/blocks/index/latest_tv.php
+++ b/blocks/index/latest_tv.php
@@ -1,19 +1,17 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $torrent = $container->get(Torrent::class);
 $last5tvtorrents = $torrent->get_latest($site_config['categories']['tv']);
 

--- a/blocks/index/latest_user.php
+++ b/blocks/index/latest_user.php
@@ -1,17 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\User;
 
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $user_class = $container->get(User::class);
 $userid = $user_class->get_latest_user();
 $latestuser = format_username((int) $userid);

--- a/blocks/index/mow.php
+++ b/blocks/index/mow.php
@@ -1,19 +1,17 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $torrent = $container->get(Torrent::class);
 $motw = $torrent->get_mow();
 

--- a/blocks/index/offers.php
+++ b/blocks/index/offers.php
@@ -1,13 +1,10 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Offer;
 use Pu239\Torrent;
@@ -16,6 +13,7 @@ require_once INCL_DIR . 'function_torrent_hover.php';
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $offer_class = $container->get(Offer::class);
 $offered = $offer_class->get_all($site_config['latest']['offers_limit'], 0, 'added', false, false, (bool) $user['hidden']);
 $torrent_class = $container->get(Torrent::class);

--- a/blocks/index/poll.php
+++ b/blocks/index/poll.php
@@ -1,11 +1,10 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-
+$db = $container->get(Database::class);
 $site_poll .= parse_poll();

--- a/blocks/index/requests.php
+++ b/blocks/index/requests.php
@@ -1,13 +1,10 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Request;
 use Pu239\Torrent;
@@ -16,6 +13,7 @@ require_once INCL_DIR . 'function_torrent_hover.php';
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $request_class = $container->get(Request::class);
 $requested = $request_class->get_all($site_config['latest']['requests_limit'], 0, 'added', false, false, (bool) $user['hidden'], $user['id']);
 $torrent_class = $container->get(Torrent::class);

--- a/migration-report.md
+++ b/migration-report.md
@@ -55,6 +55,28 @@ $ rg "mysqli_|sql_query\(|sqlesc\(" admin/bannedemails.php admin/user_hits.php a
 No matches in modified files.
 
 ## blocks
+- `blocks/global/demotion.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/freeleech.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/happyhour.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/message.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/advertise.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/ajaxchat.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/comments.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/cooker.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/disclaimer.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/gift.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/latest_movies.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/latest_torrents.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/latest_torrents_glide.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/latest_torrents_scroll.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/latest_tv.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/latest_user.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/mow.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/offers.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/poll.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/requests.php`: standardized `bootstrap_pdo.php` and added strict typing.
+
+### Previous migrations
 - `blocks/index/forum_posts.php`: migrated from legacy `sql_query`/`mysqli_fetch_assoc` to `$db->fetchAll` with bound parameters and standardized bootstrap/strict typing.
 
 ### Verification


### PR DESCRIPTION
## Summary
- standardize bootstrap_pdo usage and enable strict types across first 20 Block components
- ensure Blocks obtain `Pu239\Database` instance through container
- document migration status for Blocks

## Testing
- `php -l blocks/global/demotion.php blocks/global/freeleech.php blocks/global/happyhour.php blocks/global/message.php blocks/index/advertise.php blocks/index/ajaxchat.php blocks/index/comments.php blocks/index/cooker.php blocks/index/disclaimer.php blocks/index/gift.php blocks/index/latest_movies.php blocks/index/latest_torrents.php blocks/index/latest_torrents_glide.php blocks/index/latest_torrents_scroll.php blocks/index/latest_tv.php blocks/index/latest_user.php blocks/index/mow.php blocks/index/offers.php blocks/index/poll.php blocks/index/requests.php`
- `rg -l "mysqli_|sql_query\(|sqlesc\(" blocks | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68bdedc5f93c8325b04cf15e35138810