### PR TITLE
Migrate public to 43.7D (PDO + bound params)

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -3,10 +3,13 @@
 ## public
 - `public/tenpercent.php`: migrated from legacy mysqli/sql_query/sqlesc to `Pu239\Database` with bound parameters; switched to `bootstrap_pdo.php`; added strict typing.
 - `public/contactstaff.php`: migrated from `sql_query`/`sqlesc` to `$db->run` with bound parameters; standardized bootstrap and added strict typing.
+- `public/ajax/like.php`: replaced legacy queries with `$db->run`, added transaction handling and input validation, and standardized bootstrap.
+- `public/users.php`: migrated user search to bound parameters with explicit columns and sanitized input.
+- `public/messages.php`: standardized bootstrap and converted mailbox lookup to `$db->fetchAll` with bound parameters.
 
 ### Verification
 ```
-$ rg "mysqli_|sql_query\(|sqlesc\(" public/contactstaff.php public/tenpercent.php
+$ rg "mysqli_|sql_query\(|sqlesc\(" public/contactstaff.php public/tenpercent.php public/ajax/like.php public/users.php public/messages.php
 ```
 No matches in modified files.
 

--- a/public/ajax/like.php
+++ b/public/ajax/like.php
@@ -1,13 +1,16 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
 use Pu239\Database;
+
+global $container, $site_config;
+$db = $container->get(Database::class);
 
 require_once __DIR__ . '/../../include/bittorrent.php';
 require_once INCL_DIR . 'function_users.php';
