### PR TITLE
Migrate forums to 43.7D/aura-ExtendedPDO (PDO + bound params)

### DIFF
--- a/forums/stafflock_post.php
+++ b/forums/stafflock_post.php
@@ -1,12 +1,13 @@
 <?php
-$db = $container->get(Database::class);
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
+
+$db = $container->get(Database::class);
 
 $post_id = (isset($_GET['post_id']) ? (int) $_GET['post_id'] : (isset($_POST['post_id']) ? (int) $_POST['post_id'] : 0));
 $topic_id = (isset($_GET['topic_id']) ? (int) $_GET['topic_id'] : (isset($_POST['topic_id']) ? (int) $_POST['topic_id'] : 0));
@@ -15,10 +16,9 @@ if (!is_valid_id($post_id) || !is_valid_id($topic_id)) {
     stderr(_('Error'), _('Invalid ID.'));
 }
 //=== make sure it's their post or they are staff... this may change
-$res_post = $db->run(');
-}
+$res_post = $db->run('SELECT user_id FROM posts WHERE id = :id', [':id' => $post_id])->fetch();
 if ($mode === 'unlock') {
-    sql_query("UPDATE posts SET status = 'ok', staff_lock = 0 WHERE id = " . sqlesc($post_id)) or sqlerr(__FILE__, __LINE__);
+    $db->run('UPDATE posts SET status = ?, staff_lock = 0 WHERE id = ?', ['ok', $post_id]);
     //=== ok, all done here, send them back! \o/
     header('Location: ' . $_SERVER['PHP_SELF'] . '?action=view_topic&post_id=' . $post_id . '&topic_id=' . $topic_id);
     app_halt('Exit called');

--- a/migration-report.md
+++ b/migration-report.md
@@ -134,3 +134,12 @@ No matches.
 $ rg "mysqli_|sql_query\\(|sqlesc\\(" database
 ```
 No matches.
+
+## forums
+- `forums/stafflock_post.php`: switched to `bootstrap_pdo.php`, added strict typing, and migrated from `sql_query`/`sqlesc` to `$db->run` with bound parameters.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\\(|sqlesc\\(" forums/stafflock_post.php
+```
+No matches.


### PR DESCRIPTION
## Summary
- standardize bootstrap to `bootstrap_pdo.php`
- add strict typing
- migrate `stafflock_post.php` from legacy `sql_query`/`sqlesc` to `Pu239\Database` with bound parameters

## Testing
- `php -l forums/stafflock_post.php`
- `rg -n "mysqli_|sql_query\(|sqlesc\(" forums/stafflock_post.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0dd686fc8325be6ea34fe6ae6504