### PR TITLE
Migrate database to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/database/sql_updates.php
+++ b/database/sql_updates.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 $sql_updates = [
     [

--- a/migration-report.md
+++ b/migration-report.md
@@ -125,3 +125,12 @@ No matches.
 $ rg "mysqli_|sql_query\(|sqlesc\(" cleanup/optimizedb.php cleanup/announcement_update.php
 ```
 No matches.
+
+## database
+- `database/sql_updates.php`: standardized `bootstrap_pdo.php`, added strict typing, and imported `Pu239\\Database`.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\\(|sqlesc\\(" database
+```
+No matches.


### PR DESCRIPTION
## Summary
- standardize bootstrap usage in `database/sql_updates.php`
- import `Pu239\Database` and enable strict typing

## Testing
- `rg "mysqli_|sql_query\(|sqlesc\(" -n database`
- `php -l database/sql_updates.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c05936883258fe2ff0b1015a64a