### PR TITLE
feat(blocks/**): 2025 uplift (batch transform offset=0)

### DIFF
--- a/blocks/bootstrap.php
+++ b/blocks/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/bootstrap.php';

--- a/blocks/global/bugmessages.php
+++ b/blocks/global/bugmessages.php
@@ -1,39 +1,61 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Cache;
 use Pu239\Database;
+use Psr\SimpleCache\CacheInterface as Cache;
 
-$user = check_user_status();
 global $container, $site_config;
 
-$db = $container->get(Database::class);
-$cache = $container->get(Cache::class);
-if ($site_config['alerts']['bug'] && has_access($user['class'], UC_STAFF, 'coder')) {
-    $bug_count = $cache->get('bug_mess_');
-    if ($bug_count === false || is_null($bug_count)) {
-        $bug_count = $db->fetchValue('SELECT COUNT(*) AS count FROM bugs WHERE status = ?', ['na']);
-        $cache->set('bug_mess_', $bug_count, $site_config['expires']['alerts']);
-    }
-    if ($bug_count > 0) {
-        $htmlout .= "
-    <li>
-        <a href='{$site_config['paths']['baseurl']}/bugs.php?action=bugs'>
-            <span class='button tag is-warning dt-tooltipper-small' data-tooltip-content='#bugmessage_tooltip'>
-                " . _('Bug Alert Message') . "
-            </span>
-            <div class='tooltip_templates'>
-                <div id='bugmessage_tooltip' class='margin20'>
-                    <div class='size_6 has-text-centered has-text-danger has-text-weight-bold bottom10'>
-                        " . _('New Bug Message') . "
-                    </div>
-                    <div class='has-text-centered'>" . _('New Bug Message') . " {$user['username']}!<br> " . _pfe('There is {0} new bug!', 'There are {0} new bugs!', $bug_count) . '</div>
-                 </div>
-            </div>
-        </a>
-    </li>';
-    }
+$user = check_user_status();
+if (empty($user) || !$site_config['alerts']['bug'] || !has_access($user['class'], UC_STAFF, 'coder')) {
+    return '';
 }
+
+/** @var Database $db */
+$db = $container->get(Database::class);
+/** @var Cache $cache */
+$cache = $container->get(Cache::class);
+
+$cacheKey = 'bug_mess_';
+$bugCount = $cache->get($cacheKey);
+if ($bugCount === null) {
+    $bugCount = (int) ($db->fetchValue(
+        'SELECT COUNT(*) AS count FROM bugs WHERE status = :status',
+        ['status' => 'na'],
+    ) ?? 0);
+    $cache->set($cacheKey, $bugCount, (int) ($site_config['expires']['alerts'] ?? 300));
+}
+
+if ($bugCount < 1) {
+    return '';
+}
+
+$s = $s ?? static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$baseurl = $s($site_config['paths']['baseurl'] ?? '');
+$username = $s($user['username'] ?? '');
+$bugMessage = $s(_pfe('There is {0} new bug!', 'There are {0} new bugs!', $bugCount));
+
+ob_start();
+?>
+<li>
+    <a href="<?= $baseurl ?>/bugs.php?action=bugs">
+        <span class="button tag is-warning dt-tooltipper-small" data-tooltip-content="#bugmessage_tooltip">
+            <?= $s(_('Bug Alert Message')) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="bugmessage_tooltip" class="margin20">
+                <div class="size_6 has-text-centered has-text-danger has-text-weight-bold bottom10">
+                    <?= $s(_('New Bug Message')) ?>
+                </div>
+                <div class="has-text-centered">
+                    <?= $s(_('New Bug Message')) ?> <?= $username ?>!<br> <?= $bugMessage ?>
+                </div>
+            </div>
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/blocks/global/crazyhour.php
+++ b/blocks/global/crazyhour.php
@@ -1,123 +1,168 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use DI\DependencyException;
 use DI\NotFoundException;
-use Pu239\Cache;
 use Pu239\Database;
-
-global $container, $site_config;
-
-$db = $container->get(Database::class);
-if ($site_config['bonus']['crazy_hour']) {
-    $htmlout .= crazyhour($db);
-}
+use Psr\SimpleCache\CacheInterface as Cache;
 
 /**
- * @throws NotFoundException
- * @throws \PDOException
  * @throws DependencyException
- * @throws Exception
- *
- * @return string
+ * @throws NotFoundException
  */
-function crazyhour(Database $db)
+function renderCrazyHour(): string
 {
-    global $CURUSER, $container;
+    global $container, $site_config, $CURUSER;
 
-    $cache = $container->get(Cache::class);
-    $htmlout = $cz = '';
-    $crazy_hour = (TIME_NOW + 3600);
-    $crazyhour['crazyhour'] = $cache->get('crazyhour_');
-    if ($crazyhour['crazyhour'] === false || is_null($crazyhour['crazyhour'])) {
-        $crazyhour['crazyhour'] = $db->fetch('SELECT var, amount FROM freeleech WHERE type = :type', [':type' => 'crazyhour']);
-        if (empty($crazyhour['crazyhour'])) {
-            $crazyhour['crazyhour']['var'] = random_int(TIME_NOW, (TIME_NOW + 86400));
-            $crazyhour['crazyhour']['amount'] = 0;
-            $update = [
-                ':var' => $crazyhour['crazyhour']['var'],
-                ':amount' => $crazyhour['crazyhour']['amount'],
-                ':type' => 'crazyhour',
-            ];
-            $db->run('UPDATE freeleech SET var = :var, amount = :amount WHERE type = :type', $update);
-        }
-        $cache->set('crazyhour_', $crazyhour['crazyhour'], 0);
+    if (empty($site_config['bonus']['crazy_hour'])) {
+        return '';
     }
-    if ($crazyhour['crazyhour']['var'] < TIME_NOW) { // if crazyhour over
-        $cz_lock = $cache->set('crazyhour_lock_', 1, 10);
-        if ($cz_lock !== false) {
-            $crazyhour['crazyhour_new'] = mktime(23, 59, 59, (int) date('m'), (int) date('d'), (int) date('y'));
-            $crazyhour['crazyhour']['var'] = random_int($crazyhour['crazyhour_new'], ($crazyhour['crazyhour_new'] + 86400));
-            $crazyhour['crazyhour']['amount'] = 0;
-            $crazyhour['remaining'] = ($crazyhour['crazyhour']['var'] - TIME_NOW);
-            $update = [
-                ':var' => $crazyhour['crazyhour']['var'],
-                ':amount' => $crazyhour['crazyhour']['amount'],
-                ':type' => 'crazyhour',
+
+    /** @var Database $db */
+    $db = $container->get(Database::class);
+    /** @var Cache $cache */
+    $cache = $container->get(Cache::class);
+
+    $esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $now = TIME_NOW;
+    $crazyHourWindowEnd = $now + 3600;
+    $crazyHour = $cache->get('crazyhour_');
+
+    if ($crazyHour === null) {
+        $crazyHour = $db->fetch(
+            'SELECT var, amount FROM freeleech WHERE type = :type',
+            ['type' => 'crazyhour'],
+        );
+
+        if (empty($crazyHour)) {
+            $crazyHour = [
+                'var' => random_int($now, $now + 86400),
+                'amount' => 0,
             ];
-            $db->run('UPDATE freeleech SET var = :var, amount = :amount WHERE type = :type', $update);
-            $cache->set('crazyhour_', $crazyhour['crazyhour'], 0);
-            write_log('Next [color=#FFCC00][b]Crazyhour[/b][/color] is at ' . get_date((int) $crazyhour['crazyhour']['var'] + ($CURUSER['time_offset'] - 3600), 'LONG') . '');
-            $msg = 'Next [color=orange][b]Crazyhour[/b][/color] is at ' . get_date((int) $crazyhour['crazyhour']['var'] + ($CURUSER['time_offset'] - 3600), 'LONG');
-            autoshout($msg);
+
+            $db->run(
+                'UPDATE freeleech SET var = :var, amount = :amount WHERE type = :type',
+                [
+                    'var' => $crazyHour['var'],
+                    'amount' => $crazyHour['amount'],
+                    'type' => 'crazyhour',
+                ],
+            );
         }
-    } elseif (($crazyhour['crazyhour']['var'] < $crazy_hour) && ($crazyhour['crazyhour']['var'] >= TIME_NOW)) {
-        if ($crazyhour['crazyhour']['amount'] !== 1) {
-            $crazyhour['crazyhour']['amount'] = 1;
-            $cz_lock = $cache->set('crazyhour_lock_', 1, 10);
-            if ($cz_lock !== false) {
-                $update = [
-                    ':amount' => $crazyhour['crazyhour']['amount'],
-                    ':type' => 'crazyhour',
-                ];
-                $db->run('UPDATE freeleech SET amount = :amount WHERE type = :type', $update);
-                $cache->set('crazyhour_', $crazyhour['crazyhour'], 0);
-                $msg = _("It's CrazyHour");
-                write_log($msg);
-                autoshout($msg);
+
+        $cache->set('crazyhour_', $crazyHour, 0);
+    }
+
+    $eventTimestamp = (int) ($crazyHour['var'] ?? 0);
+    $amount = (int) ($crazyHour['amount'] ?? 0);
+
+    if ($eventTimestamp < $now) {
+        $lockAcquired = $cache->set('crazyhour_lock_', 1, 10);
+        if ($lockAcquired) {
+            $endOfDay = mktime(23, 59, 59, (int) date('m'), (int) date('d'), (int) date('y'));
+            $crazyHour['var'] = random_int($endOfDay, $endOfDay + 86400);
+            $crazyHour['amount'] = 0;
+
+            $db->run(
+                'UPDATE freeleech SET var = :var, amount = :amount WHERE type = :type',
+                [
+                    'var' => $crazyHour['var'],
+                    'amount' => $crazyHour['amount'],
+                    'type' => 'crazyhour',
+                ],
+            );
+
+            $cache->set('crazyhour_', $crazyHour, 0);
+            $logTime = $crazyHour['var'] + (($CURUSER['time_offset'] ?? 0) - 3600);
+            $when = get_date((int) $logTime, 'LONG');
+            write_log('Next [color=#FFCC00][b]Crazyhour[/b][/color] is at ' . $when);
+            autoshout('Next [color=orange][b]Crazyhour[/b][/color] is at ' . $when);
+        }
+    }
+
+    $eventTimestamp = (int) ($crazyHour['var'] ?? 0);
+    $amount = (int) ($crazyHour['amount'] ?? 0);
+
+    if ($eventTimestamp >= $now && $eventTimestamp < $crazyHourWindowEnd) {
+        if ($amount !== 1) {
+            $crazyHour['amount'] = 1;
+            $lockAcquired = $cache->set('crazyhour_lock_', 1, 10);
+            if ($lockAcquired) {
+                $db->run(
+                    'UPDATE freeleech SET amount = :amount WHERE type = :type',
+                    [
+                        'amount' => 1,
+                        'type' => 'crazyhour',
+                    ],
+                );
+                $cache->set('crazyhour_', $crazyHour, 0);
+                $message = _("It's CrazyHour");
+                write_log($message);
+                autoshout($message);
             }
         }
-        $crazyhour['remaining'] = $crazyhour['crazyhour']['var'] - TIME_NOW;
-        $crazytitle = _("It's Crazyhour!");
-        $crazymessage = _('All torrents are FREE and upload stats are TRIPLED');
-        $htmlout .= "
-    <li>
-        <a href='#'>
-            <span class='button tag is-success dt-tooltipper-small' data-tooltip-content='#crazy_tooltip'>" . _('CrazyHour ON') . "</span>
-            <div class='tooltip_templates'>
-                <div id='crazy_tooltip' class='margin20'>
-                    <div class='size_4 has-text-centered has-text-success has-text-weight-bold bottom10'>
-                        " . _fe('CrazyHour {0} {1} Ends in {2} at {3}', $crazytitle, $crazymessage, mkprettytime($crazyhour['remaining']), get_date((int) $crazyhour['crazyhour']['var'], 'WITHOUT_SEC', 1, 1)) . '
+
+        $remaining = max(0, $eventTimestamp - $now);
+        $crazyTitle = _("It's Crazyhour!");
+        $crazyMessage = _('All torrents are FREE and upload stats are TRIPLED');
+        $endsAt = get_date($eventTimestamp, 'WITHOUT_SEC', 1, 1);
+
+        ob_start();
+        ?>
+        <li>
+            <a href="#">
+                <span class="button tag is-success dt-tooltipper-small" data-tooltip-content="#crazy_tooltip">
+                    <?= $esc(_('CrazyHour ON')) ?>
+                </span>
+                <div class="tooltip_templates">
+                    <div id="crazy_tooltip" class="margin20">
+                        <div class="size_4 has-text-centered has-text-success has-text-weight-bold bottom10">
+                            <?= $esc(_fe('CrazyHour {0} {1} Ends in {2} at {3}', $crazyTitle, $crazyMessage, mkprettytime($remaining), $endsAt)) ?>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </a>
-    </li>';
+            </a>
+        </li>
+        <?php
 
-        return $htmlout;
+        return (string) ob_get_clean();
     }
-    $htmlout .= "
+
+    $eventTimestamp = max($eventTimestamp, $now + 3600);
+    $startsIn = max(0, $eventTimestamp - 3600 - $now);
+    $startsAt = get_date($eventTimestamp + (($CURUSER['time_offset'] ?? 0) - 3600), 'TIME', 1);
+
+    ob_start();
+    ?>
     <li>
-        <a href='#'>
-            <span class='button tag is-success dt-tooltipper-small' data-tooltip-content='#crazy_tooltip'>" . _('CrazyHour') . "</span>
-            <div class='tooltip_templates'>
-                <div id='crazy_tooltip' class='margin20'>
-                    <div class='size_6 has-text-centered has-text-success has-text-weight-bold bottom10'>
-                        " . _('CrazyHour') . "
+        <a href="#">
+            <span class="button tag is-success dt-tooltipper-small" data-tooltip-content="#crazy_tooltip">
+                <?= $esc(_('CrazyHour')) ?>
+            </span>
+            <div class="tooltip_templates">
+                <div id="crazy_tooltip" class="margin20">
+                    <div class="size_6 has-text-centered has-text-success has-text-weight-bold bottom10">
+                        <?= $esc(_('CrazyHour')) ?>
                     </div>
-                    <div class='has-text-centered is-primary'>
-                        " . _('All torrents are FREE') . '<br>
-                        ' . _('and triple upload credit!') . '<br>
-                        ' . _fe('starts in {0}', mkprettytime($crazyhour['crazyhour']['var'] - 3600 - TIME_NOW)) . '<br>
-                        ' . _fe('at {0}', get_date((int) $crazyhour['crazyhour']['var'] + ($CURUSER['time_offset'] - 3600), 'TIME', 1)) . '
+                    <div class="has-text-centered is-primary">
+                        <?= $esc(_('All torrents are FREE')) ?><br>
+                        <?= $esc(_('and triple upload credit!')) ?><br>
+                        <?= $esc(_fe('starts in {0}', mkprettytime($startsIn))) ?><br>
+                        <?= $esc(_fe('at {0}', $startsAt)) ?>
                     </div>
                 </div>
             </div>
         </a>
-    </li>';
+    </li>
+    <?php
 
-    return $htmlout;
+    return (string) ob_get_clean();
+}
+
+try {
+    return renderCrazyHour();
+} catch (DependencyException | NotFoundException $e) {
+    return '';
 }

--- a/blocks/global/demotion.php
+++ b/blocks/global/demotion.php
@@ -1,33 +1,37 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
+global $site_config;
 
 $user = check_user_status();
-global $container, $site_config;
+if (empty($user) || (int) ($user['override_class'] ?? 255) === 255) {
+    return '';
+}
 
-$db = $container->get(Database::class);
+$esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$baseurl = $esc($site_config['paths']['baseurl'] ?? '');
 
-if ($user && $user['override_class'] != 255) {
-    $htmlout .= "
-    <li>
-        <a href='{$site_config['paths']['baseurl']}/restoreclass.php'>
-            <span class='button tag is-warning dt-tooltipper-small' data-tooltip-content='#demotion_tooltip'>
-                " . _('Temp. Demotion') . "
-            </span>
-            <div class='tooltip_templates'>
-                <div id='demotion_tooltip' class='margin20'>
-                    <div class='size_6 has-text-centered has-text-warning has-text-weight-bold bottom10'>
-                        " . _('Temporary Demotion') . "
-                    </div>
-                    <div class='has-text-centered'>
-                        " . _('To reset your class, simply click here.') . '
-                    </div>
+ob_start();
+?>
+<li>
+    <a href="<?= $baseurl ?>/restoreclass.php">
+        <span class="button tag is-warning dt-tooltipper-small" data-tooltip-content="#demotion_tooltip">
+            <?= $esc(_('Temp. Demotion')) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="demotion_tooltip" class="margin20">
+                <div class="size_6 has-text-centered has-text-warning has-text-weight-bold bottom10">
+                    <?= $esc(_('Temporary Demotion')) ?>
+                </div>
+                <div class="has-text-centered">
+                    <?= $esc(_('To reset your class, simply click here.')) ?>
                 </div>
             </div>
-        </a>
-    </li>';
-}
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/blocks/global/freeleech.php
+++ b/blocks/global/freeleech.php
@@ -1,58 +1,88 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Database;
-use Pu239\Cache;
+use Psr\SimpleCache\CacheInterface as Cache;
 
-$user = check_user_status();
 global $container;
 
+$user = check_user_status();
+if (empty($user)) {
+    return '';
+}
+
+/** @var Database $db */
 $db = $container->get(Database::class);
+/** @var Cache $cache */
 $cache = $container->get(Cache::class);
-$free = $cache->get('site_events_');
-if ($user) {
-    if (!empty($free) && $free['modifier'] != 0) {
-        switch ($free['modifier']) {
-            case 1:
-                $mode = _('All Torrents Free');
-                break;
 
-            case 2:
-                $mode = _('All Double Upload');
-                break;
+$event = $cache->get('site_events_');
+if ($event === null) {
+    $event = $db->fetch(
+        'SELECT modifier, expires, setby, title FROM events WHERE expires > :now ORDER BY id DESC LIMIT 1',
+        ['now' => TIME_NOW],
+    );
 
-            case 3:
-                $mode = _('All Torrents Free and Double Upload');
-                break;
+    if (empty($event)) {
+        $event = [
+            'modifier' => 0,
+            'expires' => 0,
+            'setby' => 0,
+            'title' => '',
+        ];
+    }
 
-            case 4:
-                $mode = _('All Torrents Silver');
-                break;
+    $ttl = max(0, (int) ($event['expires'] ?? 0) - TIME_NOW);
+    $cache->set('site_events_', $event, $ttl);
+}
 
-            default:
-                $mode = 0;
-        }
-        $username = format_username((int) $free['setby']);
-        $htmlout .= ($free['modifier'] != 0 && $free['expires'] > TIME_NOW ? "
-    <li>
-        <a href='#'>
-            <span class='button tag is-success dt-tooltipper-small' data-tooltip-content='#free_tooltip_{$free['modifier']}'>
-                " . _('FreeLeech ON') . "
-            </span>
-            <div class='tooltip_templates'>
-                <div id='free_tooltip_{$free['modifier']}' class='margin20'>
-                    <div class='size_6 has-text-centered has-text-info has-text-weight-bold bottom10'>
-                        {$mode}
-                    </div>
-                    <div class='has-text-centered'>
-                        " . _fe('{0} set by {1}<br>', $free['title'], $username) . ($free['expires'] != 1 ? _fe('Until {0} ({1} to go).', get_date((int) $free['expires'], 'DATE'), mkprettytime($free['expires'] - TIME_NOW)) : '') . '
-                    </div>
+$modifier = (int) ($event['modifier'] ?? 0);
+if ($modifier === 0 || (int) ($event['expires'] ?? 0) <= TIME_NOW) {
+    return '';
+}
+
+$mode = match ($modifier) {
+    1 => _('All Torrents Free'),
+    2 => _('All Double Upload'),
+    3 => _('All Torrents Free and Double Upload'),
+    4 => _('All Torrents Silver'),
+    default => '',
+};
+
+$esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$tooltipId = 'free_tooltip_' . $modifier;
+$title = $esc((string) ($event['title'] ?? ''));
+$setBy = format_username((int) ($event['setby'] ?? 0));
+$expiry = (int) ($event['expires'] ?? 0);
+$remaining = $expiry > 0 ? $esc(mkprettytime($expiry - TIME_NOW)) : '';
+$until = $expiry > 0 ? $esc(get_date($expiry, 'DATE')) : '';
+$setByLine = _fe('{0} set by {1}<br>', $title, $setBy);
+$untilLine = ($expiry !== 1 && $expiry > 0) ? _fe('Until {0} ({1} to go).', $until, $remaining) : '';
+
+ob_start();
+?>
+<li>
+    <a href="#">
+        <span class="button tag is-success dt-tooltipper-small" data-tooltip-content="#<?= $esc($tooltipId) ?>">
+            <?= $esc(_('FreeLeech ON')) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="<?= $esc($tooltipId) ?>" class="margin20">
+                <div class="size_6 has-text-centered has-text-info has-text-weight-bold bottom10">
+                    <?= $esc($mode) ?>
+                </div>
+                <div class="has-text-centered">
+                    <?= $setByLine ?>
+                    <?php if ($untilLine !== '') { ?>
+                        <?= $untilLine ?>
+                    <?php } ?>
                 </div>
             </div>
-        </a>
-    </li>' : '');
-    }
-}
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/blocks/global/freeleech_contribution.php
+++ b/blocks/global/freeleech_contribution.php
@@ -1,225 +1,171 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
 use Pu239\Database;
+use Psr\SimpleCache\CacheInterface as Cache;
 
 global $container, $site_config;
 
+$getActiveEvent = static function (Database $db, Cache $cache): array {
+    $event = $cache->get('site_events_details_');
+    if ($event === null) {
+        $event = $db->fetch(
+            'SELECT modifier, begin, expires FROM events WHERE expires > :now ORDER BY id DESC LIMIT 1',
+            ['now' => TIME_NOW],
+        );
+
+        if (empty($event)) {
+            $event = [
+                'modifier' => 0,
+                'begin' => 0,
+                'expires' => 0,
+            ];
+        }
+
+        $ttl = max(0, (int) ($event['expires'] ?? 0) - TIME_NOW);
+        $cache->set('site_events_details_', $event, $ttl);
+    }
+
+    return [
+        'modifier' => (int) ($event['modifier'] ?? 0),
+        'begin' => (int) ($event['begin'] ?? 0),
+        'expires' => (int) ($event['expires'] ?? 0),
+    ];
+};
+
+$getBonusProgress = static function (Cache $cache, Database $db, string $cacheKey, int $bonusId): array {
+    $progress = $cache->get($cacheKey);
+    if ($progress === null) {
+        $progress = $db->fetch(
+            'SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id',
+            ['id' => $bonusId],
+        );
+
+        if (empty($progress)) {
+            $progress = [
+                'percent' => 0.0,
+                'enabled' => 'no',
+            ];
+        }
+
+        $cache->set($cacheKey, $progress, 300);
+    }
+
+    return [
+        'percent' => (float) ($progress['percent'] ?? 0),
+        'enabled' => (string) ($progress['enabled'] ?? 'no'),
+    ];
+};
+
+$getPercentClass = static function (float $percent): string {
+    return match (true) {
+        $percent >= 90 => 'is-success',
+        $percent >= 80 => 'is-lightgreen',
+        $percent >= 70 => 'is-jade',
+        $percent >= 50 => 'is-turquoise',
+        $percent >= 40 => 'has-text-lghtblue',
+        $percent >= 30 => 'is-gold',
+        $percent >= 20 => 'has-text-oragne',
+        default => 'has-text-danger',
+    };
+};
+
+/** @var Database $db */
 $db = $container->get(Database::class);
+/** @var Cache $cache */
+$cache = $container->get(Cache::class);
 
-require_once INCL_DIR . 'function_event.php';
-$free = get_event(false);
-$freeleech_enabled = $double_upload_enabled = $half_down_enabled = false;
-$freeleech_start_time = $freeleech_end_time = $double_upload_start_time = $double_upload_end_time = $half_down_start_time = $half_down_end_time = 0;
-if (!empty($free) && $free['modifier'] != 0) {
-    $begin = $free['begin'];
-    $expires = $free['expires'];
-    if ($free['modifier'] === 1) {
-        $freeleech_start_time = $free['begin'];
-        $freeleech_end_time = $free['expires'];
-        $freeleech_enabled = true;
-    } elseif ($free['modifier'] === 2) {
-        $double_upload_start_time = $free['begin'];
-        $double_upload_end_time = $free['expires'];
-        $double_upload_enabled = true;
-    } elseif ($free['modifier'] === 3) {
-        $freeleech_start_time = $free['begin'];
-        $freeleech_end_time = $free['expires'];
-        $freeleech_enabled = true;
-        $double_upload_start_time = $free['begin'];
-        $double_upload_end_time = $free['expires'];
-        $double_upload_enabled = true;
-    } elseif ($free['modifier'] === 4) {
-        $half_down_start_time = $free['begin'];
-        $half_down_end_time = $free['expires'];
-        $half_down_enabled = true;
-    }
+$event = $getActiveEvent($db, $cache);
+$modifier = $event['modifier'];
+
+$freeleechEnabled = $modifier === 1 || $modifier === 3;
+$doubleUploadEnabled = $modifier === 2 || $modifier === 3;
+$halfDownloadEnabled = $modifier === 4;
+
+$freeleechWindow = $freeleechEnabled ? [$event['begin'], $event['expires']] : [0, 0];
+$doubleUploadWindow = $doubleUploadEnabled ? [$event['begin'], $event['expires']] : [0, 0];
+$halfDownloadWindow = $halfDownloadEnabled ? [$event['begin'], $event['expires']] : [0, 0];
+
+$freeleech = $getBonusProgress($cache, $db, 'freeleech_alerts_', 11);
+$doubleUpload = $getBonusProgress($cache, $db, 'doubleupload_alerts_', 12);
+$halfDownload = $getBonusProgress($cache, $db, 'halfdownload_alerts_', 13);
+
+if (
+    $freeleech['enabled'] !== 'yes'
+    && $doubleUpload['enabled'] !== 'yes'
+    && $halfDownload['enabled'] !== 'yes'
+) {
+    return '';
 }
 
-$freeleech = $cache->get('freeleech_alerts_');
-if ($freeleech === false || is_null($freeleech)) {
-    $freeleech = $db->fetch('SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id', [':id' => 11]);
-    $cache->set('freeleech_alerts_', $freeleech, 0);
-}
+$esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$baseurl = $esc($site_config['paths']['baseurl'] ?? '');
 
-$percent_fl = number_format((float) $freeleech['percent'], 2);
-if ($freeleech['enabled'] === 'yes') {
-    switch ($percent_fl) {
-        case $percent_fl >= 90:
-            $font_color_fl = "<span class='is-success'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl >= 80:
-            $font_color_fl = "<span class='is-lightgreen'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl >= 70:
-            $font_color_fl = "<span class='is-jade'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl >= 50:
-            $font_color_fl = "<span class='is-turquoise'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl >= 40:
-            $font_color_fl = "<span class='has-text-lghtblue'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl >= 30:
-            $font_color_fl = "<span class='is-gold'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl >= 20:
-            $font_color_fl = "<span class='has-text-oragne'> {$percent_fl}%</span>";
-            break;
-        case $percent_fl < 20:
-            $font_color_fl = "<span class='has-text-danger'> {$percent_fl}%</span>";
-            break;
-    }
-}
+$percentFl = number_format($freeleech['percent'], 2);
+$percentDu = number_format($doubleUpload['percent'], 2);
+$percentHd = number_format($halfDownload['percent'], 2);
 
-$doubleupload = $cache->get('doubleupload_alerts_');
-if ($doubleupload === false || is_null($doubleupload)) {
-    $doubleupload = $db->fetch('SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id', [':id' => 12]);
-    $cache->set('doubleupload_alerts_', $doubleupload, 0);
-}
+$freeleechClass = $getPercentClass((float) $percentFl);
+$doubleUploadClass = $getPercentClass((float) $percentDu);
+$halfDownloadClass = $getPercentClass((float) $percentHd);
 
-$percent_du = number_format((float) $doubleupload['percent'], 2);
-if ($doubleupload['enabled'] === 'yes') {
-    switch ($percent_du) {
-        case $percent_du >= 90:
-            $font_color_du = "<span class='is-success'> {$percent_du}%</span>";
-            break;
-        case $percent_du >= 80:
-            $font_color_du = "<span class='is-lightgreen'> {$percent_du}%</span>";
-            break;
-        case $percent_du >= 70:
-            $font_color_du = "<span class='is-jade'> {$percent_du}%</span>";
-            break;
-        case $percent_du >= 50:
-            $font_color_du = "<span class='is-turquoise'> {$percent_du}%</span>";
-            break;
-        case $percent_du >= 40:
-            $font_color_du = "<span class='has-text-lghtblue'> {$percent_du}%</span>";
-            break;
-        case $percent_du >= 30:
-            $font_color_du = "<span class='is-gold'> {$percent_du}%</span>";
-            break;
-        case $percent_du >= 20:
-            $font_color_du = "<span class='has-text-oragne'> {$percent_du}%</span>";
-            break;
-        case $percent_du < 20:
-            $font_color_du = "<span class='has-text-danger'> {$percent_du}%</span>";
-            break;
-    }
-}
-
-$halfdownload = $cache->get('halfdownload_alerts_');
-if ($halfdownload === false || is_null($halfdownload)) {
-    $halfdownload = $db->fetch('SELECT pointspool / points * 100 AS percent, enabled FROM bonus WHERE id = :id', [':id' => 13]);
-    $cache->set('halfdownload_alerts_', $halfdownload, 0);
-}
-
-$percent_hd = number_format((float) $halfdownload['percent'], 2);
-if ($halfdownload['enabled'] === 'yes') {
-    switch ($percent_hd) {
-        case $percent_hd >= 90:
-            $font_color_hd = "<span class='is-success'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd >= 80:
-            $font_color_hd = "<span class='is-lightgreen'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd >= 70:
-            $font_color_hd = "<span class='is-jade'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd >= 50:
-            $font_color_hd = "<span class='is-turquoise'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd >= 40:
-            $font_color_hd = "<span class='has-text-lghtblue'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd >= 30:
-            $font_color_hd = "<span class='is-gold'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd >= 20:
-            $font_color_hd = "<span class='has-text-oragne'> {$percent_hd}%</span>";
-            break;
-        case $percent_hd < 20:
-            $font_color_hd = "<span class='has-text-danger'> {$percent_hd}%</span>";
-            break;
-    }
-}
-
-if ($freeleech['enabled'] === 'yes') {
-    if ($freeleech_enabled) {
-        $fstatus = "<span class='is-success'> " . _('ON') . ' </span>';
-    } else {
-        $fstatus = $font_color_fl . '';
-    }
-}
-if ($doubleupload['enabled'] === 'yes') {
-    if ($double_upload_enabled) {
-        $dstatus = "<span class='is-success'> " . _('ON') . ' </span>';
-    } else {
-        $dstatus = $font_color_du . '';
-    }
-}
-if ($halfdownload['enabled'] === 'yes') {
-    if ($half_down_enabled) {
-        $hstatus = "<span class='is-success'> " . _('ON') . ' </span>';
-    } else {
-        $hstatus = $font_color_hd . '';
-    }
-}
-if ($freeleech['enabled'] === 'yes' || $halfdownload['enabled'] === 'yes' || $doubleupload['enabled'] === 'yes') {
-    $htmlout .= "
-        <li>
-            <a href='{$site_config['paths']['baseurl']}/mybonus.php'>
-                <span class='button tag is-success dt-tooltipper-large' data-tooltip-content='#karma_tooltip'>" . _("Karma Contribution's") . "</span>
-                <div class='tooltip_templates'>
-                    <div id='karma_tooltip' class='margin20'>
-                        <div class='size_6 has-text-centered has-text-success has-text-weight-bold bottom10'>
-                            " . _("Karma Contribution's") . '
-                        </div>';
-    if ($freeleech['enabled'] === 'yes') {
-        $htmlout .= "
-                        <div class='level is-marginless'>
-                            <span>" . _('Freeleech') . "</span><span class='left10'> [ ";
-        if ($freeleech_enabled) {
-            $htmlout .= "<span class='has-text-success'> " . _('ON') . ' </span>' . get_date((int) $freeleech_start_time, 'DATE') . ' - ' . get_date((int) $freeleech_end_time, 'DATE');
-        } else {
-            $htmlout .= $fstatus;
-        }
-        $htmlout .= ' ]
-                            </span>
-                        </div>';
-    }
-    if ($doubleupload['enabled'] === 'yes') {
-        $htmlout .= "
-                        <div class='level is-marginless'>
-                            <span>" . _('Doubleupload') . "</span><span class='left10'> [ ";
-        if ($double_upload_enabled) {
-            $htmlout .= "<span class='has-text-success'> " . _('ON') . ' </span>' . get_date((int) $double_upload_start_time, 'DATE') . ' - ' . get_date((int) $double_upload_end_time, 'DATE');
-        } else {
-            $htmlout .= $dstatus;
-        }
-        $htmlout .= ' ]
-                            </span>
-                        </div>';
-    }
-    if ($halfdownload['enabled'] === 'yes') {
-        $htmlout .= "
-                        <div class='level is-marginless'>
-                            <span>" . _('Half Download') . "</span><span class='left10'> [ ";
-        if ($half_down_enabled) {
-            $htmlout .= "<span class='has-text-success'> " . _('ON') . ' </span>' . get_date((int) $half_down_start_time, 'DATE') . ' - ' . get_date((int) $half_down_end_time, 'DATE');
-        } else {
-            $htmlout .= $hstatus;
-        }
-        $htmlout .= ' ]
-                            </span>
-                        </div>';
-    }
-    $htmlout .= '
-                    </div>
+ob_start();
+?>
+<li>
+    <a href="<?= $baseurl ?>/mybonus.php">
+        <span class="button tag is-success dt-tooltipper-large" data-tooltip-content="#karma_tooltip">
+            <?= $esc(_("Karma Contribution's")) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="karma_tooltip" class="margin20">
+                <div class="size_6 has-text-centered has-text-success has-text-weight-bold bottom10">
+                    <?= $esc(_("Karma Contribution's")) ?>
                 </div>
-            </a>
-        </li>';
-}
+                <?php if ($freeleech['enabled'] === 'yes') { ?>
+                    <div class="level is-marginless">
+                        <span><?= $esc(_('Freeleech')) ?></span>
+                        <span class="left10">[
+                            <?php if ($freeleechEnabled) { ?>
+                                <span class="has-text-success"> <?= $esc(_('ON')) ?> </span>
+                                <?= $esc(get_date($freeleechWindow[0], 'DATE')) ?> - <?= $esc(get_date($freeleechWindow[1], 'DATE')) ?>
+                            <?php } else { ?>
+                                <span class="<?= $esc($freeleechClass) ?>"> <?= $esc($percentFl) ?>%</span>
+                            <?php } ?>
+                        ]</span>
+                    </div>
+                <?php } ?>
+                <?php if ($doubleUpload['enabled'] === 'yes') { ?>
+                    <div class="level is-marginless">
+                        <span><?= $esc(_('Doubleupload')) ?></span>
+                        <span class="left10">[
+                            <?php if ($doubleUploadEnabled) { ?>
+                                <span class="has-text-success"> <?= $esc(_('ON')) ?> </span>
+                                <?= $esc(get_date($doubleUploadWindow[0], 'DATE')) ?> - <?= $esc(get_date($doubleUploadWindow[1], 'DATE')) ?>
+                            <?php } else { ?>
+                                <span class="<?= $esc($doubleUploadClass) ?>"> <?= $esc($percentDu) ?>%</span>
+                            <?php } ?>
+                        ]</span>
+                    </div>
+                <?php } ?>
+                <?php if ($halfDownload['enabled'] === 'yes') { ?>
+                    <div class="level is-marginless">
+                        <span><?= $esc(_('Half Download')) ?></span>
+                        <span class="left10">[
+                            <?php if ($halfDownloadEnabled) { ?>
+                                <span class="has-text-success"> <?= $esc(_('ON')) ?> </span>
+                                <?= $esc(get_date($halfDownloadWindow[0], 'DATE')) ?> - <?= $esc(get_date($halfDownloadWindow[1], 'DATE')) ?>
+                            <?php } else { ?>
+                                <span class="<?= $esc($halfDownloadClass) ?>"> <?= $esc($percentHd) ?>%</span>
+                            <?php } ?>
+                        ]</span>
+                    </div>
+                <?php } ?>
+            </div>
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/blocks/global/happyhour.php
+++ b/blocks/global/happyhour.php
@@ -1,37 +1,66 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
+global $site_config;
 
 $user = check_user_status();
-global $container, $site_config;
+if (empty($user) || empty($site_config['bonus']['happy_hour'])) {
+    return '';
+}
 
-$db = $container->get(Database::class);
+$happyFile = $site_config['paths']['happyhour'] ?? '';
+if (!is_string($happyFile) || $happyFile === '' || !is_file($happyFile)) {
+    return '';
+}
 
-if ($site_config['bonus']['happy_hour'] && !empty($user)) {
-    require_once INCL_DIR . 'function_happyhour.php';
-    if (happyHour('check')) {
-        $htmlout .= "
-    <li>
-        <a href='{$site_config['paths']['baseurl']}/browse.php?cat=" . happyCheck('check') . "'>
-            <span class='button tag is-success dt-tooltipper-small' data-tooltip-content='#happyhour_tooltip'>" . _('HappyHour') . "</span>
-            <div class='tooltip_templates'>
-                <div id='happyhour_tooltip' class='margin20'>
-                    <div class='size_6 has-text-centered has-text-success has-text-weight-bold bottom10'>
-                        " . _('HappyHour') . "
-                    </div>
-                    <div class='has-text-centered is-primary'>
-                        " . _('Hey its now happy hour!') . '<br>' . ((happyCheck('check') == 255) ? '
-                        ' . _('Every torrent downloaded in the happy hour is free') : '
-                        ' . _('Only in the selected Category, click on HappyHour above here to go to it')) . "<br>
-                        <span class='has-text-danger'><b>" . happyHour('time') . '</b></span>
-                    </div>
+try {
+    $data = json_decode((string) file_get_contents($happyFile), true, 512, JSON_THROW_ON_ERROR);
+} catch (JsonException) {
+    return '';
+}
+$start = isset($data['time']) ? (int) strtotime((string) $data['time']) : 0;
+$categoryId = (int) ($data['catid'] ?? 0);
+$now = TIME_NOW;
+
+if ($start <= 0 || $start >= $now || ($start + 3600) < $now) {
+    return '';
+}
+
+$timeLeft = mkprettytime(($start + 3600) - $now);
+[$minutes, $seconds] = array_pad(explode(':', $timeLeft), 2, '00');
+$formattedTime = $minutes . ' min : ' . $seconds . ' sec';
+
+$esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$baseurl = $esc($site_config['paths']['baseurl'] ?? '');
+$linkCategory = $categoryId === 255 ? '255' : (string) $categoryId;
+$categoryUrl = $esc($linkCategory);
+$categoryMessage = $categoryId === 255
+    ? _('Every torrent downloaded in the happy hour is free')
+    : _('Only in the selected Category, click on HappyHour above here to go to it');
+
+ob_start();
+?>
+<li>
+    <a href="<?= $baseurl ?>/browse.php?cat=<?= $categoryUrl ?>">
+        <span class="button tag is-success dt-tooltipper-small" data-tooltip-content="#happyhour_tooltip">
+            <?= $esc(_('HappyHour')) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="happyhour_tooltip" class="margin20">
+                <div class="size_6 has-text-centered has-text-success has-text-weight-bold bottom10">
+                    <?= $esc(_('HappyHour')) ?>
+                </div>
+                <div class="has-text-centered is-primary">
+                    <?= $esc(_('Hey its now happy hour!')) ?><br>
+                    <?= $esc($categoryMessage) ?><br>
+                    <span class="has-text-danger"><b><?= $esc($formattedTime) ?></b></span>
                 </div>
             </div>
-        </a>
-    </li>';
-    }
-}
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/blocks/global/lottery.php
+++ b/blocks/global/lottery.php
@@ -1,52 +1,70 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Cache;
 use Pu239\Database;
+use Psr\SimpleCache\CacheInterface as Cache;
 
-$user = check_user_status();
 global $container, $site_config;
 
+$user = check_user_status();
+if (empty($user)) {
+    return '';
+}
+
+/** @var Database $db */
 $db = $container->get(Database::class);
+/** @var Cache $cache */
+$cache = $container->get(Cache::class);
 
-if ($user) {
-    $cache = $container->get(Cache::class);
-    $lottery_info = $cache->get('lottery_info_');
-    if ($lottery_info === false || is_null($lottery_info)) {
-        $lottery_info = $db->fetchAll('SELECT name, value FROM lottery_config');
-        $lottery_info = array_column($lottery_info, 'value', 'name');
-        $cache->set('lottery_info_', $lottery_info, 86400);
-    }
+$lottery = $cache->get('lottery_info_');
+if ($lottery === null) {
+    $rows = $db->fetchAll('SELECT name, value FROM lottery_config');
+    $lottery = array_column($rows, 'value', 'name');
+    $cache->set('lottery_info_', $lottery, 86400);
+}
 
-    if ($lottery_info['enable']) {
-        $htmlout .= "
-    <li>
-        <a href='{$site_config['paths']['baseurl']}/lottery.php'>
-            <span class='button tag is-success dt-tooltipper-large' data-tooltip-content='#lottery_tooltip'>
-                " . _('Lottery in Progress') . "
-            </span>
-            <div class='tooltip_templates'>
-                <div id='lottery_tooltip' class='margin20'>
-                    <div>
-                        <div class='size_6 has-text-centered has-text-success has-text-weight-bold bottom10'>
-                            " . _('Lottery Info') . "
-                        </div>
-                        <div class='level-wide is-marginless'>
-                            <div>" . _('Started at') . ': </div><div>' . get_date((int) $lottery_info['start_date'], 'LONG') . "</div>
-                        </div>
-                        <div class='level-wide is-marginless'>
-                            <div class='right20'>" . _('Ends at') . ": </div><div class='left20'>" . get_date((int) $lottery_info['end_date'], 'LONG') . "</div>
-                        </div>
-                        <div class='level-wide is-marginless'>
-                            <div>" . _('Remaining') . ': </div><div>' . mkprettytime($lottery_info['end_date'] - TIME_NOW) . '</div>
-                        </div>
+if (empty($lottery['enable'])) {
+    return '';
+}
+
+$esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$baseurl = $esc($site_config['paths']['baseurl'] ?? '');
+$start = isset($lottery['start_date']) ? (int) $lottery['start_date'] : 0;
+$end = isset($lottery['end_date']) ? (int) $lottery['end_date'] : 0;
+$remaining = $end > TIME_NOW ? mkprettytime($end - TIME_NOW) : _('Ended');
+
+ob_start();
+?>
+<li>
+    <a href="<?= $baseurl ?>/lottery.php">
+        <span class="button tag is-success dt-tooltipper-large" data-tooltip-content="#lottery_tooltip">
+            <?= $esc(_('Lottery in Progress')) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="lottery_tooltip" class="margin20">
+                <div>
+                    <div class="size_6 has-text-centered has-text-success has-text-weight-bold bottom10">
+                        <?= $esc(_('Lottery Info')) ?>
+                    </div>
+                    <div class="level-wide is-marginless">
+                        <div><?= $esc(_('Started at')) ?>: </div>
+                        <div><?= $esc(get_date($start, 'LONG')) ?></div>
+                    </div>
+                    <div class="level-wide is-marginless">
+                        <div class="right20"><?= $esc(_('Ends at')) ?>: </div>
+                        <div class="left20"><?= $esc(get_date($end, 'LONG')) ?></div>
+                    </div>
+                    <div class="level-wide is-marginless">
+                        <div><?= $esc(_('Remaining')) ?>: </div>
+                        <div><?= $esc($remaining) ?></div>
                     </div>
                 </div>
             </div>
-        </a>
-    </li>';
-    }
-}
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/blocks/global/message.php
+++ b/blocks/global/message.php
@@ -1,39 +1,49 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../../include/runtime_safe.php';
-require_once __DIR__ . '/../../include/bootstrap_pdo.php';
+require_once dirname(__DIR__) . '/bootstrap.php';
 
-use Pu239\Database;
 use Pu239\Message;
 
-$user = check_user_status();
 global $container, $site_config;
 
-$db = $container->get(Database::class);
-
-if ($site_config['alerts']['message'] && !empty($user)) {
-    $messages_class = $container->get(Message::class);
-    $unread = $messages_class->get_count($user['id'], $site_config['pm']['inbox'], true);
-
-    if (!empty($unread)) {
-        $htmlout .= "
-        <li>
-            <a href='{$site_config['paths']['baseurl']}/messages.php'>
-                <span class='button tag is-info has-text-black dt-tooltipper-small' data-tooltip-content='#message_tooltip'>
-                   " . _pfe('{0} Unread PM', "{0} Unread PM's", $unread) . "
-                </span>
-                <div class='tooltip_templates'>
-                    <div id='message_tooltip' class='margin20'>
-                        <div class='size_6 has-text-centered has-text-success has-text-weight-bold bottom10'>
-                            " . _pfe('{0} Unread PM', "{0} Unread PM's", $unread) . "
-                        </div>
-                        <div class='has-text-centered'>
-                            " . _pfe('You have {0} new message', 'You have {0} new messages', $unread) . '
-                        </div>
-                    </div>
-                </div>
-            </a>
-        </li>';
-    }
+$user = check_user_status();
+if (empty($user) || empty($site_config['alerts']['message'])) {
+    return '';
 }
+
+/** @var Message $messages */
+$messages = $container->get(Message::class);
+$unread = (int) $messages->get_count($user['id'], $site_config['pm']['inbox'], true);
+
+if ($unread < 1) {
+    return '';
+}
+
+$esc = static fn($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+$baseurl = $esc($site_config['paths']['baseurl'] ?? '');
+$unreadLabel = _pfe('{0} Unread PM', "{0} Unread PM's", $unread);
+$unreadDetail = _pfe('You have {0} new message', 'You have {0} new messages', $unread);
+
+ob_start();
+?>
+<li>
+    <a href="<?= $baseurl ?>/messages.php">
+        <span class="button tag is-info has-text-black dt-tooltipper-small" data-tooltip-content="#message_tooltip">
+            <?= $esc($unreadLabel) ?>
+        </span>
+        <div class="tooltip_templates">
+            <div id="message_tooltip" class="margin20">
+                <div class="size_6 has-text-centered has-text-success has-text-weight-bold bottom10">
+                    <?= $esc($unreadLabel) ?>
+                </div>
+                <div class="has-text-centered">
+                    <?= $esc($unreadDetail) ?>
+                </div>
+            </div>
+        </div>
+    </a>
+</li>
+<?php
+
+return (string) ob_get_clean();

--- a/tools/blocks_2025_recursive_report.csv
+++ b/tools/blocks_2025_recursive_report.csv
@@ -1,0 +1,9 @@
+file,legacy_found,select_star,cache_psr16,csrf_todo,output_escaped,buffer_return,json_mode,manual_review_notes
+blocks/global/bugmessages.php,none,false,true,false,true,true,false,
+blocks/global/crazyhour.php,none,false,true,false,true,true,false,
+blocks/global/demotion.php,none,false,false,false,true,true,false,
+blocks/global/freeleech.php,none,false,true,false,true,true,false,
+blocks/global/freeleech_contribution.php,function_event,false,true,false,true,true,false,
+blocks/global/happyhour.php,function_happyhour,false,false,false,true,true,false,
+blocks/global/lottery.php,none,false,true,false,true,true,false,
+blocks/global/message.php,none,false,false,false,true,true,false,

--- a/tools/blocks_lint_recursive.txt
+++ b/tools/blocks_lint_recursive.txt
@@ -1,0 +1,9 @@
+No syntax errors detected in blocks/bootstrap.php
+No syntax errors detected in blocks/global/bugmessages.php
+No syntax errors detected in blocks/global/crazyhour.php
+No syntax errors detected in blocks/global/demotion.php
+No syntax errors detected in blocks/global/freeleech.php
+No syntax errors detected in blocks/global/freeleech_contribution.php
+No syntax errors detected in blocks/global/happyhour.php
+No syntax errors detected in blocks/global/lottery.php
+No syntax errors detected in blocks/global/message.php


### PR DESCRIPTION
## Summary
- add a blocks-level bootstrap shim so block scripts pull in the shared repository bootstrap
- modernize the first batch of global block renderers to use the container database/cache services, return buffered HTML, and escape dynamic output
- record lint and modernization metadata for the transformed files

## Testing
- php -l blocks/bootstrap.php
- php -l blocks/global/bugmessages.php
- php -l blocks/global/crazyhour.php
- php -l blocks/global/demotion.php
- php -l blocks/global/freeleech.php
- php -l blocks/global/freeleech_contribution.php
- php -l blocks/global/happyhour.php
- php -l blocks/global/lottery.php
- php -l blocks/global/message.php

------
https://chatgpt.com/codex/tasks/task_e_68ca2fc5d38483258f23b9456ea6a6b8