### PR TITLE
lottery/: quarantine broken sources, add safe 503 stubs, reports, and PDO scaffold

### DIFF
--- a/LOTTERY_REBUILD.md
+++ b/LOTTERY_REBUILD.md
@@ -1,0 +1,37 @@
+# Lottery Module Rebuild Guide
+
+## 1) Summary
+Three PHP files in `lottery/` exhibited parse errors and were quarantined. Temporary stubs now return HTTP 503 while the module is rebuilt.
+
+## 2) Quarantine Report
+| File | SHA1 | Size | Markers |
+| --- | --- | --- | --- |
+| lottery/config.php | beed9dd872f51c75a77b9d014208b2e7f675e798 | 6536 | likely_update, missing_bootstrap, missing_strict_types, unclosed_brace, dangling_quote, parse_error |
+| lottery/tickets.php | 10a3b4d2de9ea425fce811f9d7bcbea1b0ac1908 | 6826 | contains_sql_query, contains_mysqli, likely_select, likely_update, missing_bootstrap, missing_strict_types, unclosed_brace, parse_error |
+| lottery/viewtickets.php | 75915023dd7959ed7e2f8867bc30fcefb2ee05a7 | 2320 | contains_sql_query, contains_mysqli, likely_select, missing_strict_types, parse_error |
+
+## 3) Suggested Rebuild Order
+- config.php
+- tickets.php
+- viewtickets.php
+
+## 4) Implementation Notes for Later
+- Use `Pu239\Database` with bound params only (no `sql_query`, `sqlesc`, `mysqli_`).
+- Transactions for dependent writes (insert+update, counters).
+- No `SELECT *`; explicit column lists.
+- `LIMIT`/`OFFSET` → cast to int and inline.
+- `IN (...)` → dynamic placeholders (`:id0`, `:id1`, ...).
+- Safe `ORDER BY` → whitelist field & direction.
+
+## 5) Restoring a File for Local Work
+```
+cp lottery/_quarantine/<file>.orig lottery/<file>
+```
+
+## 6) Safety Note
+503 stubs are intentional until each file is properly rebuilt.
+
+## DONE-CHECKS
+- `rg -n "mysqli_|sql_query\(|sqlesc\(" lottery/` → matches only inside `lottery/_quarantine/*.orig`
+- `php -l lottery/*.php` → all pass
+- `curl -i http://127.0.0.1:8000/lottery/tickets.php` → HTTP 503 with plaintext maintenance banner

--- a/lottery/_quarantine/REPORT.json
+++ b/lottery/_quarantine/REPORT.json
@@ -1,0 +1,48 @@
+[
+  {
+    "file": "lottery/config.php",
+    "quarantined_to": "lottery/_quarantine/config.php.orig",
+    "size_bytes": 6536,
+    "sha1": "beed9dd872f51c75a77b9d014208b2e7f675e798",
+    "first_200_chars": "<?php\\n$db = $container->get(Database::class);\\n\\nrequire_once __DIR__ . '/../include/runtime_safe.php';\\n\\n\\ndeclare(strict_types = 1);\\n\\nuse Pu239\\Database;\\n\\nuse Pu239\\Session;\\n\\nrequire_once __DIR__ . '/..",
+    "detected_markers": [
+      "likely_update",
+      "missing_bootstrap",
+      "missing_strict_types",
+      "unclosed_brace",
+      "dangling_quote",
+      "parse_error"
+    ]
+  },
+  {
+    "file": "lottery/tickets.php",
+    "quarantined_to": "lottery/_quarantine/tickets.php.orig",
+    "size_bytes": 6826,
+    "sha1": "10a3b4d2de9ea425fce811f9d7bcbea1b0ac1908",
+    "first_200_chars": "<?php\\n$db = $container->get(Database::class);\\n\\nrequire_once __DIR__ . '/../include/runtime_safe.php';\\n\\n\\ndeclare(strict_types = 1);\\n\\nuse Pu239\\Cache;\\nuse Pu239\\Database;\\nuse Pu239\\Session;\\n\\nrequire_onc",
+    "detected_markers": [
+      "contains_sql_query",
+      "contains_mysqli",
+      "likely_select",
+      "likely_update",
+      "missing_bootstrap",
+      "missing_strict_types",
+      "unclosed_brace",
+      "parse_error"
+    ]
+  },
+  {
+    "file": "lottery/viewtickets.php",
+    "quarantined_to": "lottery/_quarantine/viewtickets.php.orig",
+    "size_bytes": 2320,
+    "sha1": "75915023dd7959ed7e2f8867bc30fcefb2ee05a7",
+    "first_200_chars": "<?php\\n$db = $container->get(Database::class);\\n\\nrequire_once __DIR__ . '/../include/runtime_safe.php';\\n\\nrequire_once __DIR__ . '/../include/bootstrap_pdo.php';\\n\\n\\ndeclare(strict_types = 1);\\n\\nuse Pu239\\D",
+    "detected_markers": [
+      "contains_sql_query",
+      "contains_mysqli",
+      "likely_select",
+      "missing_strict_types",
+      "parse_error"
+    ]
+  }
+]

