### PR TITLE
include/: deprecate sqlesc() and enable strict_types

### DIFF
--- a/include/DB.php
+++ b/include/DB.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/app.php
+++ b/include/app.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
-
-declare(strict_types = 1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'define.php';
 require_once CONFIG_DIR . 'classes.php';
 require_once VENDOR_DIR . 'autoload.php';

--- a/include/arcade.php
+++ b/include/arcade.php
@@ -1,6 +1,5 @@
 <?php
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 require_once __DIR__ . '/runtime_safe.php';
 require_once __DIR__ . '/bootstrap_pdo.php';

--- a/include/bittorrent.php
+++ b/include/bittorrent.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/bootstrap_pdo.php
+++ b/include/bootstrap_pdo.php
@@ -1,7 +1,6 @@
 <?php
 declare(strict_types=1);
 
-
 $db = $container->get(Database::class);
 require_once __DIR__ . '/runtime_safe.php';
 

--- a/include/class/class.bencdec.php
+++ b/include/class/class.bencdec.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 /*
 Author: djGrrr <djgrrr AT p2p-network DOT net>
 Version: 1.2.5

--- a/include/class/class.chmod.php
+++ b/include/class/class.chmod.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class Chmod.

--- a/include/class/class_blocks_apis.php
+++ b/include/class/class_blocks_apis.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class class_blocks_apis.

--- a/include/class/class_blocks_index.php
+++ b/include/class/class_blocks_index.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class class_blocks_index.

--- a/include/class/class_blocks_stdhead.php
+++ b/include/class/class_blocks_stdhead.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class class_blocks_stdhead.

--- a/include/class/class_blocks_userdetails.php
+++ b/include/class/class_blocks_userdetails.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class class_blocks_userdetails.

--- a/include/class/class_browser.php
+++ b/include/class/class_browser.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @return array

--- a/include/class/class_check.php
+++ b/include/class/class_check.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/../runtime_safe.php';
 
-
-declare(strict_types = 1);
 
 use Delight\Auth\Auth;
 use DI\DependencyException;

--- a/include/class/class_user_options.php
+++ b/include/class/class_user_options.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class class_user_options.

--- a/include/class/class_user_options_2.php
+++ b/include/class/class_user_options_2.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../runtime_safe.php';
 
 require_once __DIR__ . '/../bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * Class class_user_options_2.

--- a/include/cron_controller.php
+++ b/include/cron_controller.php
@@ -1,6 +1,5 @@
 <?php
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 require_once __DIR__ . '/runtime_safe.php';
 require_once __DIR__ . '/bootstrap_pdo.php';

--- a/include/database.php
+++ b/include/database.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/emoticons.php
+++ b/include/emoticons.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 $smilies = [
     ':-)' => 'smile1.gif',
     ':smile:' => 'smile2.gif',

--- a/include/function_account_delete.php
+++ b/include/function_account_delete.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 

--- a/include/function_announce.php
+++ b/include/function_announce.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_async.php
+++ b/include/function_async.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @param string $filename

--- a/include/function_autopost.php
+++ b/include/function_autopost.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use Delight\Auth\AuthError;
 use Delight\Auth\NotLoggedInException;

--- a/include/function_bbcode.php
+++ b/include/function_bbcode.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_bemail.php
+++ b/include/function_bemail.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/function_bitbucket.php
+++ b/include/function_bitbucket.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use Blocktrail\CryptoJSAES\CryptoJSAES;
 

--- a/include/function_bluray.php
+++ b/include/function_bluray.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_bonus.php
+++ b/include/function_bonus.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use Pu239\Cache;
 use Pu239\Database;

--- a/include/function_books.php
+++ b/include/function_books.php
@@ -1,6 +1,5 @@
 <?php
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 require_once __DIR__ . '/runtime_safe.php';
 require_once __DIR__ . '/bootstrap_pdo.php';

--- a/include/function_breadcrumbs.php
+++ b/include/function_breadcrumbs.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @param array $breadcrumbs

--- a/include/function_bt_client.php
+++ b/include/function_bt_client.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @param $id_data

--- a/include/function_categories.php
+++ b/include/function_categories.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_chatbot.php
+++ b/include/function_chatbot.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_comments.php
+++ b/include/function_comments.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_common.php
+++ b/include/function_common.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_details.php
+++ b/include/function_details.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_event.php
+++ b/include/function_event.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_fanart.php
+++ b/include/function_fanart.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_get_images.php
+++ b/include/function_get_images.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_happyhour.php
+++ b/include/function_happyhour.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/function_html.php
+++ b/include/function_html.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
@@ -6,7 +8,6 @@ require_once __DIR__ . '/runtime_safe.php';
 require_once __DIR__ . '/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
 
 use Delight\Auth\AuthError;
 use Delight\Auth\NotLoggedInException;

--- a/include/function_imdb.php
+++ b/include/function_imdb.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 require_once INCL_DIR . 'function_fanart.php';
 require_once INCL_DIR . 'function_tmdb.php';

--- a/include/function_ircbot.php
+++ b/include/function_ircbot.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_newsrss.php
+++ b/include/function_newsrss.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_onlinetime.php
+++ b/include/function_onlinetime.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @param $stamp

--- a/include/function_pager.php
+++ b/include/function_pager.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @param       $perpage

--- a/include/function_password.php
+++ b/include/function_password.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 /**
  * @param int $bytes

--- a/include/function_polls.php
+++ b/include/function_polls.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_rating.php
+++ b/include/function_rating.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/function_returnto.php
+++ b/include/function_returnto.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_searchcloud.php
+++ b/include/function_searchcloud.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_staff.php
+++ b/include/function_staff.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_tfreak.php
+++ b/include/function_tfreak.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_tmdb.php
+++ b/include/function_tmdb.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/function_torrent_hover.php
+++ b/include/function_torrent_hover.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_torrenttable.php
+++ b/include/function_torrenttable.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use Delight\Auth\AuthError;
 use Delight\Auth\NotLoggedInException;

--- a/include/function_translate.php
+++ b/include/function_translate.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use Delight\I18n\I18n;
 use Pu239\Session;

--- a/include/function_trivia.php
+++ b/include/function_trivia.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_tvmaze.php
+++ b/include/function_tvmaze.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/function_users.php
+++ b/include/function_users.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
-
-declare(strict_types = 1);
 
 use Delight\Auth\Auth;
 use Delight\Auth\AuthError;

--- a/include/geoipregionvars.php
+++ b/include/geoipregionvars.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 // Copyright 2016 MaxMind, Inc. All Rights Reserved
 

--- a/include/images_update.php
+++ b/include/images_update.php
@@ -1,12 +1,12 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
 require_once __DIR__ . '/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
 
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
 use Pu239\Cache;

--- a/include/invincible.php
+++ b/include/invincible.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/nologip.php
+++ b/include/nologip.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
-
-declare(strict_types = 1);
 
 use DI\DependencyException;
 use DI\NotFoundException;

--- a/include/runtime_safe.php
+++ b/include/runtime_safe.php
@@ -1,7 +1,6 @@
 <?php
 declare(strict_types=1);
 
-
 $db = $container->get(Database::class);
 /**
  * runtime_safe.php
@@ -61,3 +60,11 @@ if (!function_exists('debug_log')) {
         }
     }
 }
+/**
+ * @deprecated Use bound parameters via Pu239\Database. To be removed when repo is clean.
+ */
+function sqlesc($x) {
+    trigger_error('sqlesc() is deprecated – migrate to bound params', E_USER_DEPRECATED);
+    return $x;
+}
+

--- a/include/stealth.php
+++ b/include/stealth.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__.'/runtime_safe.php';

--- a/include/timezone.php
+++ b/include/timezone.php
@@ -1,6 +1,5 @@
 <?php
-
-declare(strict_types = 1);
+declare(strict_types=1);
 
 require_once __DIR__ . '/runtime_safe.php';
 require_once __DIR__ . '/bootstrap_pdo.php';


### PR DESCRIPTION
## Summary
- add `declare(strict_types=1);` to all files under `include/`
- provide a deprecated `sqlesc()` shim in `runtime_safe.php`

## Testing
- `while IFS= read -r -d '' file; do php -l "$file"; done < <(find include -type f -name "*.php" -print0)`
- `rg -n "sql_query\(|mysqli_|sqlesc\(" include/`


------
https://chatgpt.com/codex/tasks/task_e_68c0f7686a8c8325964131803bdf9fae