### PR TITLE
Migrate config to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/config/ann_config.php
+++ b/config/ann_config.php
@@ -1,14 +1,14 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/app.php';
 require_once CONFIG_DIR . 'classes.php';
-require_once INCL_DIR . 'database.php';
-$agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : 'Not Provided by Client';
+
+$agent = $_SERVER['HTTP_USER_AGENT'] ?? 'Not Provided by Client';

--- a/config/classes.php
+++ b/config/classes.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 define('UC_USER', 0);
 define('UC_MIN', 0);

--- a/config/config_example.php
+++ b/config/config_example.php
@@ -1,14 +1,13 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use Delight\I18n\Codes;
+
+$db = $container->get(Database::class);
 
 require_once CONFIG_DIR . 'functions.php';
 /*

--- a/config/define.php
+++ b/config/define.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 define('TIME_NOW', time());
 define('ROOT_DIR', realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);

--- a/config/definitions.php
+++ b/config/definitions.php
@@ -1,20 +1,20 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Aura\Sql\ExtendedPdo;
 use Delight\Auth\Auth;
 use Delight\I18n\I18n;
 use Imdb\Config;
 use PHPMailer\PHPMailer\PHPMailer;
+use Pu239\Database;
 use Psr\Container\ContainerInterface;
 use Rakit\Validation\Validator;
 use Scriptotek\GoogleBooks\GoogleBooks;
 
+$db = $container->get(Database::class);
 return [
     Auth::class => DI\factory(function (ContainerInterface $c) {
         $pdo = $c->get(PDO::class);

--- a/config/emoticons.php
+++ b/config/emoticons.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 return [
     'smilies' => [

--- a/config/functions.php
+++ b/config/functions.php
@@ -1,13 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
-
+$db = $container->get(Database::class);
 /**
  * @param $val
  *

--- a/config/session.php
+++ b/config/session.php
@@ -1,20 +1,19 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Delight\Cookie\Session;
+use Pu239\Database;
+use Pu239\Settings;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
+
 require_once INCL_DIR . 'function_common.php';
 require_once CONFIG_DIR . 'functions.php';
 
-use Delight\Cookie\Session;
-use Pu239\Settings;
-
 global $container;
-
 // Override the settings in php.ini
 ini_set('memory_limit', '1024M');
 ini_set('zlib.output_compression', 'Off');

--- a/config/subtitles.php
+++ b/config/subtitles.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 return [
     'subtitles' => [

--- a/config/whereis.php
+++ b/config/whereis.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 return [
     'where' => [

--- a/migration-report.md
+++ b/migration-report.md
@@ -125,3 +125,14 @@ No matches.
 $ rg "mysqli_|sql_query\(|sqlesc\(" cleanup/optimizedb.php cleanup/announcement_update.php
 ```
 No matches.
+
+## config
+- `config/ann_config.php`: standardized bootstrap order, removed legacy `database.php` include, and added strict typing.
+- `config/classes.php`, `config/config_example.php`, `config/define.php`, `config/emoticons.php`, `config/functions.php`, `config/session.php`, `config/subtitles.php`, `config/whereis.php`: standardized bootstrap and added strict typing.
+- `config/definitions.php`: added missing `bootstrap_pdo.php`, imported `Pu239\\Database`, and enforced strict typing.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\(|sqlesc\(" config
+```
+No matches.


### PR DESCRIPTION
## Summary
- standardize config bootstrap to runtime_safe + bootstrap_pdo
- introduce Pu239\Database service and strict types across config
- document config migration

## Testing
- `rg -n "mysqli_|sql_query\(|sqlesc\(" config`
- `php -l config/ann_config.php`
- `php -l config/classes.php`
- `php -l config/config_example.php`
- `php -l config/define.php`
- `php -l config/definitions.php`
- `php -l config/emoticons.php`
- `php -l config/functions.php`
- `php -l config/session.php`
- `php -l config/subtitles.php`
- `php -l config/whereis.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0bb5d5d4832592af07acf5dabee6