--- a/lottery/_quarantine/config.php.orig
+++ b/lottery/_quarantine/config.php.orig
@@ -1,0 +1,135 @@
+<?php
+$db = $container->get(Database::class);
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+
+
+declare(strict_types = 1);
+
+use Pu239\Database;
+
+use Pu239\Session;
+
+require_once __DIR__ . '/../include/bittorrent.php';
+require_once CLASS_DIR . 'class_check.php';
+require_once INCL_DIR . 'function_html.php';
+require_once INCL_DIR . 'function_users.php';
+class_check(UC_STAFF);
+$lconf = $db->run(');
+        if ($site_config['site']['autoshout_chat'] || $site_config['site']['autoshout_irc']) {
+            $link = "[url={$site_config['paths']['baseurl']}/lottery.php]" . _('Lottery') . '[/url]';
+            $msg = _fe('The {0} has begun! Get your tickets now. The pot is {1} and each ticket is only {2} {3}.', $link, $fund, $cost, $type);
+            autoshout($msg);
+        }
+        $session->set('is-success', _('Lottery configuration was saved!'));
+        header("Location: {$_SERVER['PHP_SELF']}");
+        app_halt('Exit called');
+    } else {
+        $session->set('is-warning', _('There was an error while executing the update query.'));
+    }
+}
+if (!empty($lottery_config)) {
+    if ($lottery_config['enable']) {
+        $classes = implode(', ', array_map('get_user_class_name', explode('|', $lottery_config['class_allowed'])));
+        stderr(_('Lottery Config Closed'), _fe('Classes playing in this lottery are: {0}', $classes));
+    } else {
+        $html = "
+        <form action='{$site_config['paths']['baseurl']}/lottery.php?action=config' method='post' enctype='multipart/form-data' accept-charset='utf-8'>
+            <div class='portlet'>";
+        $table = "
+                    <tr>
+                        <td class='rowhead'>" . _('Enable The Lottery') . "</td>
+                        <td>
+                            <input type='radio' name='enable' value='1' " . ($lottery_config['enable'] ? 'checked' : '') . '> ' . _('Yes') . "
+                            <input type='radio' name='enable' value='0' " . (!$lottery_config['enable'] ? 'checked' : '') . '> ' . _('No') . '
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>' . _('Use Prize Fund (No, uses default pot of all users).') . "</td>
+                        <td>
+                            <input type='radio' name='use_prize_fund' value='1' " . ($lottery_config['use_prize_fund'] ? 'checked' : '') . '> ' . _('Yes') . "
+                            <input type='radio' name='use_prize_fund' value='0' " . (!$lottery_config['use_prize_fund'] ? 'checked' : '') . '> ' . _('No') . '
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>' . _('Prize Fund') . "</td>
+                        <td><input type='number' name='prize_fund' value='{$lottery_config['prize_fund']}' class='w-100' required></td>
+                    </tr>
+                    <tr>
+                        <td>" . _('Ticket Amount') . "</td>
+                        <td><input type='number' name='ticket_amount' value='{$lottery_config['ticket_amount']}' class='w-100' required></td>
+                    </tr>
+                    <tr>
+                        <td>" . _('Ticket Amount Type') . "</td>
+                        <td>
+                            <select name='ticket_amount_type' class='w-100'>
+                                <option value='seedbonus' selected>" . _('Karma Bonus Points') . '</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>' . _('Amount Of Tickets Allowed') . "</td>
+                        <td><input type='number' name='user_tickets' value='{$lottery_config['user_tickets']}' class='w-100' required></td>
+                    </tr>
+                    <tr>
+                        <td>" . _('Classes Allowed') . "</td>
+                        <td>
+                            <div class='level-center'>";
+        for ($i = UC_MIN; $i <= UC_MAX; ++$i) {
+            $table .= "
+                                <div class='level-center'>
+                                    <label for='c{$i}'>" . get_user_class_name($i) . "</label>
+                                    <input type='checkbox' value='{$i}' id='c{$i}' name='class_allowed[]' class='left10' checked>
+                                </div>";
+        }
+        $table .= '
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>' . _('Total Winners') . "</td>
+                        <td><input type='number' name='total_winners' min='1' max='10' value='{$lottery_config['total_winners']}' class='w-100' required></td>
+                    </tr>
+                    <tr>
+                        <td>" . _('Start Date') . "</td>
+                        <td>
+                            <select name='start_date' class='w-100'>
+                                <option value='" . TIME_NOW . "'>" . _('Now') . '</option>';
+        for ($i = 2; $i <= 24; $i += 2) {
+            $table .= "
+                                <option value='" . (TIME_NOW + (3600 * $i)) . "'>" . _pfe('{0} hour', '{0} hours', $i) . '</option>';
+        }
+        $table .= '
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>' . _('Run Length') . "</td>
+                        <td>
+                            <select name='end_date' class='w-100'>";
+        for ($i = 7; $i >= 1; --$i) {
+            $table .= "
+                                <option value='" . (TIME_NOW + (86400 * $i)) . "'>" . _pfe('{0} day', '{0} days', $i) . '</option>';
+        }
+        $table .= "
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan='2'>
+                            <div class='has-text-centered'>
+                                <input type='submit' class='button is-small' value='Apply changes'>
+                            </div>
+                        </td>
+                    </tr>";
+        $html .= main_table($table) . '
+            </div>
+        </form>';
+    }
+}
+$title = _('Lottery Config');
+$breadcrumbs = [
+    "<a href='{$site_config['paths']['baseurl']}/games.php'>" . _('Games') . '</a>',
+    "<a href='{$site_config['paths']['baseurl']}/lottery.php'>" . _('Lottery') . '</a>',
+    "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
+];
+echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($html) . stdfoot();

