### PR TITLE
feat(messages): 2025 uplift (bootstrap unify, PDO params, legacy purge, lint+report)

### DIFF
--- a/messages/delete.php
+++ b/messages/delete.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Cache;
-use Pu239\Database;
 use Pu239\Message;
 
 global $container, $CURUSER, $site_config;
-$db = $container->get(Database::class);
 
 $messages_class = $container->get(Message::class);
 $message = $messages_class->get_by_id($pm_id);

--- a/messages/edit_mailboxes.php
+++ b/messages/edit_mailboxes.php
@@ -2,17 +2,19 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
+use Envms\FluentPDO\Literal;
 use Pu239\Cache;
 use Pu239\Database;
 use Pu239\Message;
 use Pu239\User;
 
-require_once INCL_DIR . 'function_categories.php';
 global $container, $CURUSER, $site_config;
+/** @var Database $db */
 $db = $container->get(Database::class);
+
+// TODO(2025): csrf
 
 $all_my_boxes = $user_cache = $categories = '';
 $users_class = $container->get(User::class);
@@ -42,42 +44,33 @@ if (isset($_POST['action2'])) {
             app_halt('Exit called');
 
         case 'add':
-            if ($_POST['new'] === '') {
+            $new_entries = $_POST['new'] ?? [];
+            if (!is_array($new_entries)) {
+                $new_entries = [$new_entries];
+            }
+            $new_entries = array_filter(array_map(static fn ($value) => preg_replace('/[^\da-z\-_]/i', '', (string) $value), $new_entries));
+            if (empty($new_entries)) {
                 stderr(_('Error'), _('to add new PM boxes you MUST enter at least one PM box name!'));
             }
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-            $row = $db->fetch('SELECT MAX(boxnumber) AS boxnumber FROM pmboxes');
-            $boxnumber = isset($row['boxnumber']) ? (int) $row['boxnumber'] : 0;
-            $box = $boxnumber < 2 ? 2 : $boxnumber;
-=======
-            $box_row = $db->fetch('SELECT MAX(boxnumber) AS boxnumber FROM pmboxes');
-            $boxnumber = (int) ($box_row['boxnumber'] ?? 0);
-            $box = $boxnumber < 2 ? 2 : $boxnumber++;
-/ master
-            $new_box = preg_replace('/[^\da-z\-_]/i', '', $_POST['new']);
-            foreach ($new_box as $key => $add_it) {
-                $add_it = preg_replace('/[^\da-z\-_]/i', '', $add_it);
-                if (!empty($add_it)) {
-                    $name = htmlsafechars($add_it);
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-                    $values = [
+            $box_row = $db->fetch(
+                'SELECT MAX(boxnumber) AS boxnumber FROM pmboxes WHERE userid = :userid',
+                [
+                    'userid' => (int) $CURUSER['id'],
+                ],
+            );
+            $boxnumber = (int) ($box_row['boxnumber'] ?? 1);
+            $box = $boxnumber < 2 ? 2 : $boxnumber + 1;
+            foreach ($new_entries as $add_it) {
+                $db->run(
+                    'INSERT INTO pmboxes (userid, name, boxnumber) VALUES (:userid, :name, :boxnumber)',
+                    [
                         'userid' => (int) $CURUSER['id'],
-                        'name' => $name,
+                        'name' => $add_it,
                         'boxnumber' => (int) $box,
-                    ];
-                    $sql = 'INSERT INTO pmboxes (userid, name, boxnumber) VALUES (:userid, :name, :boxnumber)';
-                    $db->run($sql, $values);
-=======
-                    $sql = 'INSERT INTO pmboxes (userid, name, boxnumber) VALUES (:userid, :name, :boxnumber)';
-                    $db->run($sql, [
-                        ':userid' => (int) $CURUSER['id'],
-                        ':name' => $name,
-                        ':boxnumber' => (int) $box,
-                    ]);
-/ master
-                    $cache->delete('get_all_boxes_' . $CURUSER['id']);
-                    $cache->delete('insertJumpTo_' . $CURUSER['id']);
-                }
+                    ],
+                );
+                $cache->delete('get_all_boxes_' . $CURUSER['id']);
+                $cache->delete('insertJumpTo_' . $CURUSER['id']);
                 ++$box;
                 $worked = '&boxes=1';
             }
@@ -86,53 +79,42 @@ if (isset($_POST['action2'])) {
             break;
 
         case 'edit_boxes':
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-            $boxes = $db->fetchAll('SELECT id, name, boxnumber FROM pmboxes WHERE userid = :userid', [
-                'userid' => (int) $CURUSER['id'],
-            ]);
-=======
             $boxes = $db->fetchAll(
-                'SELECT id, name, boxnumber FROM pmboxes WHERE userid = :uid',
+                'SELECT id, name, boxnumber FROM pmboxes WHERE userid = :userid',
                 [
-                    ':uid' => (int) $CURUSER['id'],
+                    'userid' => (int) $CURUSER['id'],
                 ],
             );
-/ master
 
             if (empty($boxes)) {
                 stderr(_('Error'), _('No Mailboxes to edit'));
             }
             foreach ($boxes as $row) {
-                $name = htmlsafechars(preg_replace('/[^\da-z\-_]/i', '', $_POST['edit' . $row['id']]));
-                if (!empty($name) && $name !== $row['name']) {
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-                    $set = [
-                        'name' => $name,
-                    ];
-                    $sql = 'UPDATE pmboxes SET name = :name WHERE id = :id';
-                    $db->run($sql, array_merge($set, ['id' => (int) $row['id']]));
-=======
-                    $sql = 'UPDATE pmboxes SET name = :name WHERE id = :id';
-                    $db->run($sql, [
-                        ':name' => $name,
-                        ':id' => (int) $row['id'],
-                    ]);
-/ master
+                $post_key = 'edit' . $row['id'];
+                $submitted = isset($_POST[$post_key]) ? (string) $_POST[$post_key] : '';
+                $name = preg_replace('/[^\da-z\-_]/i', '', $submitted);
+                if ($name !== '' && $name !== $row['name']) {
+                    $db->run(
+                        'UPDATE pmboxes SET name = :name WHERE id = :id',
+                        [
+                            'name' => $name,
+                            'id' => (int) $row['id'],
+                        ],
+                    );
                     $cache->delete('get_all_boxes_' . $CURUSER['id']);
                     $cache->delete('insertJumpTo_' . $CURUSER['id']);
                     $worked = '&name=1';
-                } elseif (empty($name)) {
+                } elseif ($name === '') {
                     $set = [
                         'location' => 1,
                     ];
                     $messages_class->update_location($set, (int) $row['boxnumber'], $CURUSER['id']);
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-                    $db->run('DELETE FROM pmboxes WHERE id = :id', [
-                        'id' => (int) $row['id'],
-                    ]);
-=======
-                    $db->run('DELETE FROM pmboxes WHERE id = :id', [':id' => (int) $row['id']]);
-/ master
+                    $db->run(
+                        'DELETE FROM pmboxes WHERE id = :id',
+                        [
+                            'id' => (int) $row['id'],
+                        ],
+                    );
                     $cache->delete('get_all_boxes_' . $CURUSER['id']);
                     $cache->delete('insertJumpTo_' . $CURUSER['id']);
                     $deleted = '&box_delete=1';
@@ -146,7 +128,8 @@ if (isset($_POST['action2'])) {
             $set = [];
             $change_pm_number = isset($_POST['change_pm_number']) ? (int) $_POST['change_pm_number'] : 20;
             $setbits = $clrbits = 0;
-            if ($_POST['show_pm_avatar'] === 'yes') {
+            $show_pm_avatar_post = isset($_POST['show_pm_avatar']) ? $_POST['show_pm_avatar'] : 'no';
+            if ($show_pm_avatar_post === 'yes') {
                 $setbits |= class_user_options_2::SHOW_PM_AVATAR;
             } else {
                 $clrbits |= class_user_options_2::SHOW_PM_AVATAR;
@@ -190,18 +173,12 @@ if (isset($_POST['action2'])) {
     }
 }
 
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-$boxes = $db->fetchAll('SELECT id, name, boxnumber FROM pmboxes WHERE userid = :userid ORDER BY boxnumber', [
-    'userid' => (int) $CURUSER['id'],
-]);
-=======
 $boxes = $db->fetchAll(
-    'SELECT id, name, boxnumber FROM pmboxes WHERE userid = :uid ORDER BY boxnumber',
+    'SELECT id, name, boxnumber FROM pmboxes WHERE userid = :userid ORDER BY boxnumber',
     [
-        ':uid' => (int) $CURUSER['id'],
+        'userid' => (int) $CURUSER['id'],
     ],
 );
-/ master
 $count_boxes = !empty($boxes) ? count($boxes) : 0;
 
 if (!empty($boxes)) {

--- a/messages/forward.php
+++ b/messages/forward.php
@@ -2,15 +2,12 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
 use Pu239\Message;
 use Pu239\User;
 
 global $container, $CURUSER, $site_config;
-$db = $container->get(Database::class);
 
 $body = '';
 $messages_class = $container->get(Message::class);

--- a/messages/forward_pm.php
+++ b/messages/forward_pm.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-require_once INCL_DIR . 'function_html.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Database;
 use Pu239\Message;
 use Pu239\User;
 
 global $container, $CURUSER, $site_config;
+/** @var Database $db */
 $db = $container->get(Database::class);
+
+// TODO(2025): csrf
 
 flood_limit('messages');
 $messages_class = $container->get(Message::class);
@@ -24,7 +24,8 @@ if ($message['receiver'] == $CURUSER['id'] && $message['sender'] == $CURUSER['id
     stderr(_('Error'), _('He be as good a gentleman as the devil is, as Lucifer and Beelzebub himself.'));
 }
 $users_class = $container->get(User::class);
-$to_user = $users_class->getUserFromId((int) $users_class->getUserIdFromName((string) $_POST['to']));
+$to_name = isset($_POST['to']) ? trim((string) $_POST['to']) : '';
+$to_user = $users_class->getUserFromId((int) $users_class->getUserIdFromName($to_name));
 if (empty($to_user)) {
     stderr(_('Error'), _('Sorry, there is no member with that username.'));
 }
@@ -44,25 +45,11 @@ if (!has_access($CURUSER['class'], UC_STAFF, '')) {
     if ($to_user['acceptpms'] === 'no') {
         stderr(_('Error'), _("This user dosen't accept PMs."));
     }
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-    $blocked = $db->fetch('SELECT id FROM blocks WHERE userid = :userid AND blockid = :blockid', [
-        'userid' => (int) $to_user['id'],
-        'blockid' => (int) $CURUSER['id'],
-    ]);
-    if (!$blocked) {
-        stderr(_('Refused'), _('This member has blocked PMs from you.'));
-    }
-    if ($to_user['acceptpms'] === 'friends') {
-        $friend = $db->fetch('SELECT id FROM friends WHERE userid = :userid AND friendid = :friendid', [
-            'userid' => (int) $to_user['id'],
-            'friendid' => (int) $CURUSER['id'],
-        ]);
-=======
     $blocked = $db->fetch(
-        'SELECT id FROM blocks WHERE userid = :uid AND blockid = :bid',
+        'SELECT id FROM blocks WHERE userid = :userid AND blockid = :blockid',
         [
-            ':uid' => (int) $to_user['id'],
-            ':bid' => (int) $CURUSER['id'],
+            'userid' => (int) $to_user['id'],
+            'blockid' => (int) $CURUSER['id'],
         ],
     );
     if ($blocked) {
@@ -70,22 +57,23 @@ if (!has_access($CURUSER['class'], UC_STAFF, '')) {
     }
     if ($to_user['acceptpms'] === 'friends') {
         $friend = $db->fetch(
-            'SELECT id FROM friends WHERE userid = :uid AND friendid = :fid',
+            'SELECT id FROM friends WHERE userid = :userid AND friendid = :friendid',
             [
-                ':uid' => (int) $to_user['id'],
-                ':fid' => (int) $CURUSER['id'],
+                'userid' => (int) $to_user['id'],
+                'friendid' => (int) $CURUSER['id'],
             ],
         );
-/ master
         if (!$friend) {
             stderr(_('Refused'), _('This member only accepts PMs from members on their friends list.'));
         }
     }
 }
 
-$subject = htmlsafechars($_POST['subject']);
-$first_from = valid_username($_POST['first_from']) ? htmlsafechars($_POST['first_from']) : '';
-$msg = "\n\n" . $_POST['body'] . "\n\n" . _fe("-------- Original Message from [b]{0} :: [/b]{1}\n{3}", $first_from, htmlsafechars($message['subject']), $message['msg']);
+$subject = isset($_POST['subject']) ? htmlsafechars((string) $_POST['subject']) : '';
+$first_from_input = isset($_POST['first_from']) ? (string) $_POST['first_from'] : '';
+$first_from = valid_username($first_from_input) ? htmlsafechars($first_from_input) : '';
+$body_content = isset($_POST['body']) ? (string) $_POST['body'] : '';
+$msg = "\n\n" . $body_content . "\n\n" . _fe("-------- Original Message from [b]{0} :: [/b]{1}\n{3}", $first_from, htmlsafechars($message['subject']), $message['msg']);
 
 $msgs_buffer[] = [
     'sender' => $CURUSER['id'],

--- a/messages/move.php
+++ b/messages/move.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Cache;
-use Pu239\Database;
 use Pu239\Message;
 
 global $container, $site_config, $CURUSER;
-$db = $container->get(Database::class);
+
+// TODO(2025): csrf
+$new_location = isset($_POST['boxx']) ? (int) $_POST['boxx'] : 0;
 $set = [
-    'location' => $_POST['boxx'],
+    'location' => $new_location,
 ];
 $messages_class = $container->get(Message::class);
 $result = $messages_class->update($set, $pm_id);

--- a/messages/move_or_delete_multi.php
+++ b/messages/move_or_delete_multi.php
@@ -2,29 +2,30 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Cache;
-use Pu239\Database;
 use Pu239\Message;
 
 global $container, $site_config, $CURUSER;
-$db = $container->get(Database::class);
 
-if (empty($_POST['pm'])) {
-    header("Location: {$_SERVER['HTTP_REFERER']}");
+// TODO(2025): csrf
+$posted_pm = $_POST['pm'] ?? [];
+if (empty($posted_pm)) {
+    $referer = $_SERVER['HTTP_REFERER'] ?? $_SERVER['PHP_SELF'];
+    header('Location: ' . $referer);
     app_halt('Exit called');
 }
-$pm_messages = is_array($_POST['pm']) ? $_POST['pm'] : [$_POST['pm']];
+$pm_messages = is_array($posted_pm) ? $posted_pm : [$posted_pm];
+$pm_messages = array_map(static fn ($value) => (int) $value, $pm_messages);
 $messages_class = $container->get(Message::class);
 $cache = $container->get(Cache::class);
 if (isset($_POST['move'])) {
     $set = [
-        'location' => $_POST['boxx'],
+        'location' => isset($_POST['boxx']) ? (int) $_POST['boxx'] : 0,
     ];
     foreach ($pm_messages as $pm_message) {
-        $messages_class->update($set, (int) $pm_message);
+        $messages_class->update($set, $pm_message);
     }
     $cache->delete('inbox_' . $CURUSER['id']);
     header('Location: ' . $_SERVER['PHP_SELF'] . '?action=view_mailbox&multi_move=1&box=' . $mailbox);
@@ -57,8 +58,9 @@ if (isset($_POST['delete'])) {
     if (!$result) {
         stderr(_('Error'), _("Messages couldn't be deleted!"));
     }
+    $return_action = isset($_POST['returnto']) ? preg_replace('/[^a-z_]/i', '', (string) $_POST['returnto']) : '';
     if (isset($_POST['returnto'])) {
-        header('Location: ' . $_SERVER['PHP_SELF'] . '?action=' . $_POST['returnto'] . '&multi_delete=1');
+        header('Location: ' . $_SERVER['PHP_SELF'] . '?action=' . $return_action . '&multi_delete=1');
     } elseif (isset($_POST['draft_section'])) {
         header('Location: ' . $_SERVER['PHP_SELF'] . '?action=viewdrafts&multi_delete=1');
     } else {

--- a/messages/new_draft.php
+++ b/messages/new_draft.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
 use Pu239\Message;
 
 global $container, $CURUSER;
-$db = $container->get(Database::class);
+
+// TODO(2025): csrf
 
 $subject = $draft = '';
 if (!empty($_POST['buttonval']) && $_POST['buttonval'] === 'Save draft') {

--- a/messages/save_or_edit_draft.php
+++ b/messages/save_or_edit_draft.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
 use Pu239\Message;
 
 global $container, $CURUSER;
-$db = $container->get(Database::class);
+
+// TODO(2025): csrf
 
 $save_or_edit = (isset($_POST['edit']) ? 'edit' : (isset($_GET['edit']) ? 'edit' : 'save'));
 $messages_class = $container->get(Message::class);

--- a/messages/search.php
+++ b/messages/search.php
@@ -2,44 +2,259 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Database;
 
 $user = check_user_status();
-global $container, $site_config;
+global $container, $site_config, $top_links, $mailbox, $HTMLOUT;
+/** @var Database $db */
 $db = $container->get(Database::class);
 
-$num_result = $and_member = '';
-$keywords = isset($_POST['keywords']) ? htmlsafechars($_POST['keywords']) : '';
-$member = isset($_POST['member']) ? htmlsafechars($_POST['member']) : '';
-$all_boxes = isset($_POST['all_boxes']) ? (int) $_POST['all_boxes'] : '';
-$sender_reciever = $mailbox >= 1 ? 'sender' : 'receiver';
-$params = [':userid' => $user['id']];
-$what_in_out = $mailbox >= 1 ? 'AND receiver = :userid' : 'AND sender = :userid';
-$location = isset($_POST['all_boxes']) ? 'AND location != 0' : 'AND location = ' . $mailbox;
+// TODO(2025): csrf
+
+$keywords = isset($_POST['keywords']) ? trim((string) $_POST['keywords']) : '';
+$subjectFilter = isset($_POST['subject']) ? trim((string) $_POST['subject']) : '';
+$textFilter = isset($_POST['text']) ? trim((string) $_POST['text']) : '';
+$member = isset($_POST['member']) ? trim((string) $_POST['member']) : '';
 $limit = isset($_POST['limit']) ? (int) $_POST['limit'] : 25;
-$as_list_post = isset($_POST['as_list_post']) ? (int) $_POST['as_list_post'] : 2;
-$desc_asc = isset($_POST['ASC']) == 1 ? 'ASC' : 'DESC';
-$subject = isset($_POST['subject']) ? htmlsafechars($_POST['subject']) : '';
-$text = isset($_POST['text']) ? htmlsafechars($_POST['text']) : '';
-$member_sys = isset($_POST['system']) ? 'system' : '';
-$possible_sort = [
-    'added',
-    'subject',
-    'sender',
-    'receiver',
-    'relevance',
-];
-$box = isset($_POST['box']) ? (int) $_POST['box'] : 1;
-$sort = (isset($_GET['sort']) ? htmlsafechars($_GET['sort']) : (isset($_POST['sort']) ? htmlsafechars($_POST['sort']) : 'relevance'));
-if (!in_array($sort, $possible_sort)) {
-    stderr(_('Error'), _('A ruffian that will swear, drink, dance, revel the night, rob, murder and commit the oldest of ins the newest kind of ways.'));
+$limit = $limit > 0 ? min($limit, 100) : 25;
+$sort = isset($_POST['sort']) ? (string) $_POST['sort'] : 'relevance';
+$direction = isset($_POST['direction']) ? strtoupper((string) $_POST['direction']) : 'DESC';
+$direction = in_array($direction, ['ASC', 'DESC'], true) ? $direction : 'DESC';
+$searchAllBoxes = !empty($_POST['all_boxes']);
+$include_system = !empty($_POST['system']);
+$selected_box = isset($_POST['box']) ? (int) $_POST['box'] : (isset($mailbox) ? (int) $mailbox : 1);
+
+$member_notice = '';
+$results = [];
+$search_performed = $_SERVER['REQUEST_METHOD'] === 'POST';
+
+if ($search_performed) {
+    $params = ['user_id' => (int) $user['id']];
+    $conditions = [];
+
+    if ($searchAllBoxes) {
+        $conditions[] = '(m.receiver = :user_id OR m.sender = :user_id)';
+    } else {
+        $sentBox = $site_config['pm']['sent'] ?? -1;
+        $inboxLocation = $site_config['pm']['inbox'] ?? 1;
+        if ($selected_box === $sentBox) {
+            $conditions[] = 'm.sender = :user_id';
+            $conditions[] = 'm.location = :sent_location';
+            $params['sent_location'] = (int) $inboxLocation;
+        } else {
+            $conditions[] = 'm.receiver = :user_id';
+            $conditions[] = 'm.location = :location';
+            $params['location'] = $selected_box;
+        }
+    }
+
+    if ($include_system) {
+        $conditions[] = 'm.sender = 0';
+    }
+
+    if ($member !== '') {
+        $member_row = $db->fetch(
+            'SELECT id FROM users WHERE username = :username',
+            [
+                'username' => $member,
+            ],
+        );
+        if ($member_row === null) {
+            $member_notice = sprintf(_('No member found matching "%s".'), htmlsafechars($member));
+        } else {
+            $params['member_id'] = (int) $member_row['id'];
+            if ($searchAllBoxes) {
+                $conditions[] = '(m.sender = :member_id OR m.receiver = :member_id)';
+            } else {
+                $sentBox = $site_config['pm']['sent'] ?? -1;
+                if ($selected_box === $sentBox) {
+                    $conditions[] = 'm.receiver = :member_id';
+                } else {
+                    $conditions[] = 'm.sender = :member_id';
+                }
+            }
+        }
+    }
+
+    if ($keywords !== '') {
+        $params['keywords'] = '%' . $keywords . '%';
+        $conditions[] = '(m.subject LIKE :keywords OR m.msg LIKE :keywords)';
+    }
+
+    if ($subjectFilter !== '') {
+        $params['subject_search'] = '%' . $subjectFilter . '%';
+        $conditions[] = 'm.subject LIKE :subject_search';
+    }
+
+    if ($textFilter !== '') {
+        $params['body_search'] = '%' . $textFilter . '%';
+        $conditions[] = 'm.msg LIKE :body_search';
+    }
+
+    $where = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
+    $sortColumns = [
+        'relevance' => 'm.added',
+        'added' => 'm.added',
+        'subject' => 'm.subject',
+        'sender' => 'sender_name',
+        'receiver' => 'receiver_name',
+    ];
+    $orderColumn = $sortColumns[$sort] ?? $sortColumns['relevance'];
+    if ($sort === 'relevance') {
+        $direction = 'DESC';
+    }
+
+    $sql = <<<SQL
+        SELECT m.id, m.subject, m.msg, m.added, m.unread, m.urgent, m.location, m.sender, m.receiver,
+               s.username AS sender_name, r.username AS receiver_name
+        FROM messages AS m
+        LEFT JOIN users AS s ON s.id = m.sender
+        LEFT JOIN users AS r ON r.id = m.receiver
+        $where
+        ORDER BY $orderColumn $direction
+        LIMIT $limit
+    SQL;
+
+    $results = $member_notice === '' ? $db->fetchAll($sql, $params) : [];
 }
 
-if ($member) {
-    $res_username = $db->run('SELECT /* columns */ FROM users WHERE username = :member', [
-        ':member' => $member,
-    ]);
+$form_action = $site_config['paths']['baseurl'] . '/messages.php?action=search';
+$keyword_value = htmlsafechars($keywords);
+$subject_value = htmlsafechars($subjectFilter);
+$text_value = htmlsafechars($textFilter);
+$member_value = htmlsafechars($member);
+$limit_value = $limit;
+$checked_all_boxes = $searchAllBoxes ? 'checked' : '';
+$checked_system = $include_system ? 'checked' : '';
+
+$sort_options = [
+    'relevance' => _('Most Recent'),
+    'added' => _('Date'),
+    'subject' => _('Subject'),
+    'sender' => _('Sender'),
+    'receiver' => _('Receiver'),
+];
+
+$direction_options = [
+    'DESC' => _('Descending'),
+    'ASC' => _('Ascending'),
+];
+
+$HTMLOUT .= $top_links . "
+    <h1>" . _('Search Messages') . "</h1>
+    <form method='post' action='{$form_action}' accept-charset='utf-8'>
+        <input type='hidden' name='box' value='{$selected_box}'>
+        <div class='table-wrapper'>
+            <table class='table table-bordered table-striped'>
+                <tr>
+                    <td class='w-25'><label for='keywords'>" . _('Keywords') . "</label></td>
+                    <td><input type='text' class='w-100' id='keywords' name='keywords' value='{$keyword_value}'></td>
+                </tr>
+                <tr>
+                    <td><label for='subject'>" . _('Subject contains') . "</label></td>
+                    <td><input type='text' class='w-100' id='subject' name='subject' value='{$subject_value}'></td>
+                </tr>
+                <tr>
+                    <td><label for='text'>" . _('Message text contains') . "</label></td>
+                    <td><input type='text' class='w-100' id='text' name='text' value='{$text_value}'></td>
+                </tr>
+                <tr>
+                    <td><label for='member'>" . _('Member') . "</label></td>
+                    <td><input type='text' class='w-100' id='member' name='member' value='{$member_value}'></td>
+                </tr>
+                <tr>
+                    <td>" . _('Options') . "</td>
+                    <td>
+                        <label class='right10'>
+                            <input type='checkbox' name='all_boxes' value='1' {$checked_all_boxes}> " . _('Search all mailboxes') . "
+                        </label>
+                        <label>
+                            <input type='checkbox' name='system' value='1' {$checked_system}> " . _('Only system messages') . "
+                        </label>
+                    </td>
+                </tr>
+                <tr>
+                    <td><label for='limit'>" . _('Max results') . "</label></td>
+                    <td><input type='number' id='limit' name='limit' value='{$limit_value}' min='1' max='100'></td>
+                </tr>
+                <tr>
+                    <td><label for='sort'>" . _('Sort by') . "</label></td>
+                    <td>
+                        <select id='sort' name='sort'>";
+foreach ($sort_options as $value => $label) {
+    $selected = $sort === $value ? 'selected' : '';
+    $HTMLOUT .= "<option value='{$value}' {$selected}>{$label}</option>";
+}
+$HTMLOUT .= "</select>
+                        <select name='direction'>";
+foreach ($direction_options as $value => $label) {
+    $selected = $direction === $value ? 'selected' : '';
+    $HTMLOUT .= "<option value='{$value}' {$selected}>{$label}</option>";
+}
+$HTMLOUT .= "</select>
+                    </td>
+                </tr>
+                <tr>
+                    <td colspan='2' class='has-text-centered'>
+                        <input type='submit' class='button is-small' value='" . _('Search') . "'>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </form>";
+
+if ($member_notice !== '') {
+    $HTMLOUT .= "<div class='top20 has-text-danger'>{$member_notice}</div>";
+}
+
+if ($search_performed) {
+    $HTMLOUT .= "<h2 class='top20'>" . _('Results') . "</h2>";
+    if (empty($results)) {
+        $HTMLOUT .= "<div class='top10'>" . _('No messages matched your search.') . "</div>";
+    } else {
+        $HTMLOUT .= "<div class='table-wrapper'>
+            <table class='table table-bordered table-striped'>
+                <thead>
+                    <tr>
+                        <th>" . _('Subject') . "</th>
+                        <th>" . _('From') . "</th>
+                        <th>" . _('To') . "</th>
+                        <th>" . _('Date') . "</th>
+                        <th>" . _('Preview') . "</th>
+                    </tr>
+                </thead>
+                <tbody>";
+        foreach ($results as $row) {
+            $subject_text = $row['subject'] !== '' ? htmlsafechars($row['subject']) : _('No Subject');
+            $view_url = $site_config['paths']['baseurl'] . '/messages.php?action=view_message&id=' . (int) $row['id'];
+            $from_display = (int) $row['sender'] === 0 ? _('System') : format_username((int) $row['sender']);
+            $to_display = (int) $row['receiver'] === 0 ? _('System') : format_username((int) $row['receiver']);
+            $date_display = get_date((int) $row['added'], '');
+            $preview = htmlsafechars(mb_substr($row['msg'], 0, 120));
+            if (mb_strlen($row['msg']) > 120) {
+                $preview .= '&hellip;';
+            }
+            $tags = [];
+            if ($row['unread'] === 'yes') {
+                $tags[] = "<span class='tag is-info'>" . _('Unread') . "</span>";
+            }
+            if ($row['urgent'] === 'yes') {
+                $tags[] = "<span class='tag is-danger'>" . _('Urgent') . "</span>";
+            }
+            $tag_display = empty($tags) ? '' : '<div class="tags">' . implode('', $tags) . '</div>';
+
+            $HTMLOUT .= "<tr>
+                    <td><a class='is-link' href='{$view_url}'>{$subject_text}</a>{$tag_display}</td>
+                    <td>{$from_display}</td>
+                    <td>{$to_display}</td>
+                    <td>{$date_display}</td>
+                    <td>{$preview}</td>
+                </tr>";
+        }
+        $HTMLOUT .= "</tbody>
+            </table>
+        </div>";
+    }
 }

--- a/messages/send_message.php
+++ b/messages/send_message.php
@@ -2,20 +2,15 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
-
-use Pu239\Database;
-
-require_once INCL_DIR . 'function_users.php';
-require_once INCL_DIR . 'function_html.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Message;
 use Pu239\User;
 
 $subject = $msg = '';
 global $container, $CURUSER, $site_config;
-$db = $container->get(Database::class);
+
+// TODO(2025): csrf
 
 $messages_class = $container->get(Message::class);
 $users_class = $container->get(User::class);

--- a/messages/use_draft.php
+++ b/messages/use_draft.php
@@ -2,20 +2,17 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
 use Pu239\Message;
 use Pu239\User;
-
-require_once INCL_DIR . 'function_html.php';
 
 $save_or_edit = (isset($_POST['edit']) ? 'edit' : (isset($_GET['edit']) ? 'edit' : 'save'));
 $save_or_edit = (isset($_POST['send']) ? 'send' : (isset($_GET['send']) ? 'send' : $save_or_edit));
 
 global $container, $site_config, $CURUSER;
-$db = $container->get(Database::class);
+
+// TODO(2025): csrf
 $messages_class = $container->get(Message::class);
 $users_class = $container->get(User::class);
 

--- a/messages/view_mailbox.php
+++ b/messages/view_mailbox.php
@@ -2,36 +2,27 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Database;
 use Pu239\Message;
 
 $user = check_user_status();
-require_once INCL_DIR . 'function_users.php';
 global $container, $site_config;
+/** @var Database $db */
 $db = $container->get(Database::class);
 
 $show_pm_avatar = ($user['opt2'] & class_user_options_2::SHOW_PM_AVATAR) === class_user_options_2::SHOW_PM_AVATAR;
 $message_class = $container->get(Message::class);
 if ($mailbox > 1) {
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-    $arr_box_name = $db->fetch('SELECT name FROM pmboxes WHERE userid = :userid AND boxnumber = :boxnumber', [
-        'userid' => (int) $user['id'],
-        'boxnumber' => (int) $mailbox,
-    ]);
-    if (empty($arr_box_name)) {
-=======
     $arr_box_name = $db->fetch(
-        'SELECT name FROM pmboxes WHERE userid = :uid AND boxnumber = :box',
+        'SELECT name FROM pmboxes WHERE userid = :userid AND boxnumber = :boxnumber',
         [
-            ':uid' => (int) $user['id'],
-            ':box' => (int) $mailbox,
+            'userid' => (int) $user['id'],
+            'boxnumber' => (int) $mailbox,
         ],
     );
-    if (empty($arr_box_name['name'])) {
-/ master
+    if (empty($arr_box_name) || empty($arr_box_name['name'])) {
         stderr(_('Error'), _('Invalid mailbox'));
     }
     $mailbox_name = format_comment($arr_box_name['name']);

--- a/messages/view_message.php
+++ b/messages/view_message.php
@@ -2,59 +2,45 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../include/runtime_safe.php';
-require_once __DIR__ . '/../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Cache;
 use Pu239\Database;
 use Pu239\User;
 
- $user = check_user_status();
- $image = placeholder_image();
- global $container, $site_config;
- $db = $container->get(Database::class);
- $cache = $container->get(Cache::class);
+$user = check_user_status();
+$image = placeholder_image();
+global $container, $site_config;
+/** @var Database $db */
+$db = $container->get(Database::class);
+$cache = $container->get(Cache::class);
 
 $subject = $friends = '';
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-$message = $db->fetch('SELECT m.id, m.sender, m.receiver, m.added, m.msg, m.subject, m.unread, m.urgent, m.location, m.draft,
-       f.id AS friend, b.id AS blocked, a.id AS attachment, u.title, u.last_access, u.show_email, u.email, u.website, u.seedbonus
-    FROM messages AS m
-    LEFT JOIN friends AS f ON f.userid = :userid AND f.friendid = m.sender
-    LEFT JOIN blocks AS b ON b.userid = :userid AND b.blockid = m.sender
-    LEFT JOIN attachments AS a ON m.added = a.post_id
-    LEFT JOIN users AS u ON m.sender = u.id
-    WHERE m.id = :pm_id', [
+$message = $db->fetch(
+    'SELECT m.id, m.sender, m.receiver, m.added, m.msg, m.subject, m.location, m.draft, m.unread, m.urgent,
+            f.id AS friend, b.id AS blocked, a.id AS attachment, u.title, u.last_access, u.show_email, u.email, u.website, u.seedbonus
+        FROM messages AS m
+        LEFT JOIN friends AS f ON f.userid = :userid AND f.friendid = m.sender
+        LEFT JOIN blocks AS b ON b.userid = :userid AND b.blockid = m.sender
+        LEFT JOIN attachments AS a ON m.added = a.post_id
+        LEFT JOIN users AS u ON m.sender = u.id
+        WHERE m.id = :pm_id',
+    [
         'userid' => (int) $user['id'],
         'pm_id' => (int) $pm_id,
-    ]);
-=======
-$message = $db->fetch(
-    'SELECT m.id, m.sender, m.receiver, m.added, m.msg, m.subject, m.location, m.draft, m.unread, m.urgent, f.id AS friend, b.id AS blocked, a.id AS attachment, u.title, u.last_access, u.show_email, u.email, u.website, u.seedbonus FROM messages AS m LEFT JOIN friends AS f ON f.userid = :uid AND f.friendid = m.sender LEFT JOIN blocks AS b ON b.userid = :bid AND b.blockid = m.sender LEFT JOIN attachments AS a ON m.added = a.post_id LEFT JOIN users AS u ON m.sender = u.id WHERE m.id = :mid',
-    [
-        ':uid' => (int) $user['id'],
-        ':bid' => (int) $user['id'],
-        ':mid' => (int) $pm_id,
     ],
 );
-/ master
 if (empty($message) || ($message['receiver'] != $user['id'] && $message['sender'] != $user['id'])) {
     stderr(_('Error'), _('You do not have permission to view this message.'));
 }
 $attachment = '';
 if (!empty($message['attachment'])) {
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-    $attachments = $db->fetchAll('SELECT id, file_name, size FROM attachments WHERE post_id = :post_id', [
-        'post_id' => (int) $message['added'],
-    ]);
-=======
     $attachments = $db->fetchAll(
-        'SELECT id, file_name, size FROM attachments WHERE post_id = :pid',
+        'SELECT id, file_name, size FROM attachments WHERE post_id = :post_id',
         [
-            ':pid' => (int) $message['added'],
+            'post_id' => (int) $message['added'],
         ],
     );
-/ master
     $i = 0;
     foreach ($attachments as $file) {
         ++$i;
@@ -69,22 +55,14 @@ $users_class = $container->get(User::class);
 $arr_user_stuff = $users_class->getUserFromId((int) $message['sender'] === $user['id'] ? (int) $message['receiver'] : (int) $message['sender']);
 $id = $arr_user_stuff['id'];
 $update = [
-    ':unread' => 'no',
-    ':id' => (int) $pm_id,
-    ':receiver' => (int) $user['id'],
-];
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-$db->run('UPDATE messages SET unread = :unread WHERE id = :id AND receiver = :receiver', [
     'unread' => 'no',
     'id' => (int) $pm_id,
     'receiver' => (int) $user['id'],
-]);
-=======
+];
 $db->run(
     'UPDATE messages SET unread = :unread WHERE id = :id AND receiver = :receiver',
     $update,
 );
-/ master
 $cache->decrement('inbox_' . $user['id']);
 if ($message['friend'] > 0) {
     $friends = '
@@ -113,22 +91,14 @@ if (($message['receiver'] != $user['id'] || $message['sender'] === $user['id']) 
     $mailbox = $message['location'];
 }
 if ($message['location'] > 1) {
-/ codex/migrate-db-calls-to-pu239-database-f8wbuj
-    $name = $db->fetch('SELECT name FROM pmboxes WHERE userid = :userid AND boxnumber = :boxnumber', [
-        'userid' => (int) $user['id'],
-        'boxnumber' => (int) $mailbox,
-    ]);
-    if (empty($name)) {
-=======
     $name = $db->fetch(
-        'SELECT name FROM pmboxes WHERE userid = :uid AND boxnumber = :box',
+        'SELECT name FROM pmboxes WHERE userid = :userid AND boxnumber = :boxnumber',
         [
-            ':uid' => (int) $user['id'],
-            ':box' => (int) $mailbox,
+            'userid' => (int) $user['id'],
+            'boxnumber' => (int) $mailbox,
         ],
     );
-    if (empty($name['name'])) {
-/ master
+    if (empty($name) || empty($name['name'])) {
         stderr(_('Error'), _('Invalid mailbox'));
     }
     $mailbox_name = htmlsafechars($name['name']);

--- a/tools/messages_2025_report.csv
+++ b/tools/messages_2025_report.csv
@@ -1,0 +1,14 @@
+file,legacy_found(mysqli|sql_query|sqlesc|function_*),select_star,csrf_todo,manual_review_notes
+messages/delete.php,false,false,false,
+messages/edit_mailboxes.php,false,false,true,"Box numbering now scoped per-user; verify expected ordering."
+messages/forward.php,false,false,false,
+messages/forward_pm.php,false,false,true,
+messages/move.php,false,false,true,
+messages/move_or_delete_multi.php,false,false,true,"Return action restricted to alpha underscores."
+messages/new_draft.php,false,false,true,
+messages/save_or_edit_draft.php,false,false,true,
+messages/search.php,false,false,true,"Search rebuilt with LIKE filters; confirm legacy criteria alignment."
+messages/send_message.php,false,false,true,
+messages/use_draft.php,false,false,true,
+messages/view_mailbox.php,false,false,false,
+messages/view_message.php,false,false,false,

--- a/tools/messages_lint.txt
+++ b/tools/messages_lint.txt
@@ -1,0 +1,13 @@
+No syntax errors detected in messages/delete.php
+No syntax errors detected in messages/edit_mailboxes.php
+No syntax errors detected in messages/forward.php
+No syntax errors detected in messages/forward_pm.php
+No syntax errors detected in messages/move.php
+No syntax errors detected in messages/move_or_delete_multi.php
+No syntax errors detected in messages/new_draft.php
+No syntax errors detected in messages/save_or_edit_draft.php
+No syntax errors detected in messages/search.php
+No syntax errors detected in messages/send_message.php
+No syntax errors detected in messages/use_draft.php
+No syntax errors detected in messages/view_mailbox.php
+No syntax errors detected in messages/view_message.php


### PR DESCRIPTION
## Summary
- unify bootstrap usage across the messages flows and pull database handles from the container
- harden message forms (int casting, sanitized inputs) and rebuild the search page with explicit columns and named parameters
- remove legacy function includes, add CSRF TODO markers, and record lint/report artifacts for the module

## Testing
- php -l messages/delete.php
- php -l messages/edit_mailboxes.php
- php -l messages/forward.php
- php -l messages/forward_pm.php
- php -l messages/move.php
- php -l messages/move_or_delete_multi.php
- php -l messages/new_draft.php
- php -l messages/save_or_edit_draft.php
- php -l messages/search.php
- php -l messages/send_message.php
- php -l messages/use_draft.php
- php -l messages/view_mailbox.php
- php -l messages/view_message.php


------
https://chatgpt.com/codex/tasks/task_e_68c9ce49b2dc8325b9ee900964211e54