@@ -37,18 +40,20 @@ if (!empty($user) && is_array($user)) {
  */
 function comment_like_unlike(array $fields, array $user)
 {
-    global $container;
-$db = $container->get(Database::class);;
+    global $container, $site_config, $db;
 
-    $id = (int) $_POST['id'];
-    $type = $_POST['type'];
-    $current = $_POST['current'];
     header('content-type: application/json');
-    if (!array_key_exists($type, $fields)) {
+
+    $id = (int) ($_POST['id'] ?? 0);
+    $type = mb_substr(trim((string) ($_POST['type'] ?? '')), 0, 12);
+    $current = mb_substr(trim((string) ($_POST['current'] ?? '')), 0, 10);
+
+    if (!isset($fields[$type])) {
         echo json_encode(['label' => _('Invalid Data Type')]);
         app_halt('Exit called');
     }
-    if (!is_int($id)) {
+
+    if ($id <= 0) {
         echo json_encode(['label' => _('Invalid ID')]);
         app_halt('Exit called');
     }
@@ -57,53 +62,75 @@ $db = $container->get(Database::class);;
         $type = 'comment';
     }
 
-    $sql = 'SELECT COUNT(id) AS count FROM likes WHERE user_id=' . sqlesc($user['id']) . " AND {$type}_id=" . sqlesc($id);
-    $res = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-    $data = mysqli_fetch_assoc($res);
-    $table = 'comments';
-    if ($type === 'topic' || $type === 'post' || $type === 'usercomment') {
-        $table = $fields[$type];
-    }
-    $cache = $container->get(Cache::class);
-    $fluent = $db; // alias
-// $fluent removed — use $this->db (ExtendedPdo)
-    if ($data['count'] == 0 && $current === 'Like') {
-        $sql = "INSERT INTO likes ({$type}_id, user_id) VALUES (" . sqlesc($id) . ', ' . sqlesc($user['id']) . ')';
-        $res = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-        $sql = "UPDATE $table SET user_likes = user_likes + 1 WHERE id = " . sqlesc($id);
-        $res = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-        $cache->delete("{$type}_user_likes_" . $id);
-        $cache->delete('latest_comments_');
-        $data['label'] = 'Unlike';
-        $data['list'] = 'you like this';
-    } elseif ($data['count'] == 1 && $current === 'Unlike') {
-        $sql = "DELETE FROM likes WHERE {$type}_id=" . sqlesc($id) . ' AND user_id=' . sqlesc($user['id']);
-        $res = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-        $sql = "UPDATE $table SET user_likes = user_likes - 1 WHERE id = " . sqlesc($id);
-        $res = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-        $cache->delete("{$type}_user_likes_" . $id);
-        $cache->delete('latest_comments_');
-        $data['label'] = 'Like';
-        $data['list'] = '';
-    } elseif ($data['count'] == 1 && $current === 'Like') {
-        $data['label'] = _('Unlike');
-        $data['list'] = _('you like this');
-    } else {
-        $data['label'] = _('you lost me');
-    }
-    $sql = $fluent->from('likes')
-                  ->select(null)
-                  ->select('user_id')
-                  ->where("{$type}_id = ?", $id)
-                  ->where('user_id != ?', $user['id']);
-    foreach ($sql as $row) {
-        $rows[] = format_username((int) $row['user_id']);
-    }
-    if (!empty($rows)) {
-        $data['list'] = implode(', ', $rows) . (!empty($data['list']) ? ' and ' . $data['list'] : ' like' . plural(count($rows)) . ' this');
-    }
-    $data['class'] = "tot-$id";
+    $table = match ($type) {
+        'post' => 'posts',
+        'comment' => 'comments',
+        'topic' => 'topics',
+        'usercomment' => 'usercomments',
+        'request' => 'requests',
+        'offer' => 'offers',
+        'torrent' => 'torrents',
+        default => throw new InvalidArgumentException('Invalid like type'),
+    };
 
-    echo json_encode($data);
+    $exists = (int) $db->run(
+        "SELECT COUNT(id) FROM likes WHERE user_id = :uid AND {$type}_id = :id",
+        [':uid' => (int) $user['id'], ':id' => $id]
+    )->fetchColumn();
+    $cache = $container->get(Cache::class);
+
+    if ($exists === 0 && $current === 'Like') {
+        try {
+            $db->beginTransaction();
+            $db->run("INSERT INTO likes ({$type}_id, user_id) VALUES (:id, :uid)", [':id' => $id, ':uid' => (int) $user['id']]);
+            $db->run("UPDATE {$table} SET user_likes = user_likes + 1 WHERE id = :id", [':id' => $id]);
+            $db->commit();
+        } catch (\PDOException $e) {
+            if ((int) ($e->errorInfo[1] ?? 0) === 1062) {
+                $db->rollBack();
+            } else {
+                $db->rollBack();
+                throw $e;
+            }
+        }
+        $cache->delete("{$type}_user_likes_" . $id);
+        $cache->delete('latest_comments_');
+        $label = 'Unlike';
+        $list = 'you like this';
+    } elseif ($exists === 1 && $current === 'Unlike') {
+        try {
+            $db->beginTransaction();
+            $db->run("DELETE FROM likes WHERE {$type}_id = :id AND user_id = :uid", [':id' => $id, ':uid' => (int) $user['id']]);
+            $db->run("UPDATE {$table} SET user_likes = user_likes - 1 WHERE id = :id", [':id' => $id]);
+            $db->commit();
+        } catch (\PDOException $e) {
+            $db->rollBack();
+            throw $e;
+        }
+        $cache->delete("{$type}_user_likes_" . $id);
+        $cache->delete('latest_comments_');
+        $label = 'Like';
+        $list = '';
+    } elseif ($exists === 1 && $current === 'Like') {
+        $label = _('Unlike');
+        $list = _('you like this');
+    } else {
+        $label = _('you lost me');
+        $list = '';
+    }
+
+    $rows = $db->fetchAll(
+        "SELECT user_id FROM likes WHERE {$type}_id = :id AND user_id != :uid",
+        [':id' => $id, ':uid' => (int) $user['id']]
+    );
+    $names = [];
+    foreach ($rows as $row) {
+        $names[] = format_username((int) $row['user_id']);
+    }
+    if (!empty($names)) {
+        $list = implode(', ', $names) . (!empty($list) ? ' and ' . $list : ' like' . plural(count($names)) . ' this');
+    }
+
+    echo json_encode(['label' => $label, 'list' => $list, 'class' => "tot-$id"]);
     app_halt('Exit called');
 }

--- a/public/messages.php
+++ b/public/messages.php
@@ -1,8 +1,8 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use DI\DependencyException;
 use DI\NotFoundException;
@@ -10,6 +10,10 @@ use Pu239\Cache;
 use Pu239\Database;
 use Pu239\Session;
 use Pu239\User;
+
+global $container, $site_config;
+$db = $container->get(Database::class);
+$cache = $container->get(Cache::class);
 
 require_once __DIR__ . '/../include/bittorrent.php';
 require_once INCL_DIR . 'function_users.php';
@@ -30,9 +34,7 @@ $stdfoot = [
         get_file_name('user_search_js'),
     ],
 ];
-$HTMLOUT = $count2 = $other_box_info = $maxpic = $maxbox = '';
-
-global $site_config;
+ $HTMLOUT = $count2 = $other_box_info = $maxpic = $maxbox = '';
 
 $maxbox = 100 * ($user['class'] + 1);
 $maxboxes = 5 * ($user['class'] + 1);
@@ -90,12 +92,6 @@ $top_links = '
         </ul>
     </div>';
 
-global $container;
-$db = $container->get(Database::class);;
-
-$cache = $container->get(Cache::class);
-$fluent = $db; // alias
-// $fluent removed — use $this->db (ExtendedPdo)
 if (isset($_GET['change_pm_number'])) {
     $change_pm_number = (isset($_GET['change_pm_number']) ? (int) $_GET['change_pm_number'] : 20);
     $db->run(');
@@ -255,14 +251,12 @@ $db = $container->get(Database::class);, $site_config;
  */
 function insertJumpTo(int $mailbox, int $userid)
 {
-    global $container;
-$db = $container->get(Database::class);, $site_config;
+    global $cache, $db, $site_config;
 
-    $cache = $container->get(Cache::class);
     $cache->delete('insertJumpTo_' . $userid);
     $insertJumpTo = $cache->get('insertJumpTo_' . $userid);
     if ($insertJumpTo === false || is_null($insertJumpTo)) {
-        $rows = $db->fetchAll('SELECT boxnumber,name FROM pmboxes WHERE userid=' . sqlesc($userid) . ' ORDER BY boxnumber');
+        $rows = $db->fetchAll('SELECT boxnumber, name FROM pmboxes WHERE userid = :uid ORDER BY boxnumber', [':uid' => $userid]);
         $insertJumpTo = '
             <div class="has-text-centered">
                 <form action="messages.php" method="get" accept-charset="utf-8">
@@ -273,7 +267,7 @@ $db = $container->get(Database::class);, $site_config;
                         <option value="' . $site_config['paths']['baseurl'] . '/messages.php?action=view_mailbox&amp;box=-1" ' . ($mailbox === -1 ? 'selected' : '') . '>' . _('Sentbox') . '</option>
                         <option value="' . $site_config['paths']['baseurl'] . '/messages.php?action=view_mailbox&amp;box=-2" ' . ($mailbox === -2 ? 'selected' : '') . '>' . _('Drafts') . '</option>
                         <option value="' . $site_config['paths']['baseurl'] . '/messages.php?action=view_mailbox&amp;box=0" ' . ($mailbox === 0 ? 'selected' : '') . '>' . _('Deleted') . '</option>';
-        while ($row = mysqli_fetch_assoc($res)) {
+        foreach ($rows as $row) {
             $insertJumpTo .= '
                         <option value="' . $site_config['paths']['baseurl'] . '/messages.php?action=view_mailbox&amp;box=' . (int) $row['boxnumber'] . '" ' . ($mailbox === (int) $row['boxnumber'] ? 'selected' : '') . '>' . htmlsafechars($row['name']) . '</option>';
         }

--- a/public/users.php
+++ b/public/users.php
@@ -1,47 +1,44 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
+
+global $container, $site_config;
+$db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/bittorrent.php';
 require_once INCL_DIR . 'function_users.php';
 require_once INCL_DIR . 'function_html.php';
 require_once INCL_DIR . 'function_pager.php';
 check_user_status();
-global $site_config;
 
-$search = isset($_GET['search']) ? strip_tags(trim($_GET['search'])) : '';
-$class = isset($_GET['class']) ? $_GET['class'] : '-';
-$letter = '';
+$search = mb_substr(trim((string) ($_GET['search'] ?? '')), 0, 64);
+$class = (int) ($_GET['class'] ?? 0);
+$letter = mb_substr(trim((string) ($_GET['letter'] ?? '')), 0, 1);
+$where = ['status = 0', 'verified = 1', 'anonymous_until = 0'];
+$params = [];
 $q1 = '';
-if ($class === '-' || !ctype_digit($class)) {
-    $class = '';
+
+if ($search !== '') {
+    $where[] = 'username LIKE :search';
+    $params[':search'] = "%{$search}%";
+    $q1 = 'search=' . urlencode($search);
+} elseif ($letter !== '' && strpos('abcdefghijklmnopqrstuvwxyz0123456789', $letter) !== false) {
+    $where[] = 'username LIKE :letter';
+    $params[':letter'] = "{$letter}%";
+    $q1 = 'letter=' . urlencode($letter);
 }
-if ($search != '' || $class) {
-    $query1 = 'username LIKE ' . sqlesc("%$search%") . ' AND status = 0 AND verified = 1 AND anonymous_until = 0';
-    if ($search) {
-        $q1 = 'search = ' . htmlsafechars($search);
-    }
-} else {
-    $letter = isset($_GET['letter']) ? trim((string) $_GET['letter']) : '';
-    if (strlen($letter) > 1) {
-        app_halt('Exit called');
-    }
-    if ($letter == '' || strpos('abcdefghijklmnopqrstuvwxyz0123456789', $letter) === false) {
-        $letter = '';
-    }
-    $query1 = "username LIKE '$letter%' AND status = 0 AND verified = 1 AND anonymous_until = 0";
-    $q1 = "letter = $letter";
-}
-if (ctype_digit($class)) {
-    $query1 .= " AND class = $class";
+
+if ($class > 0) {
+    $where[] = 'class = :class';
+    $params[':class'] = $class;
     $q1 .= ($q1 ? '&amp;' : '') . "class=$class";
 }
+
+$query1 = implode(' AND ', $where);
 
 $HTMLOUT = "
     <h1 class='has-text-centered'>Search " . _('Users') . '</h1>';
@@ -56,7 +53,7 @@ $div .= "
 for ($i = 0;; ++$i) {
     if ($c = get_user_class_name((int) $i)) {
         $div .= "
-                <option value='$i' " . (ctype_digit($class) && $class == $i ? 'selected' : '') . ">$c</option>";
+                <option value='$i' " . ($class === $i ? 'selected' : '') . ">$c</option>";
     } else {
         break;
     }
@@ -97,14 +94,18 @@ $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
 $perpage = 25;
 $browsemenu = '';
 $pagemenu = '';
-$rows = $db->fetchAll('SELECT COUNT(id) FROM users WHERE ' . $query1) or sqlerr(__FILE__, __LINE__);
-$arr = mysqli_fetch_row($res);
-$pager = pager($perpage, (int) $arr[0], "{$site_config['paths']['baseurl']}/users.php?$q1&amp;");
-if ($arr[0] > 0) {
-    if ($arr[0] > $perpage) {
+$total = (int) $db->run('SELECT COUNT(id) FROM users WHERE ' . $query1, $params)->fetchColumn();
+$pager = pager($perpage, $total, "{$site_config['paths']['baseurl']}/users.php?$q1&amp;");
+if ($total > 0) {
+    if ($total > $perpage) {
         $HTMLOUT .= $pager['pagertop'];
     }
-    $res = sql_query("SELECT users.*, countries.name, countries.flagpic FROM users LEFT JOIN countries ON country = countries.id WHERE $query1 ORDER BY username {$pager['limit']}") or sqlerr(__FILE__, __LINE__);
+    $offset = max(0, (int) ($pager['offset'] ?? 0));
+    $limit = max(1, (int) ($pager['limit'] ?? $perpage));
+    $rows = $db->fetchAll(
+        'SELECT id, username, registered, last_access, class, country FROM users WHERE ' . $query1 . ' ORDER BY username LIMIT ' . $offset . ', ' . $limit,
+        $params
+    );
     $heading = "
                 <tr>
                     <th class='has-text-centered'>" . _('User name') . "</th>
@@ -114,8 +115,8 @@ if ($arr[0] > 0) {
                     <th class='has-text-centered'>" . _('Country') . '</th>
                 </tr>';
     $body = '';
-    while ($row = mysqli_fetch_assoc($res)) {
-        $country = ($row['name'] != null) ? "<img src='{$site_config['paths']['images_baseurl']}flag/" . htmlsafechars($row['flagpic']) . "' alt='" . htmlsafechars($row['name']) . "'>" : '---';
+    foreach ($rows as $row) {
+        $country = ($row['country'] !== null) ? "<img src='{$site_config['paths']['images_baseurl']}flag/" . htmlsafechars($row['country']) . "' alt='">" : '---';
         $body .= '
                 <tr>
                     <td>' . format_username((int) $row['id']) . '</td>
@@ -123,10 +124,10 @@ if ($arr[0] > 0) {
                     <td class="has-text-centered">' . get_date((int) $row['last_access'], 'LONG') . '</td>
                     <td class="has-text-centered">' . get_user_class_name((int) $row['class']) . "</td>
                     <td class='has-text-centered'>$country</td>
-                </tr>";
+                </tr>';
     }
     $HTMLOUT .= main_table($body, $heading);
-    if ($arr[0] > $perpage) {
+    if ($total > $perpage) {
         $HTMLOUT .= $pager['pagerbottom'];
     }
 }


### PR DESCRIPTION
## Summary
- migrate like handler to PDO with transactions and whitelist tables
- convert users listing to bound parameters and sanitized filters
- update messages mailbox jump menu to PDO and modern bootstrap

## Testing
- `rg "mysqli_|sql_query\(|sqlesc\(" public/contactstaff.php public/tenpercent.php public/ajax/like.php public/users.php public/messages.php`
- `rg -n "SELECT \*" public/ajax/like.php public/users.php public/messages.php`
- `rg -n "LIMIT\s*:\w+" public/ajax/like.php public/users.php public/messages.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0fd3aab1c83259fb7ba83b26e085a