--- a/lottery/_quarantine/tickets.php.orig
+++ b/lottery/_quarantine/tickets.php.orig
@@ -1,0 +1,121 @@
+<?php
+$db = $container->get(Database::class);
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+
+
+declare(strict_types = 1);
+
+use Pu239\Cache;
+use Pu239\Database;
+use Pu239\Session;
+
+require_once __DIR__ . '/../include/bittorrent.php';
+require_once INCL_DIR . 'function_html.php';
+$lconf = $db->run(');
+                autoshout($msg);
+            }
+        } else {
+            $session->set('is-warning', _('There was an error with the update query.'));
+        }
+    }
+}
+$classes_allowed = (strpos($lottery_config['class_allowed'], '|') ? explode('|', $lottery_config['class_allowed']) : $lottery_config['class_allowed']);
+if (!(is_array($classes_allowed) ? in_array($CURUSER['class'], $classes_allowed) : $CURUSER['class'] == $classes_allowed)) {
+    $session->set('is-danger', _('Your class is not allowed to play in this lottery'));
+    header('Location: ' . $site_config['paths']['baseurl']);
+    app_halt('Exit called');
+}
+//some default values
+$lottery['total_pot'] = 0;
+$lottery['current_user'] = [];
+$lottery['current_user']['tickets'] = [];
+$lottery['total_tickets'] = 0;
+//select the total amount of tickets
+$qt = sql_query('SELECT id,user FROM tickets ORDER BY id ') or sqlerr(__FILE__, __LINE__);
+while ($at = mysqli_fetch_assoc($qt)) {
+    ++$lottery['total_tickets'];
+    if ($at['user'] == $CURUSER['id']) {
+        $lottery['current_user']['tickets'][] = $at['id'];
+    }
+}
+//set the current user total tickets amount
+$lottery['current_user']['total_tickets'] = count($lottery['current_user']['tickets']);
+//check if the prize setting is set to calculate the totat pot
+if ($lottery_config['use_prize_fund']) {
+    $lottery['total_pot'] = $lottery_config['prize_fund'];
+} else {
+    $lottery['total_pot'] = $lottery_config['ticket_amount'] * $lottery['total_tickets'];
+}
+//how much the winner gets
+$lottery['per_user'] = round($lottery['total_pot'] / $lottery_config['total_winners'], 2);
+//how many tickets could the user buy
+$lottery['current_user']['could_buy'] = $lottery['current_user']['can_buy'] = $lottery_config['user_tickets'] - $lottery['current_user']['total_tickets'];
+//if he has less bonus points calculate how many tickets can he buy with what he has
+if ($CURUSER['seedbonus'] < ($lottery['current_user']['could_buy'] * $lottery_config['ticket_amount'])) {
+    for ($lottery['current_user']['can_buy']; $CURUSER['seedbonus'] < ($lottery_config['ticket_amount'] * $lottery['current_user']['can_buy']); --$lottery['current_user']['can_buy']) {
+    }
+}
+//check if the lottery ended if the lottery ended don't allow the user to buy more tickets or if he has already bought the max tickets
+if (time() > $lottery_config['end_date'] || $lottery_config['user_tickets'] <= $lottery['current_user']['total_tickets']) {
+    $lottery['current_user']['can_buy'] = 0;
+}
+$html = "
+        <h1 class='has-text-centered'>" . _fe('{0} Lottery', $site_config['site']['name']) . '</h1>';
+$body = "
+                <ul class='padding20 disc left20'>
+                    <li>" . _('Tickets are non-refundable') . '</li>
+                    <li>' . _fe('Each ticket costs {0} Karma Bonus Points, which is taken from your seedbonus amount.', number_format((int) $lottery_config['ticket_amount'])) . '</li>
+                    <li>' . _('Purchasable shows how many tickets you can afford to purchase.') . '</li>
+                    <li>' . _('You can only buy up to your purchaseable amount.') . '</li>
+                    <li>' . _fe('The competition will end: {0}', get_date((int) $lottery_config['end_date'], 'LONG')) . '</li>
+                    <li>' . _pfe('There will be {0} winner, picked at random.', 'There will be {0} winners, picked at random.', $lottery_config['total_winners']) . '</li>
+                    <li>' . _pfe('The {0} winner will get {1} added to their seedbonus amount.', 'The {0} winners will get {1} added to their seedbonus amount.', $lottery_config['total_winners'], number_format($lottery['per_user'])) . '</li>
+                    <li>' . _('The Winners will be announced once the lottery has closed and posted on the home page.') . '</li>';
+if (!$lottery_config['use_prize_fund']) {
+    $body .= '
+                    <li>' . _('The more tickets that are sold the bigger the pot will be!') . '</li>';
+}
+if (!empty($lottery['current_user']['tickets']) && count($lottery['current_user']['tickets'])) {
+    $body .= '
+                    <li>' . _fe('You own ticket numbers: {0}', implode(', ', $lottery['current_user']['tickets'])) . '</li>';
+}
+$body .= '
+                </ul>';
+$table = '
+            <tr>
+                <td>' . _('Total Pot') . '</td>
+                <td>' . number_format((int) $lottery['total_pot']) . '</td>
+            </tr>
+            <tr>
+                <td>' . _('Total Tickets Purchased') . '</td>
+                <td>' . _pfe('{0} Ticket', '{0} Tickets', number_format((int) $lottery['total_tickets'])) . '</td>
+            </tr>
+            <tr>
+                <td>' . _('Tickets Purchased by You') . '</td>
+                <td>' . _pfe('{0} Ticket', '{0} Tickets', number_format((int) $lottery['current_user']['total_tickets'])) . '</td>
+            </tr>
+            <tr>
+                <td>' . _('Purchaseable') . '</td>
+                <td>' . ($lottery['current_user']['could_buy'] > $lottery['current_user']['can_buy'] ? _pfe('You have enough points for {0} ticket.', 'You have enough points for {0} tickets.', number_format((int) $lottery['current_user']['can_buy'])) . ' ' . _pfe('You can buy another {0} ticket if you get get more bonus points.', 'You can buy another {0} tickets if you get get more bonus points.', $lottery['current_user']['could_buy'] - $lottery['current_user']['can_buy']) : number_format($lottery['current_user']['can_buy'])) . '</td>
+            </tr>';
+
+$html = main_div($body) . main_table($table, '', 'top20');
+if ($lottery['current_user']['can_buy'] > 0) {
+    $available = $lottery['current_user']['could_buy'] < $lottery['current_user']['can_buy'] ? $lottery['current_user']['could_buy'] : $lottery['current_user']['can_buy'];
+    $html .= "
+        <form action='lottery.php?action=tickets' method='post' enctype='multipart/form-data' accept-charset='utf-8'>
+            <div class='has-text-centered margin20'>
+                <input type='number' min='0' max='$available' name='tickets' value='1' required>
+                <input type='submit' value='Buy tickets' class='button is-small left10'>
+            </div>
+        </form>";
+}
+
+$title = _('Buy tickets for lottery');
+$breadcrumbs = [
+    "<a href='{$site_config['paths']['baseurl']}/games.php'>" . _('Games') . '</a>',
+    "<a href='{$site_config['paths']['baseurl']}/lottery.php'>" . _('Lottery') . '</a>',
+    "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
+];
+echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($html) . stdfoot();

