### PR TITLE
Batch – blocks/index: PDO-migrering til Pu239\Database

### DIFF
--- a/blocks/index/active_24h_users.php
+++ b/blocks/index/active_24h_users.php
@@ -18,9 +18,9 @@ if ($active24 === false || is_null($active24)) {
 
     $dt = TIME_NOW - 86400;
     $query = $db->fetchAll('SELECT id FROM users WHERE last_access > :dt AND anonymous_until < :now AND perms < :perms AND id != 2 ORDER BY username', [
-        ':dt' => $dt,
-        ':now' => TIME_NOW,
-        ':perms' => PERMS_STEALTH,
+        ':dt' => (int) $dt,
+        ':now' => (int) TIME_NOW,
+        ':perms' => (int) PERMS_STEALTH,
     ]);
 
     $count = count($query);
@@ -44,9 +44,9 @@ if ($active24 === false || is_null($active24)) {
     $active24['record'] = get_date((int) $record['value_u'], '');
     if ($count > $record['value_i']) {
         $db->run('UPDATE avps SET value_s = :value_s, value_i = :value_i, value_u = :value_u WHERE arg = :arg', [
-            ':value_s' => 0,
-            ':value_i' => $count,
-            ':value_u' => TIME_NOW,
+            ':value_s' => '0',
+            ':value_i' => (int) $count,
+            ':value_u' => (int) TIME_NOW,
             ':arg' => 'last24',
         ]);
     }

--- a/blocks/index/active_birthday_users.php
+++ b/blocks/index/active_birthday_users.php
@@ -16,10 +16,10 @@ if ($birthday === false || is_null($birthday)) {
     $birthday = $list = [];
     $current_date = getdate();
     $query = $db->fetchAll('SELECT id FROM users WHERE MONTH(birthday) = :mon AND DAYOFMONTH(birthday) = :day AND perms < :perms AND anonymous_until < :now ORDER BY username', [
-        ':mon' => $current_date['mon'],
-        ':day' => $current_date['mday'],
-        ':perms' => PERMS_STEALTH,
-        ':now' => TIME_NOW,
+        ':mon' => (int) $current_date['mon'],
+        ':day' => (int) $current_date['mday'],
+        ':perms' => (int) PERMS_STEALTH,
+        ':now' => (int) TIME_NOW,
     ]);
 
     $count = count($query);

--- a/blocks/index/active_irc_users.php
+++ b/blocks/index/active_irc_users.php
@@ -16,8 +16,8 @@ if ($irc === false || is_null($irc)) {
     $irc = $list = [];
     $query = $db->fetchAll('SELECT id FROM users WHERE onirc = :onirc AND perms < :perms AND anonymous_until < :now AND id != 2 ORDER BY username', [
         ':onirc' => 'yes',
-        ':perms' => PERMS_STEALTH,
-        ':now' => TIME_NOW,
+        ':perms' => (int) PERMS_STEALTH,
+        ':now' => (int) TIME_NOW,
     ]);
 
     $count = count($query);

--- a/blocks/index/active_users.php
+++ b/blocks/index/active_users.php
@@ -16,9 +16,9 @@ if ($active === false || is_null($active)) {
     $list = [];
     $dt = TIME_NOW - 900;
     $query = $db->fetchAll('SELECT id FROM users WHERE last_access > :dt AND perms < :perms AND anonymous_until < :now AND id != 2 ORDER BY username', [
-        ':dt' => $dt,
-        ':perms' => PERMS_STEALTH,
-        ':now' => TIME_NOW,
+        ':dt' => (int) $dt,
+        ':perms' => (int) PERMS_STEALTH,
+        ':now' => (int) TIME_NOW,
     ]);
 
     $count = count($query);

--- a/blocks/index/forum_posts.php
+++ b/blocks/index/forum_posts.php
@@ -34,8 +34,8 @@ if ($topics === false || is_null($topics)) {
             ORDER BY t.last_post DESC
             LIMIT :limit',
         [
-            ':class' => $CURUSER['class'],
-            ':limit' => $site_config['latest']['posts_limit'],
+            ':class' => (int) $CURUSER['class'],
+            ':limit' => (int) $site_config['latest']['posts_limit'],
         ]
     );
     if (!empty($topics)) {

--- a/blocks/index/gift.php
+++ b/blocks/index/gift.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 use Pu239\Database;
 
-global $CURUSER, $site_config;
+global $container, $CURUSER, $site_config;
 
 $db = $container->get(Database::class);
 

--- a/blocks/index/news.php
+++ b/blocks/index/news.php
@@ -14,7 +14,13 @@ $cache = $container->get(Cache::class);
 $news = $cache->get('latest_news_');
 if ($news === false || is_null($news)) {
     $dt = TIME_NOW - (86400 * 45);
-    $news = $db->fetchAll('SELECT * FROM news WHERE (added > :dt AND sticky = "no") OR sticky = "yes" ORDER BY sticky, added DESC LIMIT 10', [':dt' => $dt]);
+    $news = $db->fetchAll(
+        'SELECT id, userid, anonymous, title, added, body, sticky FROM news WHERE (added > :dt AND sticky = "no") OR sticky = "yes" ORDER BY sticky, added DESC LIMIT :limit',
+        [
+            ':dt' => (int) $dt,
+            ':limit' => (int) 10,
+        ]
+    );
     $cache->set('latest_news_', $news, $site_config['expires']['latest_news']);
 }
 

--- a/migration-report.md
+++ b/migration-report.md
@@ -350,3 +350,23 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" forums/stafflock_post.php
 ```
 No matches.
 ********* master
+## blocks/index (pdo cleanup)
+- `blocks/index/active_24h_users.php`: cast integer parameters and sanitized update bindings.
+- `blocks/index/active_birthday_users.php`: cast integer parameters.
+- `blocks/index/active_irc_users.php`: cast integer parameters.
+- `blocks/index/active_users.php`: cast integer parameters.
+- `blocks/index/forum_posts.php`: cast class and limit parameters.
+- `blocks/index/gift.php`: added missing `$container` to global bootstrap.
+- `blocks/index/news.php`: replaced `SELECT *` with explicit columns, bound `LIMIT`, and cast integer parameters.
+
+### Verification
+```
+$ rg "mysqli_|sql_query\(|sqlesc\(" blocks/index
+```
+No matches.
+
+* Files modified: 7
+* Legacy patterns removed: before=0, after=0
+* Transactions added: none
+* COUNT(*) replacements: none
+* Bound parameters added for LIMIT: `blocks/index/news.php`


### PR DESCRIPTION
## Summary
- Cast bound integers and ensure consistent container bootstrap in index blocks
- Replace `SELECT *` and bind `LIMIT` in news block
- Document migrations in `migration-report.md`

## Testing
- `php -l blocks/index/gift.php`
- `php -l blocks/index/news.php`
- `php -l blocks/index/forum_posts.php`
- `php -l blocks/index/active_users.php`
- `php -l blocks/index/active_24h_users.php`
- `php -l blocks/index/active_birthday_users.php`
- `php -l blocks/index/active_irc_users.php`
- `rg "mysqli_|sql_query\s*\(|sqlesc\s*\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" blocks/index`

------
https://chatgpt.com/codex/tasks/task_e_68c39c86ee8883259e660a0dfc80c800