### PR TITLE
Batch – scripts/: PDO-migrering til Pu239\Database

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -350,3 +350,11 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" forums/stafflock_post.php
 ```
 No matches.
 ********* master
+## scripts
+- No PHP files found; no database migrations were necessary.
+
+### Verification
+```bash
+$ rg "mysqli_|sql_query\(|sqlesc\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" scripts
+```
+No matches.


### PR DESCRIPTION
## Summary
- document that the `scripts` directory contains no PHP files requiring PDO migration

## Testing
- `rg -n 'mysqli_' scripts || true`
- `rg -n 'sql_query\s*\(' scripts || true`
- `rg -n 'sqlesc\s*\(' scripts || true`
- `rg -n 'mysqli_fetch' scripts || true`
- `rg -n 'mysqli_num_rows' scripts || true`
- `rg -n 'mysqli_insert_id' scripts || true`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c39b50ed088325aacc9b380c5b1fd5