--- a/lottery/_quarantine/viewtickets.php.orig
+++ b/lottery/_quarantine/viewtickets.php.orig
@@ -1,0 +1,63 @@
+<?php
+$db = $container->get(Database::class);
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
+
+declare(strict_types = 1);
+
+use Pu239\Database;
+
+require_once __DIR__ . '/../include/bittorrent.php';
+require_once INCL_DIR . 'function_html.php';
+$lconf = sql_query('SELECT * FROM lottery_config') or sqlerr(__FILE__, __LINE__);
+while ($ac = mysqli_fetch_assoc($lconf)) {
+    $lottery_config[$ac['name']] = $ac['value'];
+}
+if (!$lottery_config['enable']) {
+    stderr(_('Error'), _('Lottery is closed'));
+}
+global $site_config;
+
+$html = '
+    <div class="has-text-centered padding20">
+        <h1>' . _fe('{0} Lottery', $site_config['site']['name']) . '</h1>
+        <span class="size_4">
+            Started: ' . get_date((int) $lottery_config['start_date'], 'LONG') . '<br>
+            Ends: ' . get_date((int) $lottery_config['end_date'], 'LONG') . "<br>
+            Time Remaining: <span class='has-text-danger'>" . mkprettytime($lottery_config['end_date'] - TIME_NOW) . '</span>
+        </span>
+    </div>';
+$qs = sql_query('SELECT count(t.id) AS tickets , u.id, u.seedbonus FROM tickets AS t LEFT JOIN users AS u ON u.id = t.user GROUP BY u.id ORDER BY tickets DESC, username') or sqlerr(__FILE__, __LINE__);
+$header = $body = $html = '';
+
+if (!mysqli_num_rows($qs)) {
+    $html .= '<div class="has-text-centered size_5 padding20">' . _('No tickets have been purchased!') . '</div>';
+    $html = main_div($html);
+} else {
+    $header = '
+    <tr>
+      <th>' . _('Username') . '</th>
+      <th>' . _('tickets') . '</th>
+      <th>' . _('seedbonus') . '</th>
+    </tr>';
+    while ($ar = mysqli_fetch_assoc($qs)) {
+        $body .= '
+    <tr>
+        <td>' . format_username((int) $ar['id']) . '</a></td>
+        <td>' . number_format((int) $ar['tickets']) . '</td>
+        <td>' . number_format((float) $ar['seedbonus']) . '</td>
+    </tr>';
+    }
+    $html .= main_table($body, $header);
+}
+
+$title = _('Lottery Tickets');
+$breadcrumbs = [
+    "<a href='{$site_config['paths']['baseurl']}/games.php'>" . _('Games') . '</a>',
+    "<a href='{$site_config['paths']['baseurl']}/lottery.php'>" . _('Lottery') . '</a>',
+    "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
+];
+echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($html) . stdfoot();

