### PR TITLE
Batch – /: PDO-migrering til Pu239\Database

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -22,6 +22,8 @@
 - `public/messages.php`: standardized bootstrap and converted mailbox lookup to `$db->fetchAll` with bound parameters.
 - `public/ajax/rating.php`: migrated from legacy queries to `$db->run` with transactions and bound parameters; standardized bootstrap.
 - `public/ajax/thanks.php`: migrated from `sql_query`/`sqlesc` to `$db->run` with transactions and bound parameters; standardized bootstrap.
+- `public/trivia_results.php`: replaced legacy `sql_query`, `mysqli_fetch_*`, `mysqli_num_rows`, and `sqlesc` with `$db->fetchAll` and bound parameters; bound `LIMIT` and standardized bootstrap.
+- `public/fastdelete.php`: removed `sql_query`/`sqlesc` and FluentPDO usage in favor of `$db->fetch`/`run` with bound parameters and standardized bootstrap.
 
 ### public/ajax summary
 - Files changed: 2 (`public/ajax/rating.php`, `public/ajax/thanks.php`)
@@ -33,7 +35,7 @@
 
 ### Verification
 ```
-$ rg "mysqli_|sql_query\(|sqlesc\(" public/contactstaff.php public/tenpercent.php public/ajax/like.php public/users.php public/messages.php public/ajax/rating.php public/ajax/thanks.php
+$ rg "mysqli_|sql_query\(|sqlesc\(" public/contactstaff.php public/tenpercent.php public/ajax/like.php public/users.php public/messages.php public/ajax/rating.php public/ajax/thanks.php public/trivia_results.php public/fastdelete.php
 ```
 No matches in modified files.
 

--- a/public/fastdelete.php
+++ b/public/fastdelete.php
@@ -1,22 +1,19 @@
 <?php
+declare(strict_types=1);
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
-
 use Pu239\Cache;
 use Pu239\Database;
 use Pu239\Session;
 use Pu239\Torrent;
+global $container;
+$db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/bittorrent.php';
 require_once INCL_DIR . 'function_users.php';
 require_once INCL_DIR . 'function_html.php';
+global $site_config;
 $user = check_user_status();
