### PR TITLE
Migrate include to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/include/arcade.php
+++ b/include/arcade.php
@@ -1,14 +1,15 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/runtime_safe.php';
-
 
 declare(strict_types = 1);
+
+require_once __DIR__ . '/runtime_safe.php';
+require_once __DIR__ . '/bootstrap_pdo.php';
 
 use Pu239\Database;
 use Pu239\Session;
 use Pu239\User;
+
+$db = $container->get(Database::class);
 
 $user = check_user_status();
 global $container, $site_config;
@@ -33,7 +34,7 @@ if (isset($_POST['levelName'])) {
         return false;
     }
 }
-// $fluent removed — use $this->db (ExtendedPdo)
+// using $db (ExtendedPdo)
 $score = isset($_POST['score']) ? (int) $_POST['score'] : (isset($_POST['gscore']) ? (int) $_POST['gscore'] : 0);
 $level = isset($_POST['level']) ? (int) $_POST['level'] : 1;
 $values = [
@@ -55,15 +56,11 @@ $game_id = array_search($gname, $site_config['arcade']['games']);
 $game = $site_config['arcade']['game_names'][$game_id];
 $link = '[url=' . $site_config['paths']['baseurl'] . '/flash.php?gameURI=' . $gname . '.swf&gamename=' . $gname . '&game_id=' . $game_id . ']' . $game . '[/url]';
 $classColor = get_user_class_color($user['class']);
-$scores = $fluent->from('flashscores')
-                 ->select(null)
-                 ->select('score')
-                 ->where('game = ?', $gname)
-                 ->where('score != ?', $score)
-                 ->orderBy('level DESC')
-                 ->orderBy('score DESC')
-                 ->fetch('score');
-$highScore = !empty($scores) ? $scores : 0;
+$scores = $db->fetch(
+    'SELECT score FROM flashscores WHERE game = :game AND score != :score ORDER BY level DESC, score DESC LIMIT 1',
+    ['game' => $gname, 'score' => $score]
+);
+$highScore = $scores['score'] ?? 0;
 if ($highScore < $score) {
     $message = "[color=#$classColor][b]{$user['username']}[/b][/color] has just set a new high score of " . number_format($score) . " in $link and earned {$site_config['arcade']['top_score_points']} karma points.";
     $bonuscomment = get_date((int) TIME_NOW, 'DATE', 1) . " - {$site_config['arcade']['top_score_points']} Points for setting a new high score in $game.\n ";
@@ -82,11 +79,11 @@ if ($site_config['site']['autoshout_chat']) {
     require_once INCL_DIR . 'function_users.php';
     autoshout($message);
 }
-$high = $fluent->from('highscores')
-               ->select(null)
-               ->select('score')
-               ->where('game = ?', $gname)
-               ->fetch('score');
+$high = $db->fetch(
+    'SELECT score FROM highscores WHERE game = :game',
+    ['game' => $gname]
+);
+$high = $high['score'] ?? null;
 if (!empty($high) && $score > $high) {
     $update = [
         'score' => $score,

--- a/include/cron_controller.php
+++ b/include/cron_controller.php
@@ -1,19 +1,18 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/runtime_safe.php';
-
-require_once __DIR__ . '/bootstrap_pdo.php';
-
 
 declare(strict_types = 1);
 
+require_once __DIR__ . '/runtime_safe.php';
+require_once __DIR__ . '/bootstrap_pdo.php';
+
+use Pu239\Database;
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
 use Pu239\Comment;
-use Pu239\Database;
 use Pu239\Torrent;
+
+$db = $container->get(Database::class);
 
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bittorrent.php';
 require_once INCL_DIR . 'function_users.php';
@@ -52,18 +51,15 @@ function autoclean(string $run)
     $cache = $container->get(Cache::class);
     $cache->set('cleanup_check_', 'running', 600);
     $now = TIME_NOW;
-    // $fluent removed — use $this->db (ExtendedPdo)
-    $query = $fluent->from('cleanup');
+    // using $db (ExtendedPdo)
     if (!empty($run)) {
-        $query = $query->where('function_name = ?', $run);
+        $sql = 'SELECT * FROM cleanup WHERE function_name = :run';
+        $params = ['run' => $run];
     } else {
-        $query = $query->where('clean_on = 1')
-                       ->where('function_name != ?', 'funds_table_update')
-                       ->where('clean_time < ?', $now)
-                       ->orderBy('clean_time ASC')
-                       ->orderBy('clean_increment ASC');
+        $sql = 'SELECT * FROM cleanup WHERE clean_on = 1 AND function_name != :function AND clean_time < :now ORDER BY clean_time ASC, clean_increment ASC';
+        $params = ['function' => 'funds_table_update', 'now' => $now];
     }
-    $query = $query->fetchAll();
+    $query = $db->fetchAll($sql, $params);
     if (!$query) {
         echo "Nothing to process, all caught up.\n";
     } else {
@@ -92,9 +88,7 @@ $db->perform($sql, array_merge($set, ['clean_id' => $row['clean_id']]));
         echo "Newsrss Starting\n";
         $tfreak_cron = $cache->get('tfreak_cron_');
         if ($tfreak_cron === false || is_null($tfreak_cron)) {
-            $query = $fluent->from('newsrss')
-                            ->select(null)
-                            ->select('link');
+            $query = $db->fetchAll('SELECT link FROM newsrss');
 
             foreach ($query as $tfreak_new) {
                 $tfreak_news[] = $tfreak_new['link'];

--- a/include/function_books.php
+++ b/include/function_books.php
@@ -1,15 +1,12 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/runtime_safe.php';
-
-require_once __DIR__ . '/bootstrap_pdo.php';
-
 
 declare(strict_types = 1);
 
+require_once __DIR__ . '/runtime_safe.php';
+require_once __DIR__ . '/bootstrap_pdo.php';
 require_once INCL_DIR . 'function_html.php';
 
+use Pu239\Database;
 use Biblys\Isbn\Isbn;
 use DI\DependencyException;
 use DI\NotFoundException;
@@ -19,6 +16,8 @@ use Pu239\Image;
 use Pu239\Torrent;
 use Scriptotek\GoogleBooks\GoogleBooks;
 use Spatie\Image\Exceptions\InvalidManipulation;
+
+$db = $container->get(Database::class);
 
 /**
  *

--- a/include/timezone.php
+++ b/include/timezone.php
@@ -1,12 +1,13 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/runtime_safe.php';
-
-require_once __DIR__ . '/bootstrap_pdo.php';
-
 
 declare(strict_types = 1);
+
+require_once __DIR__ . '/runtime_safe.php';
+require_once __DIR__ . '/bootstrap_pdo.php';
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /**
  * Get time zone.

--- a/migration-report.md
+++ b/migration-report.md
@@ -36,6 +36,9 @@ No matches.
 - `include/function_tmdb.php`: replaced `sql_query` with `$db->run` and bound parameters for bulk inserts; added strict typing and standardized bootstrap.
 - `include/function_happyhour.php`: removed `sql_query`/`sqlesc` in favor of `$db->run` with bound parameters; added strict typing and standardized bootstrap.
 - `include/database.php`, `include/DB.php`, `include/bittorrent.php`: switched to `bootstrap_pdo.php`, removed legacy scaffolding, and added strict typing.
+- `include/arcade.php`: migrated from `$fluent` to `$db->fetch` and `$db->fetchAll` with bound parameters; standardized bootstrap.
+- `include/cron_controller.php`: replaced `$fluent` queries with `$db->fetchAll` and bound parameters; standardized bootstrap.
+- `include/function_books.php`, `include/timezone.php`: standardized bootstrap order.
 
 ### Verification
 ```


### PR DESCRIPTION
## Summary
- standardize bootstrap and strict typing across include helpers
- replace remaining FluentPDO queries in arcade and cron controller with `Pu239\Database`
- document migration progress for include

## Testing
- `php -l include/arcade.php include/cron_controller.php include/function_books.php include/timezone.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" include`


------
https://chatgpt.com/codex/tasks/task_e_68bf0e290af083258614e1caabbb677f