### PR TITLE
Batch – chat/: PDO-migrering til Pu239\Database

### DIFF
--- a/chat/lib/class/AJAXChatEncoding.php
+++ b/chat/lib/class/AJAXChatEncoding.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/AJAXChatFileSystem.php
+++ b/chat/lib/class/AJAXChatFileSystem.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/AJAXChatHTTPHeader.php
+++ b/chat/lib/class/AJAXChatHTTPHeader.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/AJAXChatLanguage.php
+++ b/chat/lib/class/AJAXChatLanguage.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/AJAXChatString.php
+++ b/chat/lib/class/AJAXChatString.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/AJAXChatTemplate.php
+++ b/chat/lib/class/AJAXChatTemplate.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/CustomAJAXChat.php
+++ b/chat/lib/class/CustomAJAXChat.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/class/CustomAJAXChatInterface.php
+++ b/chat/lib/class/CustomAJAXChatInterface.php
@@ -1,10 +1,21 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/classes.php
+++ b/chat/lib/classes.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../include/runtime_safe.php';
+require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/config.php
+++ b/chat/lib/config.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../include/runtime_safe.php';
+require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/custom.php
+++ b/chat/lib/custom.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../include/runtime_safe.php';
+require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/data/channels.php
+++ b/chat/lib/data/channels.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/data/users.php
+++ b/chat/lib/data/users.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/ar.php
+++ b/chat/lib/lang/ar.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/bg.php
+++ b/chat/lib/lang/bg.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/ca.php
+++ b/chat/lib/lang/ca.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/cy.php
+++ b/chat/lib/lang/cy.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/cz.php
+++ b/chat/lib/lang/cz.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/da.php
+++ b/chat/lib/lang/da.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/de.php
+++ b/chat/lib/lang/de.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/el.php
+++ b/chat/lib/lang/el.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/en.php
+++ b/chat/lib/lang/en.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/es.php
+++ b/chat/lib/lang/es.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/et.php
+++ b/chat/lib/lang/et.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/fa.php
+++ b/chat/lib/lang/fa.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/fi.php
+++ b/chat/lib/lang/fi.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/fr.php
+++ b/chat/lib/lang/fr.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/gl.php
+++ b/chat/lib/lang/gl.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/he.php
+++ b/chat/lib/lang/he.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/hr.php
+++ b/chat/lib/lang/hr.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/hu.php
+++ b/chat/lib/lang/hu.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/in.php
+++ b/chat/lib/lang/in.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/it.php
+++ b/chat/lib/lang/it.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/ja.php
+++ b/chat/lib/lang/ja.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/ka.php
+++ b/chat/lib/lang/ka.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/kr.php
+++ b/chat/lib/lang/kr.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/mk.php
+++ b/chat/lib/lang/mk.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/nl-be.php
+++ b/chat/lib/lang/nl-be.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/nl.php
+++ b/chat/lib/lang/nl.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/no.php
+++ b/chat/lib/lang/no.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/pl.php
+++ b/chat/lib/lang/pl.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/pt-br.php
+++ b/chat/lib/lang/pt-br.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/pt-pt.php
+++ b/chat/lib/lang/pt-pt.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/ro.php
+++ b/chat/lib/lang/ro.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/ru.php
+++ b/chat/lib/lang/ru.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/sk.php
+++ b/chat/lib/lang/sk.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/sl.php
+++ b/chat/lib/lang/sl.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/sr.php
+++ b/chat/lib/lang/sr.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/chat/lib/lang/sv.php
+++ b/chat/lib/lang/sv.php
@@ -1,12 +1,22 @@
 <?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../../include/runtime_safe.php';
+require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
+use Pu239\Database;
+
+global $container;
 $db = $container->get(Database::class);
 
-require_once __DIR__ . '/../../../include/runtime_safe.php';
-
-require_once __DIR__ . '/../../../include/bootstrap_pdo.php';
 
 
-declare(strict_types = 1);
+
+
+
+
+
+
+
+
 /*
  * @package AJAX_Chat
  * @author Sebastian Tschan

--- a/migration-report.md
+++ b/migration-report.md
@@ -350,3 +350,65 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" forums/stafflock_post.php
 ```
 No matches.
 ********* master
+## chat
+- Standardized runtime bootstrap, strict typing, and `$db` initialization across 49 files:
+- `chat/lib/class/AJAXChatEncoding.php`
+- `chat/lib/class/AJAXChatFileSystem.php`
+- `chat/lib/class/AJAXChatHTTPHeader.php`
+- `chat/lib/class/AJAXChatLanguage.php`
+- `chat/lib/class/AJAXChatString.php`
+- `chat/lib/class/AJAXChatTemplate.php`
+- `chat/lib/class/CustomAJAXChat.php`
+- `chat/lib/class/CustomAJAXChatInterface.php`
+- `chat/lib/classes.php`
+- `chat/lib/config.php`
+- `chat/lib/custom.php`
+- `chat/lib/data/channels.php`
+- `chat/lib/data/users.php`
+- `chat/lib/lang/ar.php`
+- `chat/lib/lang/bg.php`
+- `chat/lib/lang/ca.php`
+- `chat/lib/lang/cy.php`
+- `chat/lib/lang/cz.php`
+- `chat/lib/lang/da.php`
+- `chat/lib/lang/de.php`
+- `chat/lib/lang/el.php`
+- `chat/lib/lang/en.php`
+- `chat/lib/lang/es.php`
+- `chat/lib/lang/et.php`
+- `chat/lib/lang/fa.php`
+- `chat/lib/lang/fi.php`
+- `chat/lib/lang/fr.php`
+- `chat/lib/lang/gl.php`
+- `chat/lib/lang/he.php`
+- `chat/lib/lang/hr.php`
+- `chat/lib/lang/hu.php`
+- `chat/lib/lang/in.php`
+- `chat/lib/lang/it.php`
+- `chat/lib/lang/ja.php`
+- `chat/lib/lang/ka.php`
+- `chat/lib/lang/kr.php`
+- `chat/lib/lang/mk.php`
+- `chat/lib/lang/nl-be.php`
+- `chat/lib/lang/nl.php`
+- `chat/lib/lang/no.php`
+- `chat/lib/lang/pl.php`
+- `chat/lib/lang/pt-br.php`
+- `chat/lib/lang/pt-pt.php`
+- `chat/lib/lang/ro.php`
+- `chat/lib/lang/ru.php`
+- `chat/lib/lang/sk.php`
+- `chat/lib/lang/sl.php`
+- `chat/lib/lang/sr.php`
+- `chat/lib/lang/sv.php`
+
+### Legacy cleanup
+- Legacy patterns removed (mysqli_*, sql_query(), sqlesc()): 0 → 0
+- Transactions introduced: none
+- COUNT(*) replacements: none
+- Bound IN/LIKE/LIMIT parameters: none
+- Verification
+```bash
+$ rg "mysqli_|sql_query\\(|sqlesc\\(" chat
+```
+No matches.


### PR DESCRIPTION
## Summary
- Standardize runtime bootstrap and `Pu239\Database` initialization across chat library and language files.
- Ensure strict typing and unified `$db` access.

## Testing
- `php -l` on 49 chat files
- `rg "mysqli_|sql_query\(|sqlesc\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" chat`


------
https://chatgpt.com/codex/tasks/task_e_68c39d7445b4832584794da9afa7512a