### PR TITLE
Migrate Blocks to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/blocks/global/bugmessages.php
+++ b/blocks/global/bugmessages.php
@@ -1,12 +1,8 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
@@ -14,17 +10,12 @@ use Pu239\Database;
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 if ($site_config['alerts']['bug'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $bug_count = $cache->get('bug_mess_');
     if ($bug_count === false || is_null($bug_count)) {
-        // $fluent removed — use $this->db (ExtendedPdo)
-        $bug_count = $fluent->from('bugs')
-                            ->select(null)
-                            ->select('COUNT(id) AS count')
-                            ->where('status = ?', 'na')
-                            ->fetch("count");
-
+        $bug_count = $db->fetchValue('SELECT COUNT(id) FROM bugs WHERE status = ?', ['na']);
         $cache->set('bug_mess_', $bug_count, $site_config['expires']['alerts']);
     }
     if ($bug_count > 0) {

--- a/blocks/global/crazyhour.php
+++ b/blocks/global/crazyhour.php
@@ -1,22 +1,19 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
 use Pu239\Database;
 
-global $site_config;
+global $container, $site_config;
 
+$db = $container->get(Database::class);
 if ($site_config['bonus']['crazy_hour']) {
-    $htmlout .= crazyhour();
+    $htmlout .= crazyhour($db);
 }
 
 /**
@@ -27,33 +24,25 @@ if ($site_config['bonus']['crazy_hour']) {
  *
  * @return string
  */
-function crazyhour()
+function crazyhour(Database $db)
 {
     global $CURUSER, $container;
 
     $cache = $container->get(Cache::class);
-    // $fluent removed — use $this->db (ExtendedPdo)
     $htmlout = $cz = '';
     $crazy_hour = (TIME_NOW + 3600);
     $crazyhour['crazyhour'] = $cache->get('crazyhour_');
     if ($crazyhour['crazyhour'] === false || is_null($crazyhour['crazyhour'])) {
-        $crazyhour['crazyhour'] = $fluent->from('freeleech')
-                                         ->select(null)
-                                         ->select('var')
-                                         ->select('amount')
-                                         ->where("type = 'crazyhour'")
-                                         ->fetch();
+        $crazyhour['crazyhour'] = $db->fetch('SELECT var, amount FROM freeleech WHERE type = :type', [':type' => 'crazyhour']);
         if (empty($crazyhour['crazyhour'])) {
             $crazyhour['crazyhour']['var'] = random_int(TIME_NOW, (TIME_NOW + 86400));
             $crazyhour['crazyhour']['amount'] = 0;
             $update = [
-                'var' => $crazyhour['crazyhour']['var'],
-                'amount' => $crazyhour['crazyhour']['amount'],
+                ':var' => $crazyhour['crazyhour']['var'],
+                ':amount' => $crazyhour['crazyhour']['amount'],
+                ':type' => 'crazyhour',
             ];
-            $fluent->update('freeleech')
-                   ->set($update)
-                   ->where("type = 'crazyhour'")
-                   ->execute();
+            $db->run('UPDATE freeleech SET var = :var, amount = :amount WHERE type = :type', $update);
         }
         $cache->set('crazyhour_', $crazyhour['crazyhour'], 0);
     }
@@ -65,13 +54,11 @@ function crazyhour()
             $crazyhour['crazyhour']['amount'] = 0;
             $crazyhour['remaining'] = ($crazyhour['crazyhour']['var'] - TIME_NOW);
             $update = [
-                'var' => $crazyhour['crazyhour']['var'],
-                'amount' => $crazyhour['crazyhour']['amount'],
+                ':var' => $crazyhour['crazyhour']['var'],
+                ':amount' => $crazyhour['crazyhour']['amount'],
+                ':type' => 'crazyhour',
             ];
-            $fluent->update('freeleech')
-                   ->set($update)
-                   ->where("type = 'crazyhour'")
-                   ->execute();
+            $db->run('UPDATE freeleech SET var = :var, amount = :amount WHERE type = :type', $update);
             $cache->set('crazyhour_', $crazyhour['crazyhour'], 0);
             write_log('Next [color=#FFCC00][b]Crazyhour[/b][/color] is at ' . get_date((int) $crazyhour['crazyhour']['var'] + ($CURUSER['time_offset'] - 3600), 'LONG') . '');
             $msg = 'Next [color=orange][b]Crazyhour[/b][/color] is at ' . get_date((int) $crazyhour['crazyhour']['var'] + ($CURUSER['time_offset'] - 3600), 'LONG');
@@ -83,12 +70,10 @@ function crazyhour()
             $cz_lock = $cache->set('crazyhour_lock_', 1, 10);
             if ($cz_lock !== false) {
                 $update = [
-                    'amount' => $crazyhour['crazyhour']['amount'],
+                    ':amount' => $crazyhour['crazyhour']['amount'],
+                    ':type' => 'crazyhour',
                 ];
-                $fluent->update('freeleech')
-                       ->set($update)
-                       ->where("type = 'crazyhour'")
-                       ->execute();
+                $db->run('UPDATE freeleech SET amount = :amount WHERE type = :type', $update);
                 $cache->set('crazyhour_', $crazyhour['crazyhour'], 0);
                 $msg = _("It's CrazyHour");
                 write_log($msg);

--- a/blocks/global/freeleech_contribution.php
+++ b/blocks/global/freeleech_contribution.php
@@ -1,16 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
 global $container, $site_config;
+
+$db = $container->get(Database::class);
 
 require_once INCL_DIR . 'function_event.php';
 $free = get_event(false);
@@ -41,16 +39,9 @@ if (!empty($free) && $free['modifier'] != 0) {
     }
 }
 
-// $fluent removed — use $this->db (ExtendedPdo)
 $freeleech = $cache->get('freeleech_alerts_');
 if ($freeleech === false || is_null($freeleech)) {
-    $freeleech = $fluent->from('bonus')
-                        ->select(null)
-                        ->select('pointspool / points * 100 AS percent')
-                        ->select('enabled')
-                        ->where('id=11')
-                        ->fetch();
-
+    $freeleech = $db->fetch('SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id', [':id' => 11]);
     $cache->set('freeleech_alerts_', $freeleech, 0);
 }
 
@@ -86,13 +77,7 @@ if ($freeleech['enabled'] === 'yes') {
 
 $doubleupload = $cache->get('doubleupload_alerts_');
 if ($doubleupload === false || is_null($doubleupload)) {
-    $doubleupload = $fluent->from('bonus')
-                           ->select(null)
-                           ->select('pointspool / points * 100 AS percent')
-                           ->select('enabled')
-                           ->where('id=12')
-                           ->fetch();
-
+    $doubleupload = $db->fetch('SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id', [':id' => 12]);
     $cache->set('doubleupload_alerts_', $doubleupload, 0);
 }
 
@@ -128,13 +113,7 @@ if ($doubleupload['enabled'] === 'yes') {
 
 $halfdownload = $cache->get('halfdownload_alerts_');
 if ($halfdownload === false || is_null($halfdownload)) {
-    $halfdownload = $fluent->from('bonus')
-                           ->select(null)
-                           ->select('pointspool / points * 100 AS percent')
-                           ->select('enabled')
-                           ->where('id=13')
-                           ->fetch();
-
+    $halfdownload = $db->fetch('SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id', [':id' => 13]);
     $cache->set('halfdownload_alerts_', $halfdownload, 0);
 }
 

--- a/blocks/global/lottery.php
+++ b/blocks/global/lottery.php
@@ -1,12 +1,8 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
@@ -14,14 +10,14 @@ use Pu239\Database;
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
+
 if ($user) {
     $cache = $container->get(Cache::class);
     $lottery_info = $cache->get('lottery_info_');
     if ($lottery_info === false || is_null($lottery_info)) {
-        // $fluent removed — use $this->db (ExtendedPdo)
-        $lottery_info = $fluent->from('lottery_config')
-                               ->fetchPairs('name', 'value');
-
+        $lottery_info = $db->fetchAll('SELECT name, value FROM lottery_config');
+        $lottery_info = array_column($lottery_info, 'value', 'name');
         $cache->set('lottery_info_', $lottery_info, 86400);
     }
 

--- a/blocks/global/report.php
+++ b/blocks/global/report.php
@@ -1,12 +1,8 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
@@ -14,17 +10,12 @@ use Pu239\Database;
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 if ($site_config['alerts']['report'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $delt_with = $cache->get('new_report_');
     if ($delt_with === false || is_null($delt_with)) {
-        // $fluent removed — use $this->db (ExtendedPdo)
-        $delt_with = $fluent->from('reports')
-                            ->select(null)
-                            ->select('COUNT(id) AS count')
-                            ->where('delt_with = 0')
-                            ->fetch("count");
-
+        $delt_with = $db->fetchValue('SELECT COUNT(id) FROM reports WHERE delt_with = 0');
         $cache->set('new_report_', $delt_with, $site_config['expires']['alerts']);
     }
     if ($delt_with > 0) {

--- a/blocks/global/staffmessages.php
+++ b/blocks/global/staffmessages.php
@@ -1,12 +1,8 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
@@ -14,17 +10,12 @@ use Pu239\Database;
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 if ($site_config['alerts']['staffmsg'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $answeredby = $cache->get('staff_mess_');
     if ($answeredby === false || is_null($answeredby)) {
-        // $fluent removed — use $this->db (ExtendedPdo)
-        $answeredby = $fluent->from('staffmessages')
-                             ->select(null)
-                             ->select('COUNT(id) AS count')
-                             ->where('answeredby = 0')
-                             ->fetch("count");
-
+        $answeredby = $db->fetchValue('SELECT COUNT(id) FROM staffmessages WHERE answeredby = 0');
         $cache->set('staff_mess_', $answeredby, $site_config['expires']['alerts']);
     }
     if ($answeredby > 0) {

--- a/blocks/global/uploadapp.php
+++ b/blocks/global/uploadapp.php
@@ -1,12 +1,8 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
@@ -14,17 +10,12 @@ use Pu239\Database;
 $user = check_user_status();
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 if ($site_config['alerts']['uploadapp'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $cache = $container->get(Cache::class);
     $newapp = $cache->get('new_uploadapp_');
     if ($newapp === false || is_null($newapp)) {
-        // $fluent removed — use $this->db (ExtendedPdo)
-        $newapp = $fluent->from('uploadapp')
-                         ->select(null)
-                         ->select('COUNT(id) AS count')
-                         ->where('status = ?', 'pending')
-                         ->fetch("count");
-
+        $newapp = $db->fetchValue('SELECT COUNT(id) FROM uploadapp WHERE status = ?', ['pending']);
         $cache->set('new_uploadapp_', $newapp, $site_config['expires']['alerts']);
     }
     if ($newapp > 0) {

--- a/blocks/index/active_24h_users.php
+++ b/blocks/index/active_24h_users.php
@@ -1,37 +1,27 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $active24 = $cache->get('last24_users_');
 if ($active24 === false || is_null($active24)) {
     $list = [];
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $record = $fluent->from('avps')
-                     ->where('arg = ?', 'last24')
-                     ->fetch();
+    $record = $db->fetch('SELECT value_i, value_u FROM avps WHERE arg = :arg', [':arg' => 'last24']);
 
     $dt = TIME_NOW - 86400;
-    $query = $fluent->from('users')
-                    ->select(null)
-                    ->select('id')
-                    ->where('last_access > ?', $dt)
-                    ->where('anonymous_until < ?', TIME_NOW)
-                    ->where('perms < ?', PERMS_STEALTH)
-                    ->where('id != 2')
-                    ->orderBy('username')
-                    ->fetchAll();
+    $query = $db->fetchAll('SELECT id FROM users WHERE last_access > :dt AND anonymous_until < :now AND perms < :perms AND id != 2 ORDER BY username', [
+        ':dt' => $dt,
+        ':now' => TIME_NOW,
+        ':perms' => PERMS_STEALTH,
+    ]);
 
     $count = count($query);
     $i = 0;
@@ -53,15 +43,12 @@ if ($active24 === false || is_null($active24)) {
     $active24['last24'] = number_format($record['value_i']);
     $active24['record'] = get_date((int) $record['value_u'], '');
     if ($count > $record['value_i']) {
-        $set = [
-            'value_s' => 0,
-            'value_i' => $count,
-            'value_u' => TIME_NOW,
-        ];
-        $fluent->update('avps')
-               ->set($set)
-               ->where('arg = ?', 'last24')
-               ->execute();
+        $db->run('UPDATE avps SET value_s = :value_s, value_i = :value_i, value_u = :value_u WHERE arg = :arg', [
+            ':value_s' => 0,
+            ':value_i' => $count,
+            ':value_u' => TIME_NOW,
+            ':arg' => 'last24',
+        ]);
     }
 
     $cache->set('last24_users_', $active24, $site_config['expires']['last24']);

--- a/blocks/index/active_birthday_users.php
+++ b/blocks/index/active_birthday_users.php
@@ -1,33 +1,26 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $birthday = $cache->get('birthdayusers_');
 if ($birthday === false || is_null($birthday)) {
     $birthday = $list = [];
     $current_date = getdate();
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $query = $fluent->from('users')
-                    ->select(null)
-                    ->select('id')
-                    ->where('MONTH(birthday) = ?', $current_date['mon'])
-                    ->where('DAYOFMONTH(birthday) = ?', $current_date['mday'])
-                    ->where('perms < ?', PERMS_STEALTH)
-                    ->where('anonymous_until < ?', TIME_NOW)
-                    ->orderBy('username')
-                    ->fetchAll();
+    $query = $db->fetchAll('SELECT id FROM users WHERE MONTH(birthday) = :mon AND DAYOFMONTH(birthday) = :day AND perms < :perms AND anonymous_until < :now ORDER BY username', [
+        ':mon' => $current_date['mon'],
+        ':day' => $current_date['mday'],
+        ':perms' => PERMS_STEALTH,
+        ':now' => TIME_NOW,
+    ]);
 
     $count = count($query);
     $i = 0;

--- a/blocks/index/active_irc_users.php
+++ b/blocks/index/active_irc_users.php
@@ -1,32 +1,24 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $irc = $cache->get('ircusers_');
 if ($irc === false || is_null($irc)) {
     $irc = $list = [];
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $query = $fluent->from('users')
-                    ->select(null)
-                    ->select('id')
-                    ->where('onirc = ?', 'yes')
-                    ->where('perms < ?', PERMS_STEALTH)
-                    ->where('anonymous_until < ?', TIME_NOW)
-                    ->where('id != 2')
-                    ->orderBy('username')
-                    ->fetchAll();
+    $query = $db->fetchAll('SELECT id FROM users WHERE onirc = :onirc AND perms < :perms AND anonymous_until < :now AND id != 2 ORDER BY username', [
+        ':onirc' => 'yes',
+        ':perms' => PERMS_STEALTH,
+        ':now' => TIME_NOW,
+    ]);
 
     $count = count($query);
     $i = 0;

--- a/blocks/index/active_users.php
+++ b/blocks/index/active_users.php
@@ -1,33 +1,25 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $active = $cache->get('activeusers_');
 if ($active === false || is_null($active)) {
     $list = [];
     $dt = TIME_NOW - 900;
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $query = $fluent->from('users')
-                    ->select(null)
-                    ->select('id')
-                    ->where('last_access > ?', $dt)
-                    ->where('perms < ?', PERMS_STEALTH)
-                    ->where('anonymous_until < ?', TIME_NOW)
-                    ->where('id != 2')
-                    ->orderBy('username')
-                    ->fetchAll();
+    $query = $db->fetchAll('SELECT id FROM users WHERE last_access > :dt AND perms < :perms AND anonymous_until < :now AND id != 2 ORDER BY username', [
+        ':dt' => $dt,
+        ':perms' => PERMS_STEALTH,
+        ':now' => TIME_NOW,
+    ]);
 
     $count = count($query);
     $i = 0;

--- a/blocks/index/news.php
+++ b/blocks/index/news.php
@@ -1,30 +1,20 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $news = $cache->get('latest_news_');
 if ($news === false || is_null($news)) {
     $dt = TIME_NOW - (86400 * 45);
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $news = $fluent->from('news')
-                   ->where('(added > ? AND sticky = "no") OR sticky = "yes"', $dt)
-                   ->orderBy('sticky')
-                   ->orderBy('added DESC')
-                   ->limit(10)
-                   ->fetchAll();
-
+    $news = $db->fetchAll('SELECT * FROM news WHERE (added > :dt AND sticky = "no") OR sticky = "yes" ORDER BY sticky, added DESC LIMIT 10', [':dt' => $dt]);
     $cache->set('latest_news_', $news, $site_config['expires']['latest_news']);
 }
 

--- a/blocks/index/staff_picks.php
+++ b/blocks/index/staff_picks.php
@@ -1,18 +1,17 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
 global $container, $site_config, $CURUSER;
+
+$db = $container->get(Database::class);
 
 $torrent = $container->get(Torrent::class);
 $staff_picks = $torrent->get_staff_picks();

--- a/blocks/index/stats.php
+++ b/blocks/index/stats.php
@@ -1,17 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
 use Pu239\Cache;
+use Pu239\Database;
 
 global $container, $site_config;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $stats_cache = $cache->get('site_stats_');
 if ($stats_cache === false || is_null($stats_cache)) {

--- a/blocks/index/top_torrents.php
+++ b/blocks/index/top_torrents.php
@@ -1,18 +1,17 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
 global $container, $site_config, $CURUSER;
+
+$db = $container->get(Database::class);
 
 $torrent = $container->get(Torrent::class);
 $top5torrents = $torrent->get_top();

--- a/blocks/index/torrentfreak.php
+++ b/blocks/index/torrentfreak.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container;
 
+$db = $container->get(Database::class);
 require_once INCL_DIR . 'function_tfreak.php';
 $feed = rsstfreakinfo();
 if (!empty($feed)) {

--- a/blocks/index/trivia.php
+++ b/blocks/index/trivia.php
@@ -1,15 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container, $site_config;
 
+$db = $container->get(Database::class);
 require_once INCL_DIR . 'function_trivia.php';
-global $site_config;
 
 $table = trivia_table();
 $qid = $table['qid'];

--- a/blocks/userdetails/avatar.php
+++ b/blocks/userdetails/avatar.php
@@ -1,12 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container;
+
+$db = $container->get(Database::class);
 
 if ($user['avatar']) {
     $HTMLOUT .= "

--- a/blocks/userdetails/birthday.php
+++ b/blocks/userdetails/birthday.php
@@ -1,12 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container;
+
+$db = $container->get(Database::class);
 
 $age = $birthday = '';
 if ($user['birthday'] != '1970-01-01') {

--- a/blocks/userdetails/browser.php
+++ b/blocks/userdetails/browser.php
@@ -1,12 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container;
+
+$db = $container->get(Database::class);
 
 if ($user['browser'] != '') {
     $browser = htmlsafechars($user['browser']);

--- a/migration-report.md
+++ b/migration-report.md
@@ -76,6 +76,27 @@ No matches in modified files.
 - `blocks/index/poll.php`: standardized `bootstrap_pdo.php` and added strict typing.
 - `blocks/index/requests.php`: standardized `bootstrap_pdo.php` and added strict typing.
 
+- `blocks/global/bugmessages.php`: migrated from `$fluent` to `$db->fetchValue` for bug count; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/crazyhour.php`: replaced `$fluent` queries with `$db->fetch`/`run`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/freeleech_contribution.php`: switched `$fluent` lookups to `$db->fetch`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/lottery.php`: converted `$fluent` usage to `$db->fetchAll` with `array_column`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/report.php`: migrated report count to `$db->fetchValue`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/staffmessages.php`: replaced `$fluent` count with `$db->fetchValue`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/global/uploadapp.php`: replaced `$fluent` count with `$db->fetchValue`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/active_24h_users.php`: migrated record and user queries to `$db->fetch`/`fetchAll` and `run`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/active_birthday_users.php`: migrated birthday lookup to `$db->fetchAll`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/active_irc_users.php`: migrated IRC user lookup to `$db->fetchAll`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/active_users.php`: migrated active user lookup to `$db->fetchAll`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/news.php`: migrated news listing to `$db->fetchAll`; standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/staff_picks.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/stats.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/top_torrents.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/torrentfreak.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/index/trivia.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/userdetails/avatar.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/userdetails/birthday.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/userdetails/browser.php`: standardized `bootstrap_pdo.php` and added strict typing.
+
 ### Previous migrations
 - `blocks/index/forum_posts.php`: migrated from legacy `sql_query`/`mysqli_fetch_assoc` to `$db->fetchAll` with bound parameters and standardized bootstrap/strict typing.
 


### PR DESCRIPTION
## Summary
- standardize bootstrap and strict types in blocks
- migrate blocks to Pu239\Database with bound parameters

## Testing
- `php -l blocks/global/bugmessages.php blocks/global/crazyhour.php blocks/global/freeleech_contribution.php blocks/global/lottery.php blocks/global/report.php blocks/global/staffmessages.php blocks/global/uploadapp.php blocks/index/active_24h_users.php blocks/index/active_birthday_users.php blocks/index/active_irc_users.php blocks/index/active_users.php blocks/index/news.php blocks/index/staff_picks.php blocks/index/stats.php blocks/index/top_torrents.php blocks/index/torrentfreak.php blocks/index/trivia.php blocks/userdetails/avatar.php blocks/userdetails/birthday.php blocks/userdetails/browser.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" blocks | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68bdf01d7ca88325a62406b98165f29a