### PR TITLE
Migrate src to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -148,3 +148,125 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" database
 ******* master
 ```
 No matches.
+
+## src
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+- : standardized strict typing and bootstrap order.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\(|sqlesc\(" src
+```
+No matches.
+
+## src
+- `src/Ach_bonus.php`: standardized strict typing and bootstrap order.
+- `src/Achievement.php`: standardized strict typing and bootstrap order.
+- `src/Achievementlist.php`: standardized strict typing and bootstrap order.
+- `src/Ban.php`: standardized strict typing and bootstrap order.
+- `src/Bencode.php`: standardized strict typing and bootstrap order.
+- `src/Block.php`: standardized strict typing and bootstrap order.
+- `src/Bonuslog.php`: standardized strict typing and bootstrap order.
+- `src/Bookmark.php`: standardized strict typing and bootstrap order.
+- `src/BotReplies.php`: standardized strict typing and bootstrap order.
+- `src/BotTriggers.php`: standardized strict typing and bootstrap order.
+- `src/Bounty.php`: standardized strict typing and bootstrap order.
+- `src/Cache.php`: standardized strict typing and bootstrap order.
+- `src/Casino.php`: standardized strict typing and bootstrap order.
+- `src/CasinoBets.php`: standardized strict typing and bootstrap order.
+- `src/Coin.php`: standardized strict typing and bootstrap order.
+- `src/Comment.php`: standardized strict typing and bootstrap order.
+- `src/Database.php`: standardized strict typing and bootstrap order.
+- `src/FailedLogin.php`: standardized strict typing and bootstrap order.
+- `src/Files.php`: standardized strict typing and bootstrap order.
+- `src/Forum.php`: standardized strict typing and bootstrap order.
+- `src/HappyLog.php`: standardized strict typing and bootstrap order.
+- `src/IP.php`: standardized strict typing and bootstrap order.
+- `src/Image.php`: standardized strict typing and bootstrap order.
+- `src/ImageProxy.php`: standardized strict typing and bootstrap order.
+- `src/Message.php`: standardized strict typing and bootstrap order.
+- `src/Mood.php`: standardized strict typing and bootstrap order.
+- `src/Nfo2Png.php`: standardized strict typing and bootstrap order.
+- `src/Notify.php`: standardized strict typing and bootstrap order.
+- `src/Offer.php`: standardized strict typing and bootstrap order.
+- `src/Peer.php`: standardized strict typing and bootstrap order.
+- `src/PeerCache.php`: standardized strict typing and bootstrap order.
+- `src/Person.php`: standardized strict typing and bootstrap order.
+- `src/Phpzip.php`: standardized strict typing and bootstrap order.
+- `src/Poll.php`: standardized strict typing and bootstrap order.
+- `src/PollVoter.php`: standardized strict typing and bootstrap order.
+- `src/Post.php`: standardized strict typing and bootstrap order.
+- `src/Radiance.php`: standardized strict typing and bootstrap order.
+- `src/Referrer.php`: standardized strict typing and bootstrap order.
+- `src/Request.php`: standardized strict typing and bootstrap order.
+- `src/Roles.php`: standardized strict typing and bootstrap order.
+- `src/Searchcloud.php`: standardized strict typing and bootstrap order.
+- `src/Session.php`: standardized strict typing and bootstrap order.
+- `src/Settings.php`: standardized strict typing and bootstrap order.
+- `src/Sitelog.php`: standardized strict typing and bootstrap order.
+- `src/Snatched.php`: standardized strict typing and bootstrap order.
+- `src/Support/Config.php`: standardized strict typing and bootstrap order.
+- `src/Topic.php`: standardized strict typing and bootstrap order.
+- `src/Torrent.php`: standardized strict typing and bootstrap order.
+- `src/Upcoming.php`: standardized strict typing and bootstrap order.
+- `src/User.php`: standardized strict typing and bootstrap order.
+- `src/Userblock.php`: standardized strict typing and bootstrap order.
+- `src/Usersachiev.php`: standardized strict typing and bootstrap order.
+- `src/Wiki.php`: standardized strict typing and bootstrap order.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\(|sqlesc\(" src
+```
+No matches.

--- a/src/Ach_bonus.php
+++ b/src/Ach_bonus.php
@@ -1,12 +1,10 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Ach_bonus.

--- a/src/Achievement.php
+++ b/src/Achievement.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Achievement.

--- a/src/Achievementlist.php
+++ b/src/Achievementlist.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Achievementlist.

--- a/src/Ban.php
+++ b/src/Ban.php
@@ -1,16 +1,14 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use PDOStatement;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Ban.

--- a/src/Bencode.php
+++ b/src/Bencode.php
@@ -1,10 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 /**
  * Class Bencode.

--- a/src/Block.php
+++ b/src/Block.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Block.

--- a/src/Bonuslog.php
+++ b/src/Bonuslog.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Bonuslog.

--- a/src/Bookmark.php
+++ b/src/Bookmark.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Bookmark.

--- a/src/BotReplies.php
+++ b/src/BotReplies.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class BotReplies.

--- a/src/BotTriggers.php
+++ b/src/BotTriggers.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class BotTriggers.

--- a/src/Bounty.php
+++ b/src/Bounty.php
@@ -1,16 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
-
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Bounty.

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,8 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -22,6 +19,9 @@ use MatthiasMullie\Scrapbook\Exception\Exception;
 use MatthiasMullie\Scrapbook\Exception\ServerUnhealthy;
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Cache.

--- a/src/Casino.php
+++ b/src/Casino.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Casino.

--- a/src/CasinoBets.php
+++ b/src/CasinoBets.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class CasinoBets.

--- a/src/Coin.php
+++ b/src/Coin.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Coin.

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -1,10 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -12,6 +7,9 @@ use Envms\FluentPDO\Exception;
 use Envms\FluentPDO\Queries\Select;
 use PDOStatement;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Comment.

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,13 +1,14 @@
 <?php
 declare(strict_types=1);
 
-
-$db = $container->get(Database::class);
 namespace Pu239;
 
 use PDO;
 use PDOException;
 use Throwable;
+
+$db = $container->get(Database::class);
+
 
 /**
  * Lightweight PDO wrapper with safe defaults.

--- a/src/FailedLogin.php
+++ b/src/FailedLogin.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class FailedLogin.

--- a/src/Files.php
+++ b/src/Files.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Files.

--- a/src/Forum.php
+++ b/src/Forum.php
@@ -1,16 +1,14 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use PDOStatement;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Forum.

--- a/src/HappyLog.php
+++ b/src/HappyLog.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class HappyLog.

--- a/src/IP.php
+++ b/src/IP.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class IP.

--- a/src/Image.php
+++ b/src/Image.php
@@ -1,17 +1,14 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
-
 use Envms\FluentPDO\Queries\Select;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Image.

--- a/src/ImageProxy.php
+++ b/src/ImageProxy.php
@@ -1,10 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -16,6 +11,9 @@ use Spatie\Image\Exceptions\InvalidManipulation;
 use Spatie\Image\Image;
 use Spatie\Image\Manipulations;
 use Spatie\ImageOptimizer\OptimizerChainFactory;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class ImageProxy.

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,10 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -12,6 +7,9 @@ use Envms\FluentPDO\Exception;
 use Envms\FluentPDO\Queries\Select;
 use PDOStatement;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Message.

--- a/src/Mood.php
+++ b/src/Mood.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Mood.

--- a/src/Nfo2Png.php
+++ b/src/Nfo2Png.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
+namespace Pu239;
+
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 /**
  * NFO2PNG Online Script.
@@ -17,7 +17,6 @@ declare(strict_types = 1);
  * Converted to class for use in Pu-239
  */
 
-namespace Pu239;
 
 /**
  * Class Nfo2Png.

--- a/src/Notify.php
+++ b/src/Notify.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Notify.

--- a/src/Offer.php
+++ b/src/Offer.php
@@ -1,10 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -12,6 +7,9 @@ use Envms\FluentPDO\Exception;
 use Envms\FluentPDO\Queries\Delete;
 use Envms\FluentPDO\Queries\Select;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Offer.

--- a/src/Peer.php
+++ b/src/Peer.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Peer.

--- a/src/PeerCache.php
+++ b/src/PeerCache.php
@@ -1,8 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -12,6 +9,9 @@ use MatthiasMullie\Scrapbook\Buffered\BufferedStore;
 use MatthiasMullie\Scrapbook\Buffered\TransactionalStore;
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class PeerCache.

--- a/src/Person.php
+++ b/src/Person.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use PDOStatement;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Person.

--- a/src/Phpzip.php
+++ b/src/Phpzip.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use ZipArchive;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Phpzip.

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Poll.

--- a/src/PollVoter.php
+++ b/src/PollVoter.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class PollVoter.

--- a/src/Post.php
+++ b/src/Post.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Post.

--- a/src/Radiance.php
+++ b/src/Radiance.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Radiance

--- a/src/Referrer.php
+++ b/src/Referrer.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Referrer.

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,10 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -12,6 +7,9 @@ use Envms\FluentPDO\Exception;
 use Envms\FluentPDO\Queries\Delete;
 use Envms\FluentPDO\Queries\Select;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Request.

--- a/src/Roles.php
+++ b/src/Roles.php
@@ -1,16 +1,20 @@
 <?php
-$db = $container->get(Database::class);
-
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Delight\Auth\Role;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
+$db = $container->get(Database::class);
+
+
+
+
+
+
 
 /**
  * Class Roles.

--- a/src/Searchcloud.php
+++ b/src/Searchcloud.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Searchcloud.

--- a/src/Session.php
+++ b/src/Session.php
@@ -1,12 +1,10 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Session.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,13 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use Psr\Container\ContainerInterface;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Settings.

--- a/src/Sitelog.php
+++ b/src/Sitelog.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Sitelog.

--- a/src/Snatched.php
+++ b/src/Snatched.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Snatched.

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
+namespace Pu239\Support;
 
 $db = $container->get(Database::class);
-namespace Pu239\Support;
 
 /**
  * Minimal config loader.

--- a/src/Topic.php
+++ b/src/Topic.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Topics.

--- a/src/Torrent.php
+++ b/src/Torrent.php
@@ -1,10 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -14,6 +9,9 @@ use Envms\FluentPDO\Exception;
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
 use PDOStatement;
 use Spatie\Image\Exceptions\InvalidManipulation;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Torrent.

--- a/src/Upcoming.php
+++ b/src/Upcoming.php
@@ -1,17 +1,14 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
-
 use Envms\FluentPDO\Queries\Delete;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Upcoming.

--- a/src/User.php
+++ b/src/User.php
@@ -1,8 +1,5 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
@@ -28,6 +25,9 @@ use PDOStatement;
 use Psr\Container\ContainerInterface;
 use Spatie\Image\Exceptions\InvalidManipulation;
 use function urlencode;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class User.

--- a/src/Userblock.php
+++ b/src/Userblock.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Userblock.

--- a/src/Usersachiev.php
+++ b/src/Usersachiev.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use Envms\FluentPDO\Exception;
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Usersachiev.

--- a/src/Wiki.php
+++ b/src/Wiki.php
@@ -1,14 +1,12 @@
 <?php
-require_once __DIR__ . '/../include/runtime_safe.php';
-
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Pu239;
 
 use PDOStatement;
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 /**
  * Class Wiki.


### PR DESCRIPTION
## Summary
- standardize strict_types declarations and bootstrap order across all src classes
- document src migration in migration-report

## Testing
- `find src -name "*.php" -print0 | xargs -0 -n1 php -l`
- `rg "mysqli_|sql_query\(|sqlesc\(" src`


------
https://chatgpt.com/codex/tasks/task_e_68bfa44ef15483258a2ae297715452ec