--- a/lottery/_scaffold/__template.php
+++ b/lottery/_scaffold/__template.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
+use Pu239\Database;
+
+global $container;
+/** @var Database $db */
+$db = $container->get(Database::class);
+
+/**
+ * Sanitize integer input.
+ */
+function sanitize_int(mixed $value): int
+{
+    return max(0, (int) $value);
+}
+
+/**
+ * Sanitize string input with length cap.
+ */
+function sanitize_string(string $value, int $max_length): string
+{
+    return trim(mb_substr($value, 0, $max_length));
+}
+
+/**
+ * Build dynamic IN (...) placeholders.
+ *
+ * @param array $items
+ * @param string $prefix
+ * @return array{0:array,1:array}
+ */
+function build_in_placeholders(array $items, string $prefix = 'id'): array
+{
+    $placeholders = [];
+    $params = [];
+    foreach (array_values($items) as $i => $val) {
+        $key = ":{$prefix}{$i}";
+        $placeholders[] = $key;
+        $params[$key] = $val;
+    }
+    return [$placeholders, $params];
+}
+
+/**
+ * Safe ORDER BY helper.
+ */
+function build_order_by(string $field, string $direction, array $allowed_fields): string
+{
+    $direction = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
+    if (!in_array($field, $allowed_fields, true)) {
+        return '';
+    }
+    return "ORDER BY {$field} {$direction}";
+}
+
+// Example SELECT with explicit columns and named params:
+/*
+[$placeholders, $params] = build_in_placeholders([1, 2, 3]);
+$sql = 'SELECT id, name FROM table WHERE id IN (' . implode(',', $placeholders) . ')';
+$rows = $db->fetchAll($sql, $params);
+*/
+
+// Example INSERT/UPDATE inside transaction:
+/*
+try {
+    $db->beginTransaction();
+    $db->run('INSERT INTO table (id, name) VALUES (:id, :name)', [':id' => 1, ':name' => 'test']);
+    $db->run('UPDATE table SET counter = counter + 1 WHERE id = :id', [':id' => 1]);
+    $db->commit();
+} catch (Throwable $e) {
+    $db->rollBack();
+    throw $e;
+}
+*/

--- a/lottery/config.php
+++ b/lottery/config.php
@@ -1,135 +1,19 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
-
-declare(strict_types = 1);
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
 
-use Pu239\Session;
+global $container, $site_config;
+/** @var Pu239\Database $db */
+$db = $container->get(Database::class);
 
