### PR TITLE
Sanitize include side effects (batch offset=0)

### DIFF
--- a/include/bittorrent.php
+++ b/include/bittorrent.php
@@ -2,8 +2,7 @@
 declare(strict_types=1);
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'] ?? '')) {
-    http_response_code(404);
-    exit(0);
+    throw new \RuntimeException('Direct access to include/bittorrent.php is not permitted.');
 }
 
 use Delight\Auth\Auth;

--- a/include/geoip.inc
+++ b/include/geoip.inc
@@ -1376,10 +1376,12 @@ class GeoIP
 
 function geoip_load_shared_mem($file)
 {
-    $fp = fopen($file, 'rb');
-    if (!$fp) {
-        echo "error opening $file: $php_errormsg\n";
-        exit;
+    $fp = @fopen($file, 'rb');
+    if ($fp === false) {
+        $error = error_get_last();
+        $message = $error['message'] ?? 'unknown error';
+
+        throw new \RuntimeException(sprintf('Unable to open GeoIP data file "%s": %s', (string) $file, $message));
     }
     $s_array = fstat($fp);
     $size = $s_array['size'];

--- a/tools/sideeffects_lint.txt
+++ b/tools/sideeffects_lint.txt
@@ -1,0 +1,2 @@
+No syntax errors detected in include/bittorrent.php
+No syntax errors detected in include/geoip.inc

--- a/tools/sideeffects_report.csv
+++ b/tools/sideeffects_report.csv
@@ -1,0 +1,3 @@
+file,exits_removed,buffer_return,sanitization_helper_added
+include/bittorrent.php,1,0,0
+include/geoip.inc,1,0,0


### PR DESCRIPTION
## Summary
- replace direct access guard in `include/bittorrent.php` with a RuntimeException
- convert the GeoIP shared memory loader to throw an exception instead of exiting
- record lint and reporting artifacts for the side-effects refactor batch

## Testing
- php -l include/bittorrent.php
- php -l include/geoip.inc

------
https://chatgpt.com/codex/tasks/task_e_68ce3f705cfc832591378f0b6b2124af