### PR TITLE
Batch – templates/1: PDO-migrering til Pu239\Database

### DIFF
--- a/migration-report.md
+++ b/migration-report.md
@@ -665,3 +665,20 @@ No matches.
 - `SELECT COUNT(*)` introduced: none
 - IN/LIKE/LIMIT binding: none
 - Verification: `rg "mysqli_|sql_query\\s*\(|sqlesc\\s*\(|mysqli_fetch|mysqli_num_rows|mysqli_insert_id" partials` → no matches
+
+## templates/1
+- `templates/1/navbar.php`: added missing `$container` bootstrap and restricted staff panel query to explicit columns.
+- `templates/1/files.php`: added missing `$container` bootstrap.
+- `templates/1/template.php`: added missing `$container` bootstrap and limited stylesheet query to `id` and `name` fields.
+
+### Verification
+```
+$ rg -n -e 'mysqli_' -e 'sql_query\(' -e 'sqlesc\(' -e 'mysqli_fetch' -e 'mysqli_num_rows' -e 'mysqli_insert_id' templates/1
+```
+No matches.
+
+- Files changed: 3 (`templates/1/navbar.php`, `templates/1/files.php`, `templates/1/template.php`)
+- Legacy patterns removed: before=0, after=0
+- Transactions added: none
+- `SELECT COUNT(*)` replacements: none
+- IN/LIKE/LIMIT binding: none

--- a/templates/1/files.php
+++ b/templates/1/files.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 use Pu239\Database;
 
+global $container;
 $db = $container->get(Database::class);
 
 /**

--- a/templates/1/navbar.php
+++ b/templates/1/navbar.php
@@ -11,6 +11,7 @@ use Pu239\Cache;
 use Pu239\Database;
 use Pu239\Roles;
 
+global $container;
 $db = $container->get(Database::class);
 
 /**
@@ -187,7 +188,7 @@ function staff_panel()
         $user_class = $CURUSER['class'] >= UC_STAFF ? $CURUSER['class'] : UC_MAX;
         $staff_panel = $cache->get('staff_panels_' . $user_class);
         if ($staff_panel === false || is_null($staff_panel)) {
-            $sql = 'SELECT * FROM staffpanel WHERE navbar = 1 AND av_class <= :class ORDER BY page_name';
+            $sql = 'SELECT page_name, file_name, type, av_class FROM staffpanel WHERE navbar = 1 AND av_class <= :class ORDER BY page_name';
             $staff_panel = $db->fetchAll($sql, [':class' => $user_class]);
 
             $cache->set('staff_panels_' . $user_class, $staff_panel, 0);

--- a/templates/1/template.php
+++ b/templates/1/template.php
@@ -14,6 +14,7 @@ use Pu239\Database;
 use Pu239\Session;
 use Spatie\Image\Exceptions\InvalidManipulation;
 
+global $container;
 $db = $container->get(Database::class);
 
 /**
@@ -454,7 +455,7 @@ function platform_menu()
 
     $templates = $cache->get('templates_' . $CURUSER['class']);
     if ($templates === false || is_null($templates)) {
-        $sql = 'SELECT * FROM stylesheets WHERE min_class_to_view <= :class ORDER BY id';
+        $sql = 'SELECT id, name FROM stylesheets WHERE min_class_to_view <= :class ORDER BY id';
         $templates = $db->fetchAll($sql, [':class' => $CURUSER['class']]);
 
         $cache->set('templates_' . $CURUSER['class'], $templates, 0);


### PR DESCRIPTION
## Summary
- ensure templates/1 php files initialize Pu239\Database via container
- tighten staff panel and stylesheet queries to explicit columns
- document migration for templates/1 in migration-report

## Testing
- `php -l templates/1/navbar.php`
- `php -l templates/1/files.php`
- `php -l templates/1/template.php`
- `rg -n -e 'mysqli_' -e 'sql_query\(' -e 'sqlesc\(' -e 'mysqli_fetch' -e 'mysqli_num_rows' -e 'mysqli_insert_id' templates/1`


------
https://chatgpt.com/codex/tasks/task_e_68c7930c9d84832599843695bd830516