-require_once __DIR__ . '/../include/bittorrent.php';
-require_once CLASS_DIR . 'class_check.php';
-require_once INCL_DIR . 'function_html.php';
-require_once INCL_DIR . 'function_users.php';
-class_check(UC_STAFF);
-$lconf = $db->run(');
-        if ($site_config['site']['autoshout_chat'] || $site_config['site']['autoshout_irc']) {
-            $link = "[url={$site_config['paths']['baseurl']}/lottery.php]" . _('Lottery') . '[/url]';
-            $msg = _fe('The {0} has begun! Get your tickets now. The pot is {1} and each ticket is only {2} {3}.', $link, $fund, $cost, $type);
-            autoshout($msg);
-        }
-        $session->set('is-success', _('Lottery configuration was saved!'));
-        header("Location: {$_SERVER['PHP_SELF']}");
-        app_halt('Exit called');
-    } else {
-        $session->set('is-warning', _('There was an error while executing the update query.'));
-    }
-}
-if (!empty($lottery_config)) {
-    if ($lottery_config['enable']) {
-        $classes = implode(', ', array_map('get_user_class_name', explode('|', $lottery_config['class_allowed'])));
-        stderr(_('Lottery Config Closed'), _fe('Classes playing in this lottery are: {0}', $classes));
-    } else {
-        $html = "
-        <form action='{$site_config['paths']['baseurl']}/lottery.php?action=config' method='post' enctype='multipart/form-data' accept-charset='utf-8'>
-            <div class='portlet'>";
-        $table = "
-                    <tr>
-                        <td class='rowhead'>" . _('Enable The Lottery') . "</td>
-                        <td>
-                            <input type='radio' name='enable' value='1' " . ($lottery_config['enable'] ? 'checked' : '') . '> ' . _('Yes') . "
-                            <input type='radio' name='enable' value='0' " . (!$lottery_config['enable'] ? 'checked' : '') . '> ' . _('No') . '
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>' . _('Use Prize Fund (No, uses default pot of all users).') . "</td>
-                        <td>
-                            <input type='radio' name='use_prize_fund' value='1' " . ($lottery_config['use_prize_fund'] ? 'checked' : '') . '> ' . _('Yes') . "
-                            <input type='radio' name='use_prize_fund' value='0' " . (!$lottery_config['use_prize_fund'] ? 'checked' : '') . '> ' . _('No') . '
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>' . _('Prize Fund') . "</td>
-                        <td><input type='number' name='prize_fund' value='{$lottery_config['prize_fund']}' class='w-100' required></td>
-                    </tr>
-                    <tr>
-                        <td>" . _('Ticket Amount') . "</td>
-                        <td><input type='number' name='ticket_amount' value='{$lottery_config['ticket_amount']}' class='w-100' required></td>
-                    </tr>
-                    <tr>
-                        <td>" . _('Ticket Amount Type') . "</td>
-                        <td>
-                            <select name='ticket_amount_type' class='w-100'>
-                                <option value='seedbonus' selected>" . _('Karma Bonus Points') . '</option>
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>' . _('Amount Of Tickets Allowed') . "</td>
-                        <td><input type='number' name='user_tickets' value='{$lottery_config['user_tickets']}' class='w-100' required></td>
-                    </tr>
-                    <tr>
-                        <td>" . _('Classes Allowed') . "</td>
-                        <td>
-                            <div class='level-center'>";
-        for ($i = UC_MIN; $i <= UC_MAX; ++$i) {
-            $table .= "
-                                <div class='level-center'>
-                                    <label for='c{$i}'>" . get_user_class_name($i) . "</label>
-                                    <input type='checkbox' value='{$i}' id='c{$i}' name='class_allowed[]' class='left10' checked>
-                                </div>";
-        }
-        $table .= '
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>' . _('Total Winners') . "</td>
-                        <td><input type='number' name='total_winners' min='1' max='10' value='{$lottery_config['total_winners']}' class='w-100' required></td>
-                    </tr>
-                    <tr>
-                        <td>" . _('Start Date') . "</td>
-                        <td>
-                            <select name='start_date' class='w-100'>
-                                <option value='" . TIME_NOW . "'>" . _('Now') . '</option>';
-        for ($i = 2; $i <= 24; $i += 2) {
-            $table .= "
-                                <option value='" . (TIME_NOW + (3600 * $i)) . "'>" . _pfe('{0} hour', '{0} hours', $i) . '</option>';
-        }
-        $table .= '
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>' . _('Run Length') . "</td>
-                        <td>
-                            <select name='end_date' class='w-100'>";
-        for ($i = 7; $i >= 1; --$i) {
-            $table .= "
-                                <option value='" . (TIME_NOW + (86400 * $i)) . "'>" . _pfe('{0} day', '{0} days', $i) . '</option>';
-        }
-        $table .= "
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td colspan='2'>
-                            <div class='has-text-centered'>
-                                <input type='submit' class='button is-small' value='Apply changes'>
-                            </div>
-                        </td>
-                    </tr>";
-        $html .= main_table($table) . '
-            </div>
-        </form>';
-    }
-}
-$title = _('Lottery Config');
-$breadcrumbs = [
-    "<a href='{$site_config['paths']['baseurl']}/games.php'>" . _('Games') . '</a>',
-    "<a href='{$site_config['paths']['baseurl']}/lottery.php'>" . _('Lottery') . '</a>',
-    "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
-];
-echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($html) . stdfoot();
+// TEMPORARY STUB: Lottery module under maintenance.
+// Original file quarantined: lottery/_quarantine/config.php.orig
+http_response_code(503);
+header('Content-Type: text/plain; charset=utf-8');
+echo "Lottery module is temporarily unavailable while we rebuild this section.\n";
+echo "Reference: lottery/_quarantine/config.php.orig\n";
+return;

--- a/lottery/tickets.php
+++ b/lottery/tickets.php
@@ -1,121 +1,19 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
-
-declare(strict_types = 1);
-
-use Pu239\Cache;
 use Pu239\Database;
-use Pu239\Session;
 
