### PR TITLE
Batch – blocks/global: PDO-migrering til Pu239\Database

### DIFF
--- a/blocks/global/bugmessages.php
+++ b/blocks/global/bugmessages.php
@@ -15,7 +15,7 @@ $cache = $container->get(Cache::class);
 if ($site_config['alerts']['bug'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $bug_count = $cache->get('bug_mess_');
     if ($bug_count === false || is_null($bug_count)) {
-        $bug_count = $db->fetchValue('SELECT COUNT(id) FROM bugs WHERE status = ?', ['na']);
+        $bug_count = $db->fetchValue('SELECT COUNT(*) AS count FROM bugs WHERE status = ?', ['na']);
         $cache->set('bug_mess_', $bug_count, $site_config['expires']['alerts']);
     }
     if ($bug_count > 0) {

--- a/blocks/global/demotion.php
+++ b/blocks/global/demotion.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 use Pu239\Database;
 
 $user = check_user_status();
-global $site_config;
+global $container, $site_config;
 
 $db = $container->get(Database::class);
 

--- a/blocks/global/happyhour.php
+++ b/blocks/global/happyhour.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 use Pu239\Database;
 
 $user = check_user_status();
-global $site_config;
+global $container, $site_config;
 
 $db = $container->get(Database::class);
 

--- a/blocks/global/report.php
+++ b/blocks/global/report.php
@@ -15,7 +15,7 @@ $cache = $container->get(Cache::class);
 if ($site_config['alerts']['report'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $delt_with = $cache->get('new_report_');
     if ($delt_with === false || is_null($delt_with)) {
-        $delt_with = $db->fetchValue('SELECT COUNT(id) FROM reports WHERE delt_with = 0');
+        $delt_with = $db->fetchValue('SELECT COUNT(*) AS count FROM reports WHERE delt_with = 0');
         $cache->set('new_report_', $delt_with, $site_config['expires']['alerts']);
     }
     if ($delt_with > 0) {

--- a/blocks/global/staffmessages.php
+++ b/blocks/global/staffmessages.php
@@ -15,7 +15,7 @@ $cache = $container->get(Cache::class);
 if ($site_config['alerts']['staffmsg'] && has_access($user['class'], UC_STAFF, 'coder')) {
     $answeredby = $cache->get('staff_mess_');
     if ($answeredby === false || is_null($answeredby)) {
-        $answeredby = $db->fetchValue('SELECT COUNT(id) FROM staffmessages WHERE answeredby = 0');
+        $answeredby = $db->fetchValue('SELECT COUNT(*) AS count FROM staffmessages WHERE answeredby = 0');
         $cache->set('staff_mess_', $answeredby, $site_config['expires']['alerts']);
     }
     if ($answeredby > 0) {

--- a/blocks/global/uploadapp.php
+++ b/blocks/global/uploadapp.php
@@ -15,7 +15,7 @@ if ($site_config['alerts']['uploadapp'] && has_access($user['class'], UC_STAFF, 
     $cache = $container->get(Cache::class);
     $newapp = $cache->get('new_uploadapp_');
     if ($newapp === false || is_null($newapp)) {
-        $newapp = $db->fetchValue('SELECT COUNT(id) FROM uploadapp WHERE status = ?', ['pending']);
+        $newapp = $db->fetchValue('SELECT COUNT(*) AS count FROM uploadapp WHERE status = ?', ['pending']);
         $cache->set('new_uploadapp_', $newapp, $site_config['expires']['alerts']);
     }
     if ($newapp > 0) {

--- a/migration-report.md
+++ b/migration-report.md
@@ -350,3 +350,19 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" forums/stafflock_post.php
 ```
 No matches.
 ********* master
+
+## blocks/global (PDO cleanup)
+- `blocks/global/bugmessages.php`: replaced `COUNT(id)` with `COUNT(*)`.
+- `blocks/global/demotion.php`: added missing `$container` bootstrap.
+- `blocks/global/happyhour.php`: added missing `$container` bootstrap.
+- `blocks/global/report.php`: replaced `COUNT(id)` with `COUNT(*)`.
+- `blocks/global/uploadapp.php`: replaced `COUNT(id)` with `COUNT(*)`.
+- `blocks/global/staffmessages.php`: replaced `COUNT(id)` with `COUNT(*)`.
+
+Replaced 4 occurrences of `COUNT(id)` with `COUNT(*)` for accurate counting.
+
+### Verification
+```bash
+$ rg "mysqli_|sql_query\(|sqlesc\(" blocks/global
+```
+No matches.


### PR DESCRIPTION
## Summary
- normalize database bootstrap in demotion and happyhour blocks
- replace legacy COUNT(id) usages with COUNT(*)
- document blocks/global PDO cleanup in migration report

## Testing
- `php -l blocks/global/bugmessages.php blocks/global/demotion.php blocks/global/report.php blocks/global/uploadapp.php blocks/global/staffmessages.php blocks/global/happyhour.php`
- `rg "mysqli_|sql_query\s*\(|sqlesc\s*\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" -n blocks/global`


------
https://chatgpt.com/codex/tasks/task_e_68c39c12fdc483259936584e1aa78ba7