-global $container;
-$db = $container->get(Database::class);, $site_config;
 
 if ($user['class'] < UC_STAFF) {
     stderr(_('Error'), _('You do not have permission to do this.'));
@@ -27,19 +24,13 @@ if (!isset($_GET['id']) || !is_valid_id((int) $_GET['id'])) {
 }
 
 $id = (int) $_GET['id'];
-$fluent = $db; // alias
-// $fluent removed — use $this->db (ExtendedPdo)
-$tid = $fluent->from('torrents AS t')
-              ->select(null)
-              ->select('t.id')
-              ->select('t.info_hash')
-              ->select('t.owner')
-              ->select('t.name')
-              ->select('t.added')
-              ->select('u.seedbonus')
-              ->leftJoin('users AS u ON u.id=t.owner')
-              ->where('t.id = ?', $id)
-              ->fetch();
+$tid = $db->fetch(
+    'SELECT t.id, t.info_hash, t.owner, t.name, t.added, u.seedbonus
+        FROM torrents AS t
+        LEFT JOIN users AS u ON u.id = t.owner
+        WHERE t.id = :id',
+    [':id' => $id]
+);
 
 if (!$tid) {
     stderr(_('Error'), _('Something went wrong!'));
@@ -55,21 +46,29 @@ $torrents_class = $container->get(Torrent::class);
 $torrents_class->remove_torrent($tid['info_hash']);
 $torrents_class->delete_by_id($tid['id']);
 if ($user['id'] != $tid['owner']) {
-    $msg = sqlesc(_fe('Your upload {0} has been deleted by {1}', "[b]{$tid['name']}[/b]", $user['username']));
-    sql_query('INSERT INTO messages (sender, receiver, added, msg) VALUES (2, ' . sqlesc($tid['owner']) . ', ' . TIME_NOW . ", {$msg})") or sqlerr(__FILE__, __LINE__);
+    $msg = _fe('Your upload {0} has been deleted by {1}', "[b]{$tid['name']}[/b]", $user['username']);
+    $db->run(
+        'INSERT INTO messages (sender, receiver, added, msg) VALUES (2, :receiver, :added, :msg)',
+        [
+            ':receiver' => (int) $tid['owner'],
+            ':added' => TIME_NOW,
+            ':msg' => $msg,
+        ]
+    );
 }
 write_log(_fe('Torrent {0} was deleted by {1}', $tid['name'], $user['username']));
 $cache = $container->get(Cache::class);
 if ($site_config['bonus']['on']) {
-    $dt = sqlesc(TIME_NOW - (14 * 86400));
+    $dt = TIME_NOW - (14 * 86400);
     if ($tid['added'] > $dt) {
         $sb = $tid['seedbonus'] - $site_config['bonus']['per_delete'];
-        $set = [
-            'seedbonus' => $sb,
-        ];
-        $sql = "UPDATE users SET /* columns */ WHERE id = :id";
-$db->perform($sql, array_merge($set, ['id' => $tid['owner']]));
-
+        $db->run(
+            'UPDATE users SET seedbonus = :seedbonus WHERE id = :id',
+            [
+                ':seedbonus' => $sb,
+                ':id' => (int) $tid['owner'],
+            ]
+        );
         $cache->update_row('user_' . $tid['owner'], [
             'seedbonus' => $sb,
         ], $site_config['expires']['user_cache']);

--- a/public/trivia_results.php
+++ b/public/trivia_results.php
@@ -1,42 +1,51 @@
 <?php
-$db = $container->get(Database::class);
-
+declare(strict_types=1);
 require_once __DIR__ . '/../include/runtime_safe.php';
-
 require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-
-declare(strict_types = 1);
-
 use Pu239\Database;
+global $container;
+$db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/bittorrent.php';
 require_once INCL_DIR . 'function_users.php';
 require_once INCL_DIR . 'function_html.php';
 check_user_status();
-$sql = 'SELECT gamenum, IFNULL(unix_timestamp(finished), 0) AS ended, IFNULL(unix_timestamp(started), 0) AS started FROM triviasettings GROUP BY gamenum, finished, started ORDER BY gamenum DESC LIMIT 10';
-$res = sql_query($sql) or sqlerr(__FILE__, __LINE__);
+
+$games = $db->fetchAll(
+    'SELECT gamenum, IFNULL(UNIX_TIMESTAMP(finished), 0) AS ended, IFNULL(UNIX_TIMESTAMP(started), 0) AS started
+        FROM triviasettings
+        GROUP BY gamenum, finished, started
+        ORDER BY gamenum DESC
+        LIMIT :limit',
+    [':limit' => 10]
+);
 $table = "
             <div class='portlet'>";
-while ($result = mysqli_fetch_assoc($res)) {
+$div = '';
+foreach ($games as $result) {
     $gamenum = (int) $result['gamenum'];
     $ended = $result['ended'] >= 1 ? get_date((int) $result['ended'], 'LONG') : 0;
     $started = $result['started'] >= 1 ? get_date((int) $result['started'], 'LONG') : 0;
-    $sql = 'SELECT t.gamenum, t.user_id, COUNT(t.correct) AS correct,
-                (SELECT COUNT(correct) AS incorrect FROM triviausers WHERE correct = 0 AND user_id = t.user_id AND gamenum = ' . sqlesc($gamenum) . ') AS incorrect,
+    $players = $db->fetchAll(
+        'SELECT t.gamenum, t.user_id, COUNT(t.correct) AS correct,
+                (SELECT COUNT(correct) FROM triviausers WHERE correct = 0 AND user_id = t.user_id AND gamenum = :gamenum) AS incorrect,
                 u.username, u.modcomment
             FROM triviausers AS t
             INNER JOIN users AS u ON u.id=t.user_id
             INNER JOIN triviasettings AS s ON s.gamenum = t.gamenum
-            WHERE t.correct = 1 AND t.gamenum = ' . sqlesc($gamenum) . '
+            WHERE t.correct = 1 AND t.gamenum = :gamenum
             GROUP BY t.user_id
             ORDER BY correct DESC, incorrect
-            LIMIT 10';
-    $query = sql_query($sql) or sqlerr(__FILE__, __LINE__);
-    if (mysqli_num_rows($query) > 0) {
+            LIMIT :limit',
+        [
+            ':gamenum' => $gamenum,
+            ':limit' => 10,
+        ]
+    );
+    if (!empty($players)) {
         $i = 0;
         $date = $result['ended'] >= 1 ? "Ended: $ended" : "Started: $started";
-        $div = "
+        $div .= "
                 <div class='bg-02 has-text-centered top20 round5'>
                     <div class='padtop20'>
                         <h1>Game #{$gamenum} $date</h1>
@@ -52,16 +61,16 @@ while ($result = mysqli_fetch_assoc($res)) {
                         </thead>
                         <tbody>";
 
-        while ($player = mysqli_fetch_assoc($query)) {
-            $correct = $player['correct'];
-            $incorrect = $player['incorrect'];
+        foreach ($players as $player) {
+            $correct = (int) $player['correct'];
+            $incorrect = (int) $player['incorrect'];
             $div .= '
                         <tr>
                             <td>' . format_username((int) $player['user_id']) . '</td>
-                            <td>' . sprintf('%.2f%%', $correct / ($correct + $incorrect) * 100) . "</td>
-                            <td>$correct</td>
-                            <td>$incorrect</td>
-                        </tr>";
+                            <td>' . sprintf('%.2f%%', $correct / ($correct + $incorrect) * 100) . '</td>
+                            <td>' . $correct . '</td>
+                            <td>' . $incorrect . '</td>
+                        </tr>';
         }
         $div .= '
                         </tbody>
@@ -72,8 +81,8 @@ while ($result = mysqli_fetch_assoc($res)) {
 if (empty($div)) {
     $div = main_div('No Trivia Results', 'has-text-centered', 'padding20');
 }
-$table .= $div . '
-            </div>';
+$table .= $div . "
+            </div>";
 $title = _('Trivia');
 $breadcrumbs = [
     "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",


### PR DESCRIPTION
## Summary
- migrate trivia results page to `Pu239\Database` with bound parameters
- remove legacy SQL and FluentPDO from fast delete page
- document changes in migration report

## Testing
- `php -l public/trivia_results.php`
- `php -l public/fastdelete.php`
- `rg "mysqli_|sql_query\(|sqlesc\(" public/contactstaff.php public/tenpercent.php public/ajax/like.php public/users.php public/messages.php public/ajax/rating.php public/ajax/thanks.php public/trivia_results.php public/fastdelete.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7934d50948325bfe3be6cd13a304e