-require_once __DIR__ . '/../include/bittorrent.php';
-require_once INCL_DIR . 'function_html.php';
-$lconf = $db->run(');
-                autoshout($msg);
-            }
-        } else {
-            $session->set('is-warning', _('There was an error with the update query.'));
-        }
-    }
-}
-$classes_allowed = (strpos($lottery_config['class_allowed'], '|') ? explode('|', $lottery_config['class_allowed']) : $lottery_config['class_allowed']);
-if (!(is_array($classes_allowed) ? in_array($CURUSER['class'], $classes_allowed) : $CURUSER['class'] == $classes_allowed)) {
-    $session->set('is-danger', _('Your class is not allowed to play in this lottery'));
-    header('Location: ' . $site_config['paths']['baseurl']);
-    app_halt('Exit called');
-}
-//some default values
-$lottery['total_pot'] = 0;
-$lottery['current_user'] = [];
-$lottery['current_user']['tickets'] = [];
-$lottery['total_tickets'] = 0;
-//select the total amount of tickets
-$qt = sql_query('SELECT id,user FROM tickets ORDER BY id ') or sqlerr(__FILE__, __LINE__);
-while ($at = mysqli_fetch_assoc($qt)) {
-    ++$lottery['total_tickets'];
-    if ($at['user'] == $CURUSER['id']) {
-        $lottery['current_user']['tickets'][] = $at['id'];
-    }
-}
-//set the current user total tickets amount
-$lottery['current_user']['total_tickets'] = count($lottery['current_user']['tickets']);
-//check if the prize setting is set to calculate the totat pot
-if ($lottery_config['use_prize_fund']) {
-    $lottery['total_pot'] = $lottery_config['prize_fund'];
-} else {
-    $lottery['total_pot'] = $lottery_config['ticket_amount'] * $lottery['total_tickets'];
-}
-//how much the winner gets
-$lottery['per_user'] = round($lottery['total_pot'] / $lottery_config['total_winners'], 2);
-//how many tickets could the user buy
-$lottery['current_user']['could_buy'] = $lottery['current_user']['can_buy'] = $lottery_config['user_tickets'] - $lottery['current_user']['total_tickets'];
-//if he has less bonus points calculate how many tickets can he buy with what he has
-if ($CURUSER['seedbonus'] < ($lottery['current_user']['could_buy'] * $lottery_config['ticket_amount'])) {
-    for ($lottery['current_user']['can_buy']; $CURUSER['seedbonus'] < ($lottery_config['ticket_amount'] * $lottery['current_user']['can_buy']); --$lottery['current_user']['can_buy']) {
-    }
-}
-//check if the lottery ended if the lottery ended don't allow the user to buy more tickets or if he has already bought the max tickets
-if (time() > $lottery_config['end_date'] || $lottery_config['user_tickets'] <= $lottery['current_user']['total_tickets']) {
-    $lottery['current_user']['can_buy'] = 0;
-}
-$html = "
-        <h1 class='has-text-centered'>" . _fe('{0} Lottery', $site_config['site']['name']) . '</h1>';
-$body = "
-                <ul class='padding20 disc left20'>
-                    <li>" . _('Tickets are non-refundable') . '</li>
-                    <li>' . _fe('Each ticket costs {0} Karma Bonus Points, which is taken from your seedbonus amount.', number_format((int) $lottery_config['ticket_amount'])) . '</li>
-                    <li>' . _('Purchasable shows how many tickets you can afford to purchase.') . '</li>
-                    <li>' . _('You can only buy up to your purchaseable amount.') . '</li>
-                    <li>' . _fe('The competition will end: {0}', get_date((int) $lottery_config['end_date'], 'LONG')) . '</li>
-                    <li>' . _pfe('There will be {0} winner, picked at random.', 'There will be {0} winners, picked at random.', $lottery_config['total_winners']) . '</li>
-                    <li>' . _pfe('The {0} winner will get {1} added to their seedbonus amount.', 'The {0} winners will get {1} added to their seedbonus amount.', $lottery_config['total_winners'], number_format($lottery['per_user'])) . '</li>
-                    <li>' . _('The Winners will be announced once the lottery has closed and posted on the home page.') . '</li>';
-if (!$lottery_config['use_prize_fund']) {
-    $body .= '
-                    <li>' . _('The more tickets that are sold the bigger the pot will be!') . '</li>';
-}
-if (!empty($lottery['current_user']['tickets']) && count($lottery['current_user']['tickets'])) {
-    $body .= '
-                    <li>' . _fe('You own ticket numbers: {0}', implode(', ', $lottery['current_user']['tickets'])) . '</li>';
-}
-$body .= '
-                </ul>';
-$table = '
-            <tr>
-                <td>' . _('Total Pot') . '</td>
-                <td>' . number_format((int) $lottery['total_pot']) . '</td>
-            </tr>
-            <tr>
-                <td>' . _('Total Tickets Purchased') . '</td>
-                <td>' . _pfe('{0} Ticket', '{0} Tickets', number_format((int) $lottery['total_tickets'])) . '</td>
-            </tr>
-            <tr>
-                <td>' . _('Tickets Purchased by You') . '</td>
-                <td>' . _pfe('{0} Ticket', '{0} Tickets', number_format((int) $lottery['current_user']['total_tickets'])) . '</td>
-            </tr>
-            <tr>
-                <td>' . _('Purchaseable') . '</td>
-                <td>' . ($lottery['current_user']['could_buy'] > $lottery['current_user']['can_buy'] ? _pfe('You have enough points for {0} ticket.', 'You have enough points for {0} tickets.', number_format((int) $lottery['current_user']['can_buy'])) . ' ' . _pfe('You can buy another {0} ticket if you get get more bonus points.', 'You can buy another {0} tickets if you get get more bonus points.', $lottery['current_user']['could_buy'] - $lottery['current_user']['can_buy']) : number_format($lottery['current_user']['can_buy'])) . '</td>
-            </tr>';
+global $container, $site_config;
+/** @var Pu239\Database $db */
+$db = $container->get(Database::class);
 
