### PR TITLE
Migrate blocks/userdetails to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/blocks/userdetails/comments.php
+++ b/blocks/userdetails/comments.php
@@ -1,27 +1,22 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 $usercomments = $cache->get('user_comments_' . $user['id']);
 if ($usercomments === false || is_null($usercomments)) {
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $usercomments = $fluent->from('comments')
-                           ->select(null)
-                           ->select('COUNT(id) AS count')
-                           ->where('user = ?', $user['id'])
-                           ->fetch("count");
+    $usercomments = (int) $db->fetchValue(
+        'SELECT COUNT(id) FROM comments WHERE user = ?',
+        [$user['id']]
+    );
     $cache->set('user_comments_' . $user['id'], $usercomments, $site_config['expires']['torrent_comments']);
 }
 

--- a/blocks/userdetails/completed.php
+++ b/blocks/userdetails/completed.php
@@ -1,52 +1,30 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
+
 if ($site_config['hnr_config']['hnr_online'] == 1 && $user['paranoia'] < 2 || $CURUSER['id'] == $id || $CURUSER['class'] >= (UC_MIN + 1)) {
     $completed = $count2 = $dlc = '';
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $torrents = $fluent->from('snatched AS s')
-                       ->select('t.name')
-                       ->select('t.added AS torrent_added')
-                       ->select('s.complete_date AS c')
-                       ->select('s.downspeed')
-                       ->select('s.seedtime')
-                       ->select('s.seeder')
-                       ->select('s.torrentid AS tid')
-                       ->select('s.id')
-                       ->select('c.id AS category')
-                       ->select('c.image')
-                       ->select('c.name AS catname')
-                       ->select('p.name AS parent_name')
-                       ->select('s.uploaded')
-                       ->select('s.downloaded')
-                       ->select('s.hit_and_run')
-                       ->select('s.mark_of_cain')
-                       ->select('s.complete_date')
-                       ->select('s.last_action')
-                       ->select('t.seeders')
-                       ->select('t.leechers')
-                       ->select('t.owner')
-                       ->select('s.start_date AS st')
-                       ->select('s.start_date')
-                       ->leftJoin('torrents AS t ON t.id=s.torrentid')
-                       ->leftJoin('categories AS c ON c.id=t.category')
-                       ->leftJoin('categories AS p ON c.parent_id=p.id')
-                       ->where('s.finished = "yes"')
-                       ->where('userid = ?', $id)
-                       ->where('t.owner != ?', $id)
-                       ->orderBy('s.id DESC')
-                       ->fetchAll();
+    $torrents = $db->fetchAll(
+        'SELECT t.name, t.added AS torrent_added, s.complete_date AS c, s.downspeed, s.seedtime, s.seeder,
+                s.torrentid AS tid, s.id, c.id AS category, c.image, c.name AS catname, p.name AS parent_name,
+                s.uploaded, s.downloaded, s.hit_and_run, s.mark_of_cain, s.complete_date, s.last_action,
+                t.seeders, t.leechers, t.owner, s.start_date AS st, s.start_date
+            FROM snatched AS s
+            LEFT JOIN torrents AS t ON t.id = s.torrentid
+            LEFT JOIN categories AS c ON c.id = t.category
+            LEFT JOIN categories AS p ON c.parent_id = p.id
+            WHERE s.finished = ? AND userid = ? AND t.owner != ?
+            ORDER BY s.id DESC',
+        ['yes', $id, $id]
+    );
 
     if (count($torrents) > 0) {
         $heading = '

--- a/blocks/userdetails/forumposts.php
+++ b/blocks/userdetails/forumposts.php
@@ -1,28 +1,23 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config, $CURUSER;
 
+$db = $container->get(Database::class);
+
 $cache = $container->get(Cache::class);
 $forumposts = $cache->get('forum_posts_' . $id);
 if ($forumposts === false || is_null($forumposts)) {
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $forumposts = $fluent->from('posts')
-                         ->select(null)
-                         ->select('COUNT(id) AS count')
-                         ->where('user_id = ?', $user['id'])
-                         ->fetch("count");
-
+    $forumposts = (int) $db->fetchValue(
+        'SELECT COUNT(id) FROM posts WHERE user_id = ?',
+        [$user['id']]
+    );
     $cache->set('forum_posts_' . $id, $forumposts, $site_config['expires']['forum_posts']);
 }
 if ($user['paranoia'] < 2 || $CURUSER['id'] == $id || $CURUSER['class'] >= UC_STAFF) {

--- a/blocks/userdetails/invitedby.php
+++ b/blocks/userdetails/invitedby.php
@@ -1,16 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
 global $container, $site_config, $viewer;
+
+$db = $container->get(Database::class);
 
 $type = !empty($user['join_type']) ? $user['join_type'] : 'open';
 $invite_by = (int) $user['invitedby'];
@@ -21,12 +19,10 @@ if ($invite_by > 0 && $type === 'invite') {
             <td>' . format_username($invite_by) . '</td>
         </tr>';
 } elseif ($invite_by > 0 && $type === 'promo') {
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $name = $fluent->from('promo')
-                   ->select(null)
-                   ->select('name')
-                   ->where('id = ?', $invite_by)
-                   ->fetch('name');
+    $name = $db->fetchValue(
+        'SELECT name FROM promo WHERE id = ?',
+        [$invite_by]
+    );
     $name = !empty($name) ? htmlsafechars($name) : 'Promo has been Deleted';
     $HTMLOUT .= '
         <tr>
@@ -40,18 +36,14 @@ if ($invite_by > 0 && $type === 'invite') {
             <td><b>' . _('Open Signups') . '</b></td>
         </tr>';
 }
-$invited = $fluent->from('users AS u')
-                  ->select(null)
-                  ->select('u.id')
-                  ->select('u.email')
-                  ->select('u.uploaded')
-                  ->select('u.downloaded')
-                  ->select('i.status')
-                  ->leftJoin('invite_codes AS i ON u.id = i.receiver')
-                  ->where('u.invitedby = ?', $viewer['id'])
-                  ->where('u.join_type = "invite"')
-                  ->orderBy('u.registered')
-                  ->fetchAll();
+$invited = $db->fetchAll(
+    'SELECT u.id, u.username, u.email, u.uploaded, u.downloaded, i.status
+        FROM users AS u
+        LEFT JOIN invite_codes AS i ON u.id = i.receiver
+        WHERE u.invitedby = ? AND u.join_type = ?
+        ORDER BY u.registered',
+    [$viewer['id'], 'invite']
+);
 
 $inviteted_by_this_member = '';
 if (empty($invited)) {

--- a/blocks/userdetails/seedtimeratio.php
+++ b/blocks/userdetails/seedtimeratio.php
@@ -1,29 +1,23 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
 
 global $container, $site_config, $user, $CURUSER;
 
-$cache = $container->get(Cache::class);
+$db = $container->get(Database::class);
+
+ $cache = $container->get(Cache::class);
 $cache_share_ratio = $cache->get('share_ratio_' . $user['id']);
 if ($cache_share_ratio === false || is_null($cache_share_ratio)) {
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $sql = $fluent->from('snatched')
-                  ->select(null)
-                  ->select('SUM(seedtime) AS seed_time_total')
-                  ->select('COUNT(id) AS total_number')
-                  ->where('seedtime > 0')
-                  ->where('userid = ?', $user['id'])
-                  ->fetch();
+    $sql = $db->fetch(
+        'SELECT SUM(seedtime) AS seed_time_total, COUNT(id) AS total_number FROM snatched WHERE seedtime > 0 AND userid = ?',
+        [$user['id']]
+    );
 
     $cache_share_ratio['total_number'] = (int) $sql['total_number'];
     $cache_share_ratio['seed_time_total'] = (int) $sql['seed_time_total'];

--- a/blocks/userdetails/showfriends.php
+++ b/blocks/userdetails/showfriends.php
@@ -1,12 +1,8 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;
@@ -14,29 +10,21 @@ use Pu239\Database;
 global $container, $CURUSER, $site_config;
 
 require_once INCL_DIR . 'function_users.php';
+$db = $container->get(Database::class);
 $dt = TIME_NOW - 180;
 $keys['user_friends'] = 'user_friends_' . $id;
 $cache = $container->get(Cache::class);
 $users_friends = $cache->get($keys['user_friends']);
 if ($users_friends === false || is_null($users_friends)) {
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $friends = $fluent->from('friends')
-                      ->select(null)
-                      ->select('friendid AS uid')
-                      ->select('userid')
-                      ->select('username')
-                      ->select('last_access')
-                      ->select('perms')
-                      ->select('uploaded')
-                      ->select('downloaded')
-                      ->innerJoin('users ON users.id = friendid')
-                      ->where('userid = ?', $id)
-                      ->orderBy('username')
-                      ->limit(100);
-
-    foreach ($friends as $user_friend) {
-        $users_friends[] = $user_friend;
-    }
+    $users_friends = $db->fetchAll(
+        'SELECT friendid AS uid, userid, username, last_access, perms, uploaded, downloaded
+            FROM friends
+            INNER JOIN users ON users.id = friendid
+            WHERE userid = ?
+            ORDER BY username
+            LIMIT 100',
+        [$id]
+    );
     $cache->set($keys['user_friends'], $users_friends, 86400);
 }
 

--- a/blocks/userdetails/showpm.php
+++ b/blocks/userdetails/showpm.php
@@ -1,35 +1,30 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
 global $container, $CURUSER, $user;
 
-// $fluent removed — use $this->db (ExtendedPdo)
+$db = $container->get(Database::class);
+
 if ($CURUSER['id'] != $user['id']) {
     if ($CURUSER['class'] >= UC_STAFF) {
         $showpmbutton = 1;
     } elseif ($user['acceptpms'] === 'yes') {
-        $blocked = $fluent->from('blocks')
-                          ->select('id')
-                          ->where('userid = ?', $user['id'])
-                          ->where('blockid = ?', $CURUSER['id'])
-                          ->fetch();
-        $showpmbutton = !empty($blocked) ? false : true;
+        $blocked = $db->fetch(
+            'SELECT id FROM blocks WHERE userid = ? AND blockid = ?',
+            [$user['id'], $CURUSER['id']]
+        );
+        $showpmbutton = empty($blocked);
     } elseif ($user['acceptpms'] === 'friends') {
-        $friend = $fluent->from('friends')
-                         ->select('id')
-                         ->where('userid = ?', $user['id'])
-                         ->where('friendid = ?', $CURUSER['id'])
-                         ->fetch();
-        $showpmbutton = !empty($friend) ? true : false;
+        $friend = $db->fetch(
+            'SELECT id FROM friends WHERE userid = ? AND friendid = ?',
+            [$user['id'], $CURUSER['id']]
+        );
+        $showpmbutton = !empty($friend);
     }
 }
 if (isset($showpmbutton)) {

--- a/blocks/userdetails/usercomments.php
+++ b/blocks/userdetails/usercomments.php
@@ -1,18 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
 global $container, $CURUSER, $user, $id, $site_config;
 
-// $fluent removed — use $this->db (ExtendedPdo)
+$db = $container->get(Database::class);
+
 $text = "
     <a id='startcomments'></a>
     <div>
@@ -20,11 +17,10 @@ $text = "
         <div class='has-text-centered bottom20'>
             <a href='{$site_config['paths']['baseurl']}/usercomment.php?action=add&amp;userid={$id}' class='button is-small'>Add a comment</a>
         </div>";
-$count = $fluent->from('usercomments')
-                ->select(null)
-                ->select('COUNT(id) AS count')
-                ->where('userid = ?', $id)
-                ->fetch("count");
+$count = (int) $db->fetchValue(
+    'SELECT COUNT(id) FROM usercomments WHERE userid = ?',
+    [$id]
+);
 
 if (!$count) {
     $text .= "<div class='has-text-centered padding20 size_6'>" . _('No comments yet') . '</div>';
@@ -35,12 +31,14 @@ if (!$count) {
         'lastpagedefault' => 1,
     ]);
 
-    $res = $fluent->from('usercomments')
-                  ->select('id as comment_id')
-                  ->where('userid = ?', $id)
-                  ->orderBy('id DESC')
-                  ->limit($pager['pdo']['limit'])
-                  ->offset($pager['pdo']['offset']);
+    $res = $db->fetchAll(
+        'SELECT id AS comment_id FROM usercomments WHERE userid = :id ORDER BY id DESC LIMIT :limit OFFSET :offset',
+        [
+            ':id' => $id,
+            ':limit' => $pager['pdo']['limit'],
+            ':offset' => $pager['pdo']['offset'],
+        ]
+    );
 
     $allrows = [];
     foreach ($res as $row) {

--- a/migration-report.md
+++ b/migration-report.md
@@ -97,6 +97,14 @@ No matches in modified files.
 - `blocks/userdetails/birthday.php`: standardized `bootstrap_pdo.php` and added strict typing.
 - `blocks/userdetails/browser.php`: standardized `bootstrap_pdo.php` and added strict typing.
 - `blocks/userdetails/connectable.php`: migrated `FluentPDO` lookup to `$db->fetch`; standardized bootstrap and strict typing.
+- `blocks/userdetails/comments.php`: migrated from `$fluent` to `$db->fetchValue`; standardized bootstrap and strict typing.
+- `blocks/userdetails/completed.php`: migrated from `$fluent` to `$db->fetchAll`; standardized bootstrap and strict typing.
+- `blocks/userdetails/forumposts.php`: migrated from `$fluent` to `$db->fetchValue`; standardized bootstrap and strict typing.
+- `blocks/userdetails/invitedby.php`: migrated from `$fluent` to `$db->fetchValue`/`fetchAll`; standardized bootstrap and strict typing.
+- `blocks/userdetails/seedtimeratio.php`: migrated from `$fluent` to `$db->fetch`; standardized bootstrap and strict typing.
+- `blocks/userdetails/showfriends.php`: migrated from `$fluent` to `$db->fetchAll`; standardized bootstrap and strict typing.
+- `blocks/userdetails/showpm.php`: migrated from `$fluent` to `$db->fetch`; standardized bootstrap and strict typing.
+- `blocks/userdetails/usercomments.php`: migrated from `$fluent` to `$db->fetchValue`/`fetchAll`; standardized bootstrap and strict typing.
 - `blocks/userdetails/contactinfo.php`, `flush.php`, `freestuffs.php`, `gender.php`, `iphistory.php`, `irc.php`, `joined.php`, `onlinetime.php`, `report.php`, `reputation.php`, `seedbonus.php`, `shareratio.php`, `snatched_staff.php`, `torrents_block.php`, `traffic.php`, `userclass.php`, `userhits.php`, `userinfo.php`, `userstatus.php`: standardized `bootstrap_pdo.php` and added strict typing.
 
 ### Previous migrations


### PR DESCRIPTION
## Summary
- replace remaining FluentPDO queries in user details blocks with Pu239\Database calls and bound parameters
- standardize runtime-safe/bootstrap_pdo bootstrap and strict typing across user details blocks
- document migration in `migration-report.md`

## Testing
- `php -l blocks/userdetails/comments.php`
- `php -l blocks/userdetails/showfriends.php`
- `php -l blocks/userdetails/invitedby.php`
- `php -l blocks/userdetails/completed.php`
- `php -l blocks/userdetails/forumposts.php`
- `php -l blocks/userdetails/usercomments.php`
- `php -l blocks/userdetails/seedtimeratio.php`
- `php -l blocks/userdetails/showpm.php`
- `rg "mysqli_|sql_query\(|sqlesc\(|\$fluent" -n blocks/userdetails`

------
https://chatgpt.com/codex/tasks/task_e_68be51e21f44832593a1169178618994