### PR TITLE
Batch – config: PDO-migrering til Pu239\Database

### DIFF
--- a/config/ann_config.php
+++ b/config/ann_config.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/app.php';

--- a/config/classes.php
+++ b/config/classes.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 define('UC_USER', 0);

--- a/config/config_example.php
+++ b/config/config_example.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
 use Delight\I18n\Codes;
-
+global $container;
 $db = $container->get(Database::class);
 
 require_once CONFIG_DIR . 'functions.php';

--- a/config/database.php.example
+++ b/config/database.php.example
@@ -1,4 +1,14 @@
 <?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../include/runtime_safe.php';
+require_once __DIR__ . '/../include/bootstrap_pdo.php';
+
+use Pu239\Database;
+
+global $container;
+$db = $container->get(Database::class);
+
 // config/database.php — example (copy to config/database.php and edit)
 return [
     // e.g. mysql:host=localhost;port=3306;dbname=pu239;charset=utf8mb4

--- a/config/define.php
+++ b/config/define.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 define('TIME_NOW', time());

--- a/config/definitions.php
+++ b/config/definitions.php
@@ -13,7 +13,7 @@ use Pu239\Database;
 use Psr\Container\ContainerInterface;
 use Rakit\Validation\Validator;
 use Scriptotek\GoogleBooks\GoogleBooks;
-
+global $container;
 $db = $container->get(Database::class);
 return [
     Auth::class => DI\factory(function (ContainerInterface $c) {

--- a/config/emoticons.php
+++ b/config/emoticons.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 return [

--- a/config/functions.php
+++ b/config/functions.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 /**
  * @param $val

--- a/config/session.php
+++ b/config/session.php
@@ -7,13 +7,11 @@ require_once __DIR__ . '/../include/bootstrap_pdo.php';
 use Delight\Cookie\Session;
 use Pu239\Database;
 use Pu239\Settings;
-
+global $container;
 $db = $container->get(Database::class);
 
 require_once INCL_DIR . 'function_common.php';
 require_once CONFIG_DIR . 'functions.php';
-
-global $container;
 // Override the settings in php.ini
 ini_set('memory_limit', '1024M');
 ini_set('zlib.output_compression', 'Off');

--- a/config/subtitles.php
+++ b/config/subtitles.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 return [

--- a/config/whereis.php
+++ b/config/whereis.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
 
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 return [

--- a/migration-report.md
+++ b/migration-report.md
@@ -350,3 +350,12 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" forums/stafflock_post.php
 ```
 No matches.
 ********* master
+
+## config (bootstrap refinement)
+- `config/ann_config.php`, `config/classes.php`, `config/config_example.php`, `config/define.php`, `config/definitions.php`, `config/emoticons.php`, `config/functions.php`, `config/session.php`, `config/subtitles.php`, `config/whereis.php`, `config/database.php.example`: added missing `global $container` to complete the standardized PDO bootstrap.
+
+### Verification
+```
+$ rg -n -e 'mysqli_' -e 'sql_query\(' -e 'sqlesc\(' -e 'mysqli_fetch' -e 'mysqli_num_rows' -e 'mysqli_insert_id' config
+```
+No matches.


### PR DESCRIPTION
## Summary
- Ensure all config PHP files declare strict types and initialize Pu239\Database with a shared container
- Standardize bootstrap across the config directory using runtime_safe.php and bootstrap_pdo.php
- Document config bootstrap refinement in migration-report

## Testing
- `php -l config/ann_config.php config/config_example.php config/define.php config/emoticons.php config/functions.php config/definitions.php config/session.php config/subtitles.php config/whereis.php config/classes.php config/database.php.example`
- `rg -n -e 'mysqli_' -e 'sql_query\(' -e 'sqlesc\(' -e 'mysqli_fetch' -e 'mysqli_num_rows' -e 'mysqli_insert_id' config`
- `make qa` *(fails: vendor/bin/pint missing)*
- `composer install` *(fails: lock file conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68c39db6cedc8325ba53c6f77e768961