### PR TITLE
Batch – database: PDO-migrering til Pu239\Database

### DIFF
--- a/database/sql_updates.php
+++ b/database/sql_updates.php
@@ -1,11 +1,9 @@
 <?php
 declare(strict_types=1);
-
 require_once __DIR__ . '/../include/runtime_safe.php';
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
 use Pu239\Database;
-
+global $container;
 $db = $container->get(Database::class);
 
 $sql_updates = [

--- a/migration-report.md
+++ b/migration-report.md
@@ -426,4 +426,18 @@ $ rg "mysqli_|sql_query\\(|sqlesc\\(" public/achievementlist.php
 ```
 No matches.
 
+## database
+- Files changed: 1 (`database/sql_updates.php`).
+- Legacy patterns removed: none (0 occurrences of `mysqli_`, `sql_query`, or `sqlesc`).
+- Transactions added: none.
+- SELECT COUNT(*) replacements: none.
+- IN/LIKE/LIMIT bindings: none.
+- Verification: 0 legacy pattern matches.
+
+### Verification
+```bash
+$ rg "mysqli_|sql_query\\s*\\(|sqlesc\\s*\\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" database
+```
+No matches.
+
 ********* master


### PR DESCRIPTION
## Summary
- ensure database/sql_updates.php uses container-based PDO bootstrap
- document database migration results in migration-report

## Testing
- `php -l database/sql_updates.php`
- `rg -n "mysqli_|sql_query\s*\(|sqlesc\s*\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" database`


------
https://chatgpt.com/codex/tasks/task_e_68c78b2d91ac83259edbba736240570f