### PR TITLE
Migrate cleanup to 43.7D (PDO + bound params)

### DIFF
--- a/cleanup/cheatclean_update.php
+++ b/cleanup/cheatclean_update.php
@@ -1,30 +1,28 @@
 <?php
-$db = $container->get(Database::class);
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
-use DI\DependencyException;
-use DI\NotFoundException;
+global $container;
+$db = $container->get(Database::class);
+$now = defined('TIME_NOW') ? (int) TIME_NOW : time();
 
 /**
- * @param $data
+ * @param array $data
  *
- * @throws DependencyException
- * @throws NotFoundException
- * @throws \PDOException
+ * @throws \Throwable
  */
-function cheatclean_update($data)
+function cheatclean_update(array $data): void
 {
+    global $db, $now;
+
     $time_start = microtime(true);
-    $dt = (TIME_NOW - (30 * 86400));
-    sql_query('DELETE FROM cheaters WHERE added < ' . sqlesc($dt)) or sqlerr(__FILE__, __LINE__);
+    $dt = $now - (30 * 86400);
+    $db->run('DELETE FROM cheaters WHERE added < ?', [$dt]);
     $time_end = microtime(true);
     $run_time = $time_end - $time_start;
     $text = " Run time: $run_time seconds";
@@ -33,3 +31,4 @@ function cheatclean_update($data)
         write_log('Cheaters List Cleanup: Removed old cheater entrys. Completed' . $text);
     }
 }
+

--- a/cleanup/processkill_update.php
+++ b/cleanup/processkill_update.php
@@ -1,35 +1,31 @@
 <?php
-$db = $container->get(Database::class);
+
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
-use DI\DependencyException;
-use DI\NotFoundException;
+global $container;
+$db = $container->get(Database::class);
+$now = defined('TIME_NOW') ? (int) TIME_NOW : time();
 
 /**
- * @param $data
+ * @param array $data
  *
- * @throws DependencyException
- * @throws NotFoundException
- * @throws \PDOException
+ * @throws \Throwable
  */
-function processkill_update($data)
+function processkill_update(array $data): void
 {
-    global $site_config;
+    global $db, $site_config;
 
     $time_start = microtime(true);
-    $sql = sql_query('SHOW PROCESSLIST') or sqlerr(__FILE__, __LINE__);
+    $rows = $db->fetchAll('SHOW PROCESSLIST');
     $cnt = 0;
-    while ($arr = mysqli_fetch_assoc($sql)) {
+    foreach ($rows as $arr) {
         if ($arr['db'] == $site_config['db']['database'] && $arr['Command'] === 'Sleep' && $arr['Time'] > 120) {
-            sql_query("KILL {$arr['Id']}") or sqlerr(__FILE__, __LINE__);
+            $db->run('KILL ' . (int) $arr['Id']);
             ++$cnt;
         }
     }
@@ -41,3 +37,4 @@ function processkill_update($data)
         write_log('Process Kill Cleanup: Completed' . $text);
     }
 }
+

--- a/migration-report.md
+++ b/migration-report.md
@@ -124,9 +124,11 @@ No matches.
 - `cleanup/optimizedb.php`: migrated from `sql_query`/`mysqli_fetch_assoc`/`sqlesc` to `Pu239\Database` with bound parameters; standardized bootstrap and strict typing.
 
 - `cleanup/announcement_update.php`: migrated from legacy `sql_query` to `Pu239\Database` with bound parameters; standardized bootstrap and strict typing.
+- `cleanup/cheatclean_update.php`: replaced `sql_query`/`sqlesc` with `$db->run` and bound parameters; standardized strict typing and bootstrap.
+- `cleanup/processkill_update.php`: switched from `sql_query`/`mysqli_fetch_assoc` to `$db->fetchAll`/`run`; standardized strict typing and bootstrap.
 ### Verification
 ```
-$ rg "mysqli_|sql_query\(|sqlesc\(" cleanup/optimizedb.php cleanup/announcement_update.php
+$ rg "mysqli_|sql_query\(|sqlesc\(" cleanup/optimizedb.php cleanup/announcement_update.php cleanup/cheatclean_update.php cleanup/processkill_update.php
 ```
 No matches.
 


### PR DESCRIPTION
## Summary
- refactor cheatclean_update and processkill_update to use Pu239\Database with bound parameters
- document cleanup migration in report

## Testing
- `php -l cleanup/cheatclean_update.php cleanup/processkill_update.php`
- `rg -n "mysqli_|sql_query\(|sqlesc\(" cleanup/*.php | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68c0fd0b2030832599ddc8e4c46de6c0