### PR TITLE
Migrate plugins to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -134,3 +134,12 @@ No matches.
 $ rg "mysqli_|sql_query\\(|sqlesc\\(" database
 ```
 No matches.
+
+## plugins
+- `plugins/database-hide.php`, `plugins/dump-bz2.php`, `plugins/dump-date.php`, `plugins/dump-zip.php`, `plugins/enum_types.php`, `plugins/frames.php`, `plugins/plugin.php`, `plugins/readable-dates.php`, `plugins/tables-filter.php`, `plugins/file-upload.php`, `plugins/version-noverify.php`: standardized `bootstrap_pdo.php` and added strict typing.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\\(|sqlesc\\(" plugins
+```
+No matches.

--- a/plugins/database-hide.php
+++ b/plugins/database-hide.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Hide some databases from the interface - just to improve design, not a security plugin
  *

--- a/plugins/dump-bz2.php
+++ b/plugins/dump-bz2.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Dump to Bzip2 format
  *

--- a/plugins/dump-date.php
+++ b/plugins/dump-date.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Include current date and time in export filename
  *

--- a/plugins/dump-zip.php
+++ b/plugins/dump-zip.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Dump to ZIP format
  *

--- a/plugins/enum_types.php
+++ b/plugins/enum_types.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Use <select><option> for enum edit instead of regular input text on enum type in PostgreSQL
  *

--- a/plugins/file-upload.php
+++ b/plugins/file-upload.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 //! delete
 

--- a/plugins/frames.php
+++ b/plugins/frames.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Allow using Adminer inside a frame (disables ClickJacking protection)
  *

--- a/plugins/plugin.php
+++ b/plugins/plugin.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Adminer customization allowing usage of plugins
  *

--- a/plugins/readable-dates.php
+++ b/plugins/readable-dates.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** This plugin replaces UNIX timestamps with human-readable dates in your local format.
  * Mouse click on the date field reveals timestamp back.

--- a/plugins/tables-filter.php
+++ b/plugins/tables-filter.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Use filter in tables list
 * @link https://www.adminer.org/plugins/#use

--- a/plugins/version-noverify.php
+++ b/plugins/version-noverify.php
@@ -1,8 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
+declare(strict_types=1);
 
+require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
- declare(strict_types=1);
+
+use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 /** Disable version checker
  *


### PR DESCRIPTION
## Summary
- standardize plugins to `bootstrap_pdo.php` and containerized database access
- add strict typing across Adminer plugins
- document plugins migration

## Testing
- `rg "mysqli_|sql_query\(|sqlesc\(" -n plugins`
- `php -l plugins/database-hide.php plugins/dump-bz2.php plugins/dump-date.php plugins/dump-zip.php plugins/enum_types.php plugins/file-upload.php plugins/frames.php plugins/plugin.php plugins/readable-dates.php plugins/tables-filter.php plugins/version-noverify.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfa2e3b55883259b9782c025a6d7f0