### PR TITLE
chore: audit autofix manifest → actionable lists

### DIFF
--- a/tools/manifest_audit_summary.txt
+++ b/tools/manifest_audit_summary.txt
@@ -1,4 +1,30 @@
-Audit Timestamp: 2025-09-20T09:00:14.637243+00:00
-Rehydrated files: 0
-Re-quarantined files: 20
-Unknown entries: 53
+Autofix manifest audit summary
+
+Total unique files reviewed: 30
+Rehydrated entries with files present: 0
+Rehydrated entries missing on disk: 0
+Re-quarantined entries: 20
+
+No rehydrated files with confirmed on-disk copies were found in this audit pass.
+
+Re-quarantined files:
+  - admin/class_promo.php (source: _quarantine/rebroken/admin/class_promo.php)
+  - admin/comments.php (source: _quarantine/rebroken/admin/comments.php)
+  - admin/reports.php (source: _quarantine/rebroken/admin/reports.php)
+  - admin/sitelog.php (source: _quarantine/rebroken/admin/sitelog.php)
+  - admin/system_view.php (source: _quarantine/rebroken/admin/system_view.php)
+  - include/function_account_delete.php (source: _quarantine/rebroken/include/function_account_delete.php)
+  - public/coins.php (source: _quarantine/rebroken/public/coins.php)
+  - public/comment.php (source: _quarantine/rebroken/public/comment.php)
+  - public/credits.php (source: _quarantine/rebroken/public/credits.php)
+  - public/friends.php (source: _quarantine/rebroken/public/friends.php)
+  - public/gift.php (source: _quarantine/rebroken/public/gift.php)
+  - public/invite.php (source: _quarantine/rebroken/public/invite.php)
+  - public/messages.php (source: _quarantine/rebroken/public/messages.php)
+  - public/reputation.php (source: _quarantine/rebroken/public/reputation.php)
+  - public/staffbox.php (source: _quarantine/rebroken/public/staffbox.php)
+  - public/takeedit.php (source: _quarantine/rebroken/public/takeedit.php)
+  - public/takeeditcp.php (source: _quarantine/rebroken/public/takeeditcp.php)
+  - public/usercp.php (source: _quarantine/rebroken/public/usercp.php)
+  - public/usermood.php (source: _quarantine/rebroken/public/usermood.php)
+  - public/users.php (source: _quarantine/rebroken/public/users.php)

--- a/tools/rehydrated_files.txt
+++ b/tools/rehydrated_files.txt
@@ -1,0 +1,1 @@
+file,rehydrated,re_quarantined,fixed_stray_config,function_includes_removed,notes,source_quarantine

--- a/tools/requarantined_files.txt
+++ b/tools/requarantined_files.txt
@@ -1,20 +1,21 @@
-admin/sitelog.php
-admin/system_view.php
-include/function_account_delete.php
-public/coins.php
-public/comment.php
-public/credits.php
-public/friends.php
-public/gift.php
-public/invite.php
-public/messages.php
-public/reputation.php
-public/staffbox.php
-public/takeedit.php
-public/takeeditcp.php
-public/usercp.php
-public/usermood.php
-admin/class_promo.php
-admin/comments.php
-admin/reports.php
-public/users.php
+file,rehydrated,re_quarantined,fixed_stray_config,function_includes_removed,notes,source_quarantine
+admin/class_promo.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/admin/class_promo.php).,_quarantine/rebroken/admin/class_promo.php
+admin/comments.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/admin/comments.php).,_quarantine/rebroken/admin/comments.php
+admin/reports.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/admin/reports.php).,_quarantine/rebroken/admin/reports.php
+admin/sitelog.php,false,true,false,false,Re-quarantined incomplete migration stubbed for safety.,_quarantine/rebroken/admin/sitelog.php
+admin/system_view.php,false,true,false,false,Re-quarantined incomplete migration stubbed for safety.,_quarantine/rebroken/admin/system_view.php
+include/function_account_delete.php,false,true,false,false,Re-quarantined incomplete migration stubbed for safety.,_quarantine/rebroken/include/function_account_delete.php
+public/coins.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/coins.php
+public/comment.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/comment.php
+public/credits.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/credits.php
+public/friends.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/friends.php
+public/gift.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/gift.php
+public/invite.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/invite.php
+public/messages.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/messages.php
+public/reputation.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/reputation.php
+public/staffbox.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/staffbox.php
+public/takeedit.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/takeedit.php
+public/takeeditcp.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/takeeditcp.php
+public/usercp.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/usercp.php
+public/usermood.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/usermood.php
+public/users.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/public/users.php).,_quarantine/rebroken/public/users.php


### PR DESCRIPTION
## Summary
- parse the autofix manifest and consolidate unique file statuses for rehydration and re-quarantine tracking
- publish filtered CSV exports for rehydrated (currently none present) and re-quarantined entries with notes and source paths
- replace the manifest audit summary with counts and a ready-to-use list of re-quarantined files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce78a133a483258e96a76c27db8a48