-$html = main_div($body) . main_table($table, '', 'top20');
-if ($lottery['current_user']['can_buy'] > 0) {
-    $available = $lottery['current_user']['could_buy'] < $lottery['current_user']['can_buy'] ? $lottery['current_user']['could_buy'] : $lottery['current_user']['can_buy'];
-    $html .= "
-        <form action='lottery.php?action=tickets' method='post' enctype='multipart/form-data' accept-charset='utf-8'>
-            <div class='has-text-centered margin20'>
-                <input type='number' min='0' max='$available' name='tickets' value='1' required>
-                <input type='submit' value='Buy tickets' class='button is-small left10'>
-            </div>
-        </form>";
-}
-
-$title = _('Buy tickets for lottery');
-$breadcrumbs = [
-    "<a href='{$site_config['paths']['baseurl']}/games.php'>" . _('Games') . '</a>',
-    "<a href='{$site_config['paths']['baseurl']}/lottery.php'>" . _('Lottery') . '</a>',
-    "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
-];
-echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($html) . stdfoot();
+// TEMPORARY STUB: Lottery module under maintenance.
+// Original file quarantined: lottery/_quarantine/tickets.php.orig
+http_response_code(503);
+header('Content-Type: text/plain; charset=utf-8');
+echo "Lottery module is temporarily unavailable while we rebuild this section.\n";
+echo "Reference: lottery/_quarantine/tickets.php.orig\n";
+return;

--- a/lottery/viewtickets.php
+++ b/lottery/viewtickets.php
@@ -1,63 +1,19 @@
 <?php
-$db = $container->get(Database::class);
+declare(strict_types=1);
 
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
 
 use Pu239\Database;
 
-require_once __DIR__ . '/../include/bittorrent.php';
-require_once INCL_DIR . 'function_html.php';
-$lconf = sql_query('SELECT * FROM lottery_config') or sqlerr(__FILE__, __LINE__);
-while ($ac = mysqli_fetch_assoc($lconf)) {
-    $lottery_config[$ac['name']] = $ac['value'];
-}
-if (!$lottery_config['enable']) {
-    stderr(_('Error'), _('Lottery is closed'));
-}
-global $site_config;
+global $container, $site_config;
+/** @var Pu239\Database $db */
+$db = $container->get(Database::class);
 
-$html = '
-    <div class="has-text-centered padding20">
-        <h1>' . _fe('{0} Lottery', $site_config['site']['name']) . '</h1>
-        <span class="size_4">
-            Started: ' . get_date((int) $lottery_config['start_date'], 'LONG') . '<br>
-            Ends: ' . get_date((int) $lottery_config['end_date'], 'LONG') . "<br>
-            Time Remaining: <span class='has-text-danger'>" . mkprettytime($lottery_config['end_date'] - TIME_NOW) . '</span>
-        </span>
-    </div>';
-$qs = sql_query('SELECT count(t.id) AS tickets , u.id, u.seedbonus FROM tickets AS t LEFT JOIN users AS u ON u.id = t.user GROUP BY u.id ORDER BY tickets DESC, username') or sqlerr(__FILE__, __LINE__);
-$header = $body = $html = '';
-
-if (!mysqli_num_rows($qs)) {
-    $html .= '<div class="has-text-centered size_5 padding20">' . _('No tickets have been purchased!') . '</div>';
-    $html = main_div($html);
-} else {
-    $header = '
-    <tr>
-      <th>' . _('Username') . '</th>
-      <th>' . _('tickets') . '</th>
-      <th>' . _('seedbonus') . '</th>
-    </tr>';
-    while ($ar = mysqli_fetch_assoc($qs)) {
-        $body .= '
-    <tr>
-        <td>' . format_username((int) $ar['id']) . '</a></td>
-        <td>' . number_format((int) $ar['tickets']) . '</td>
-        <td>' . number_format((float) $ar['seedbonus']) . '</td>
-    </tr>';
-    }
-    $html .= main_table($body, $header);
-}
-
-$title = _('Lottery Tickets');
-$breadcrumbs = [
-    "<a href='{$site_config['paths']['baseurl']}/games.php'>" . _('Games') . '</a>',
-    "<a href='{$site_config['paths']['baseurl']}/lottery.php'>" . _('Lottery') . '</a>',
-    "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
-];
-echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($html) . stdfoot();
+// TEMPORARY STUB: Lottery module under maintenance.
+// Original file quarantined: lottery/_quarantine/viewtickets.php.orig
+http_response_code(503);
+header('Content-Type: text/plain; charset=utf-8');
+echo "Lottery module is temporarily unavailable while we rebuild this section.\n";
+echo "Reference: lottery/_quarantine/viewtickets.php.orig\n";
+return;


### PR DESCRIPTION
## Summary
- quarantine corrupted lottery PHP sources for forensics
- replace lottery endpoints with strict 503 maintenance stubs
- add JSON report, rebuild guide, and PDO/Aura scaffold template

## Testing
- `rg -n "mysqli_|sql_query\(|sqlesc\(" lottery/`
- `php -l lottery/config.php`
- `php -l lottery/tickets.php`
- `php -l lottery/viewtickets.php`
- `curl -i 127.0.0.1:8000/lottery/tickets.php`


------
https://chatgpt.com/codex/tasks/task_e_68c249f0f29083258f01e8cfa099135b