### PR TITLE
Migrate cleanup to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/cleanup/announcement_update.php
+++ b/cleanup/announcement_update.php
@@ -1,20 +1,16 @@
 <?php
-$db = $container->get(Database::class);
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
-
-use Pu239\Database;
 
 use DI\DependencyException;
 use DI\NotFoundException;
+use Pu239\Database;
 
 /**
- * @param $data
+ * @param mixed $data
  *
  * @throws DependencyException
  * @throws NotFoundException
@@ -22,8 +18,11 @@ use DI\NotFoundException;
  */
 function announcement_update($data)
 {
+    global $container;
+
     $time_start = microtime(true);
-    sql_query('DELETE FROM announcement_main WHERE expires < ' . TIME_NOW) or sqlerr(__FILE__, __LINE__);
+    $db = $container->get(Database::class);
+    $db->run('DELETE FROM announcement_main WHERE expires < ?', [TIME_NOW]);
 
     $time_end = microtime(true);
     $run_time = $time_end - $time_start;

--- a/migration-report.md
+++ b/migration-report.md
@@ -119,8 +119,9 @@ No matches.
 ## cleanup
 - `cleanup/optimizedb.php`: migrated from `sql_query`/`mysqli_fetch_assoc`/`sqlesc` to `Pu239\Database` with bound parameters; standardized bootstrap and strict typing.
 
+- `cleanup/announcement_update.php`: migrated from legacy `sql_query` to `Pu239\Database` with bound parameters; standardized bootstrap and strict typing.
 ### Verification
 ```
-$ rg "mysqli_|sql_query\(|sqlesc\(" cleanup/optimizedb.php
+$ rg "mysqli_|sql_query\(|sqlesc\(" cleanup/optimizedb.php cleanup/announcement_update.php
 ```
 No matches.


### PR DESCRIPTION
## Summary
- add strict types to cleanup
- switch cleanup to bootstrap_pdo
- migrate announcement_update to Pu239\Database with bound params

## Testing
- `php -l cleanup/announcement_update.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" cleanup/announcement_update.php`


------
https://chatgpt.com/codex/tasks/task_e_68be588926a08325a49f038c2af81d2c