### PR TITLE
Migrate blocks/userdetails to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/blocks/userdetails/connectable.php
+++ b/blocks/userdetails/connectable.php
@@ -1,37 +1,31 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $CURUSER, $site_config;
+
+$db = $container->get(Database::class);
+$cache = $container->get(Cache::class);
 
 if ($user['paranoia'] < 1 || $CURUSER['id'] == $id || $CURUSER['class'] >= UC_STAFF) {
     $What_Cache = 'port_data_';
     $Ident_Client = '';
     $port_data = $cache->get($What_Cache . $id);
     if ($port_data === false || is_null($port_data)) {
-        // $fluent removed — use $this->db (ExtendedPdo)
-        $port_data = $fluent->from('peers')
-                            ->select(null)
-                            ->select('connectable')
-                            ->select('port')
-                            ->select('agent')
-                            ->where('userid = ?', $id)
-                            ->limit(1)
-                            ->fetch();
+        $port_data = $db->fetch('SELECT connectable, port, agent FROM peers WHERE userid = :id LIMIT 1', [
+            ':id' => $id,
+        ]);
         $cache->set('port_data_' . $id, $port_data, $site_config['expires']['port_data']);
     }
-    if (!empty($port_data) && isset($port_data[2])) {
-        $connect = $port_data[0];
-        $port = (int) $port_data[1];
-        $Ident_Client = $port_data[2];
+    if (!empty($port_data) && isset($port_data['agent'])) {
+        $connect = $port_data['connectable'];
+        $port = (int) $port_data['port'];
+        $Ident_Client = $port_data['agent'];
         if ($connect === 'yes') {
             $connectable = "
     <div class='has-text-success tooltipper' title='" . _('Sorted Yer connectable') . "'>

--- a/blocks/userdetails/contactinfo.php
+++ b/blocks/userdetails/contactinfo.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $CURUSER, $site_config, $user;
+global $container, $CURUSER, $site_config, $user;
+
+$db = $container->get(Database::class);
 
 $HTMLOUT .= (has_access($CURUSER['class'], UC_SYSOP, 'coder') || ((has_access($CURUSER['class'], UC_STAFF, 'coder') || $user['show_email'] === 'yes')) ? '
         <tr>

--- a/blocks/userdetails/flush.php
+++ b/blocks/userdetails/flush.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $viewer, $user;
+global $container, $viewer, $user;
+
+$db = $container->get(Database::class);
 
 if (has_access($viewer['class'], UC_STAFF, 'coder') || $viewer['id'] === $user['id']) {
     $table_data .= '

--- a/blocks/userdetails/freestuffs.php
+++ b/blocks/userdetails/freestuffs.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $free, $user;
+global $container, $free, $user;
+
+$db = $container->get(Database::class);
 
 $personal_freeleech = strtotime($user['personal_freeleech']);
 $HTMLOUT .= "

--- a/blocks/userdetails/gender.php
+++ b/blocks/userdetails/gender.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $site_config, $user;
+global $container, $site_config, $user;
+
+$db = $container->get(Database::class);
 
 $HTMLOUT .= "
     <tr>

--- a/blocks/userdetails/iphistory.php
+++ b/blocks/userdetails/iphistory.php
@@ -1,17 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
 use Pu239\Cache;
+use Pu239\Database;
 use Pu239\IP;
 
 global $container, $site_config, $CURUSER, $user, $id, $HTMLOUT;
+
+$db = $container->get(Database::class);
 
 $cache = $container->get(Cache::class);
 $user['ip'] = getip($id);

--- a/blocks/userdetails/irc.php
+++ b/blocks/userdetails/irc.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $user, $site_config;
+global $container, $user, $site_config;
+
+$db = $container->get(Database::class);
 
 /**
  * @param $val

--- a/blocks/userdetails/joined.php
+++ b/blocks/userdetails/joined.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $lastseen, $joindate;
+global $container, $lastseen, $joindate;
+
+$db = $container->get(Database::class);
 
 $HTMLOUT .= "
     <tr>

--- a/blocks/userdetails/onlinetime.php
+++ b/blocks/userdetails/onlinetime.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $onlinetime;
+global $container, $onlinetime;
+
+$db = $container->get(Database::class);
 
 if ($user['onlinetime'] > 0) {
     $onlinetime = time_return($user['onlinetime']);

--- a/blocks/userdetails/report.php
+++ b/blocks/userdetails/report.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $site_config;
+global $container, $site_config;
+
+$db = $container->get(Database::class);
 
 $HTMLOUT .= tr(_('Report User'), "
     <form method='post' action='{$site_config['paths']['baseurl']}/report.php?type=User&amp;id={$id}' enctype='multipart/form-data' accept-charset='utf-8'>

--- a/blocks/userdetails/reputation.php
+++ b/blocks/userdetails/reputation.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $user;
+global $container, $user;
+
+$db = $container->get(Database::class);
 
 $member_reputation = get_reputation($user, 'users');
 $HTMLOUT .= "

--- a/blocks/userdetails/seedbonus.php
+++ b/blocks/userdetails/seedbonus.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $user, $site_config;
+global $container, $user, $site_config;
+
+$db = $container->get(Database::class);
 
 $HTMLOUT .= "
     <tr>

--- a/blocks/userdetails/shareratio.php
+++ b/blocks/userdetails/shareratio.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $CURUSER, $user, $site_config;
+global $container, $CURUSER, $user, $site_config;
+
+$db = $container->get(Database::class);
 
 if ($user['paranoia'] < 2 || $CURUSER['id'] === $user['id'] || $CURUSER['class'] >= UC_STAFF) {
     if ($user['downloaded'] > 0) {

--- a/blocks/userdetails/snatched_staff.php
+++ b/blocks/userdetails/snatched_staff.php
@@ -1,14 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container, $CURUSER;
 
-global $CURUSER;
+$db = $container->get(Database::class);
 
 $count_snatched = $count2 = $dlc = '';
 if ($CURUSER['class'] >= UC_STAFF) {

--- a/blocks/userdetails/torrents_block.php
+++ b/blocks/userdetails/torrents_block.php
@@ -1,18 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Pu239\Session;
 
-$curuser = check_user_status();
 global $container, $user;
 
+$db = $container->get(Database::class);
+$curuser = check_user_status();
 $session = $container->get(Session::class);
 require_once INCL_DIR . 'function_html.php';
 require_once INCL_DIR . 'function_pager.php';

--- a/blocks/userdetails/traffic.php
+++ b/blocks/userdetails/traffic.php
@@ -1,14 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+global $container, $CURUSER, $user, $site_config;
 
-global $CURUSER, $user, $site_config;
+$db = $container->get(Database::class);
 
 if ($user['paranoia'] < 2 || $CURUSER['id'] == $id || $CURUSER['class'] >= UC_STAFF) {
     $days = round((TIME_NOW - $user['registered']) / 86400);

--- a/blocks/userdetails/userclass.php
+++ b/blocks/userdetails/userclass.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $user;
+global $container, $user;
+
+$db = $container->get(Database::class);
 
 $HTMLOUT .= "
         <tr>

--- a/blocks/userdetails/userhits.php
+++ b/blocks/userdetails/userhits.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $CURUSER, $user;
+global $container, $CURUSER, $user;
+
+$db = $container->get(Database::class);
 
 if ($CURUSER['id'] == $user['id'] || $user['paranoia'] < 2) {
     $HTMLOUT .= "

--- a/blocks/userdetails/userinfo.php
+++ b/blocks/userdetails/userinfo.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $user;
+global $container, $user;
+
+$db = $container->get(Database::class);
 
 if ($user['info']) {
     $HTMLOUT .= "<tr><td colspan='2' class='text'>" . format_comment($user['info']) . "</td></tr>\n";

--- a/blocks/userdetails/userstatus.php
+++ b/blocks/userdetails/userstatus.php
@@ -1,13 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-global $CURUSER, $user_status;
+global $container, $CURUSER, $user_status;
+
+$db = $container->get(Database::class);
 
 if ($user['paranoia'] < 1 || $CURUSER['id'] == $id || $CURUSER['class'] >= UC_STAFF) {
     if (isset($user_status['last_status'])) {

--- a/migration-report.md
+++ b/migration-report.md
@@ -96,6 +96,8 @@ No matches in modified files.
 - `blocks/userdetails/avatar.php`: standardized `bootstrap_pdo.php` and added strict typing.
 - `blocks/userdetails/birthday.php`: standardized `bootstrap_pdo.php` and added strict typing.
 - `blocks/userdetails/browser.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `blocks/userdetails/connectable.php`: migrated `FluentPDO` lookup to `$db->fetch`; standardized bootstrap and strict typing.
+- `blocks/userdetails/contactinfo.php`, `flush.php`, `freestuffs.php`, `gender.php`, `iphistory.php`, `irc.php`, `joined.php`, `onlinetime.php`, `report.php`, `reputation.php`, `seedbonus.php`, `shareratio.php`, `snatched_staff.php`, `torrents_block.php`, `traffic.php`, `userclass.php`, `userhits.php`, `userinfo.php`, `userstatus.php`: standardized `bootstrap_pdo.php` and added strict typing.
 
 ### Previous migrations
 - `blocks/index/forum_posts.php`: migrated from legacy `sql_query`/`mysqli_fetch_assoc` to `$db->fetchAll` with bound parameters and standardized bootstrap/strict typing.


### PR DESCRIPTION
## Summary
- standardize strict types and `bootstrap_pdo.php` across userdetails blocks
- migrate `blocks/userdetails/connectable.php` from FluentPDO to `Pu239\Database` with bound parameters
- update migration report for `blocks/userdetails`

## Testing
- `php -l blocks/userdetails/connectable.php blocks/userdetails/contactinfo.php blocks/userdetails/flush.php blocks/userdetails/freestuffs.php blocks/userdetails/gender.php blocks/userdetails/iphistory.php blocks/userdetails/irc.php blocks/userdetails/joined.php blocks/userdetails/onlinetime.php blocks/userdetails/report.php blocks/userdetails/reputation.php blocks/userdetails/seedbonus.php blocks/userdetails/shareratio.php blocks/userdetails/snatched_staff.php blocks/userdetails/torrents_block.php blocks/userdetails/traffic.php blocks/userdetails/userclass.php blocks/userdetails/userhits.php blocks/userdetails/userinfo.php blocks/userdetails/userstatus.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" blocks/userdetails`


------
https://chatgpt.com/codex/tasks/task_e_68bdf3cb59cc8325b7c3f19ec8dac943