### PR TITLE
Migrate partials to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -134,3 +134,15 @@ No matches.
 $ rg "mysqli_|sql_query\\(|sqlesc\\(" database
 ```
 No matches.
+
+## partials
+- `partials/categories.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `partials/free_details.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `partials/genres.php`: standardized `bootstrap_pdo.php` and added strict typing.
+- `partials/torrent_table.php`: standardized `bootstrap_pdo.php` and added strict typing.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\\(|sqlesc\\(" partials
+```
+No matches.

--- a/partials/categories.php
+++ b/partials/categories.php
@@ -1,16 +1,15 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
+use Pu239\Database;
 use DI\DependencyException;
 use DI\NotFoundException;
 use Spatie\Image\Exceptions\InvalidManipulation;
+
+$db = $container->get(Database::class);
 
 $user = check_user_status();
 require_once INCL_DIR . 'function_categories.php';

--- a/partials/free_details.php
+++ b/partials/free_details.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 global $site_config, $CURUSER;
 

--- a/partials/genres.php
+++ b/partials/genres.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 $genres = [
     _('Movie'),

--- a/partials/torrent_table.php
+++ b/partials/torrent_table.php
@@ -1,12 +1,12 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
+use Pu239\Database;
 
-declare(strict_types = 1);
+$db = $container->get(Database::class);
 
 /**
  * @param string $title


### PR DESCRIPTION
## Summary
- standardize bootstrap and strict types in partials
- initialize `Pu239\Database` in partials

## Testing
- `rg "mysqli_|sql_query\(|sqlesc\(" -n partials`
- `php -l partials/categories.php`
- `php -l partials/free_details.php`
- `php -l partials/genres.php`
- `php -l partials/torrent_table.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfa2a5bdfc8325b1d23c764c0bce8c