### PR TITLE
Migrate root to 43.7D (PDO + bound params)

### DIFF
--- a/acpmanage.php
+++ b/acpmanage.php
@@ -1,18 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
-use Pu239\Database;
+require_once __DIR__ . '/include/runtime_safe.php';
+require_once __DIR__ . '/include/bootstrap_pdo.php';
 
-require_once __DIR__ . '/../include/bittorrent.php';
+use Pu239\Database;
 
 global $container;
 $db = $container->get(Database::class);
 
 // Example migration for ACP manage - load settings from DB
-$sql = 'SELECT name, value FROM settings ORDER BY name ASC';
-$stmt = $db->prepare($sql);
-$stmt->execute();
-$settings = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$settings = $db->fetchAll('SELECT name, value FROM settings ORDER BY name ASC');
 
 echo "<h1>ACP Manage</h1>";
 echo "<ul>";

--- a/bannedemails.php
+++ b/bannedemails.php
@@ -1,18 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
-use Pu239\Database;
+require_once __DIR__ . '/include/runtime_safe.php';
+require_once __DIR__ . '/include/bootstrap_pdo.php';
 
-require_once __DIR__ . '/../include/bittorrent.php';
+use Pu239\Database;
 
 global $container;
 $db = $container->get(Database::class);
 
 // Example migration: list banned emails
-$sql = 'SELECT id, email FROM bannedemails ORDER BY email ASC';
-$stmt = $db->prepare($sql);
-$stmt->execute();
-$emails = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$emails = $db->fetchAll('SELECT id, email FROM bannedemails ORDER BY email ASC');
 
 echo "<h1>Banned Emails</h1>";
 echo "<table border='1'>";

--- a/bonusmanage.php
+++ b/bonusmanage.php
@@ -1,18 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
-use Pu239\Database;
+require_once __DIR__ . '/include/runtime_safe.php';
+require_once __DIR__ . '/include/bootstrap_pdo.php';
 
-require_once __DIR__ . '/../include/bittorrent.php';
+use Pu239\Database;
 
 global $container;
 $db = $container->get(Database::class);
 
 // Example migration: fetch bonus logs
-$sql = 'SELECT id, userid, points, date FROM bonuslog ORDER BY date DESC LIMIT 50';
-$stmt = $db->prepare($sql);
-$stmt->execute();
-$logs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$logs = $db->fetchAll('SELECT id, userid, points, date FROM bonuslog ORDER BY date DESC LIMIT 50');
 
 echo "<h1>Bonus Management</h1>";
 echo "<table border='1'>";

--- a/migration-report.md
+++ b/migration-report.md
@@ -181,3 +181,14 @@ No matches.
 $ rg "mysqli_|sql_query\\(|sqlesc\\(" partials
 ```
 No matches.
+
+## root
+- `acpmanage.php`: switched to `runtime_safe.php`/`bootstrap_pdo.php` and used `$db->fetchAll` for settings lookup.
+- `bannedemails.php`: standardized bootstrap and replaced manual `PDO` usage with `$db->fetchAll`.
+- `bonusmanage.php`: standardized bootstrap and replaced manual `PDO` usage with `$db->fetchAll`.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\\(|sqlesc\\(" acpmanage.php bannedemails.php bonusmanage.php
+```
+No matches in modified files.


### PR DESCRIPTION
## Summary
- Standardize bootstrap for root scripts using runtime_safe.php and bootstrap_pdo.php
- Replace manual PDO prepare/execute with `$db->fetchAll` for root examples
- Document root migration in migration-report

## Testing
- `php -l acpmanage.php bannedemails.php bonusmanage.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" acpmanage.php bannedemails.php bonusmanage.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa65982288325b3a49a7b55bbfacc