### PR TITLE
Audit autofix manifest for actionable lists

### DIFF
--- a/tools/manifest_audit_summary.txt
+++ b/tools/manifest_audit_summary.txt
@@ -1,30 +1,20 @@
 Autofix manifest audit summary
 
-Total unique files reviewed: 30
-Rehydrated entries with files present: 0
-Rehydrated entries missing on disk: 0
-Re-quarantined entries: 20
+Dataset: tools/autofix_manifest.csv (latest entry per file)
 
-No rehydrated files with confirmed on-disk copies were found in this audit pass.
+Key totals
+- Total unique files tracked: 35
+- Files rehydrated in latest state: 0
+- Files re-quarantined in latest state: 4
+- Files with stray config fixes applied: 0
+- Files with function include removals: 0
 
-Re-quarantined files:
-  - admin/class_promo.php (source: _quarantine/rebroken/admin/class_promo.php)
-  - admin/comments.php (source: _quarantine/rebroken/admin/comments.php)
-  - admin/reports.php (source: _quarantine/rebroken/admin/reports.php)
-  - admin/sitelog.php (source: _quarantine/rebroken/admin/sitelog.php)
-  - admin/system_view.php (source: _quarantine/rebroken/admin/system_view.php)
-  - include/function_account_delete.php (source: _quarantine/rebroken/include/function_account_delete.php)
-  - public/coins.php (source: _quarantine/rebroken/public/coins.php)
-  - public/comment.php (source: _quarantine/rebroken/public/comment.php)
-  - public/credits.php (source: _quarantine/rebroken/public/credits.php)
-  - public/friends.php (source: _quarantine/rebroken/public/friends.php)
-  - public/gift.php (source: _quarantine/rebroken/public/gift.php)
-  - public/invite.php (source: _quarantine/rebroken/public/invite.php)
-  - public/messages.php (source: _quarantine/rebroken/public/messages.php)
-  - public/reputation.php (source: _quarantine/rebroken/public/reputation.php)
-  - public/staffbox.php (source: _quarantine/rebroken/public/staffbox.php)
-  - public/takeedit.php (source: _quarantine/rebroken/public/takeedit.php)
-  - public/takeeditcp.php (source: _quarantine/rebroken/public/takeeditcp.php)
-  - public/usercp.php (source: _quarantine/rebroken/public/usercp.php)
-  - public/usermood.php (source: _quarantine/rebroken/public/usermood.php)
-  - public/users.php (source: _quarantine/rebroken/public/users.php)
+Re-quarantined files and preserved sources
+- admin/class_promo.php ← _quarantine/rebroken/admin/class_promo.php
+- admin/comments.php ← _quarantine/rebroken/admin/comments.php
+- admin/reports.php ← _quarantine/rebroken/admin/reports.php
+- public/users.php ← _quarantine/rebroken/public/users.php
+
+Observations
+- Many files remain in modernization stubs without further automated action; follow-up work will require manual restoration or new migrations.
+- No files were successfully rehydrated during this pass, so no runtime-ready assets were returned from quarantine.

--- a/tools/rehydrated_files.txt
+++ b/tools/rehydrated_files.txt
@@ -1,1 +1,2 @@
-file,rehydrated,re_quarantined,fixed_stray_config,function_includes_removed,notes,source_quarantine
+# Rehydrated files (latest state from tools/autofix_manifest.csv)
+# None found in this audit.

--- a/tools/requarantined_files.txt
+++ b/tools/requarantined_files.txt
@@ -1,21 +1,5 @@
-file,rehydrated,re_quarantined,fixed_stray_config,function_includes_removed,notes,source_quarantine
-admin/class_promo.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/admin/class_promo.php).,_quarantine/rebroken/admin/class_promo.php
-admin/comments.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/admin/comments.php).,_quarantine/rebroken/admin/comments.php
-admin/reports.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/admin/reports.php).,_quarantine/rebroken/admin/reports.php
-admin/sitelog.php,false,true,false,false,Re-quarantined incomplete migration stubbed for safety.,_quarantine/rebroken/admin/sitelog.php
-admin/system_view.php,false,true,false,false,Re-quarantined incomplete migration stubbed for safety.,_quarantine/rebroken/admin/system_view.php
-include/function_account_delete.php,false,true,false,false,Re-quarantined incomplete migration stubbed for safety.,_quarantine/rebroken/include/function_account_delete.php
-public/coins.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/coins.php
-public/comment.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/comment.php
-public/credits.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/credits.php
-public/friends.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/friends.php
-public/gift.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/gift.php
-public/invite.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/invite.php
-public/messages.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/messages.php
-public/reputation.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/reputation.php
-public/staffbox.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/staffbox.php
-public/takeedit.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/takeedit.php
-public/takeeditcp.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/takeeditcp.php
-public/usercp.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/usercp.php
-public/usermood.php,false,true,false,false,Standardized modernization stub pending SQL restore.,_quarantine/rebroken/public/usermood.php
-public/users.php,false,true,false,false,Re-quarantined corrupted file and installed runtime stub (source preserved at _quarantine/rebroken/public/users.php).,_quarantine/rebroken/public/users.php
+# Re-quarantined files (latest state from tools/autofix_manifest.csv)
+admin/class_promo.php -> _quarantine/rebroken/admin/class_promo.php
+admin/comments.php -> _quarantine/rebroken/admin/comments.php
+admin/reports.php -> _quarantine/rebroken/admin/reports.php
+public/users.php -> _quarantine/rebroken/public/users.php


### PR DESCRIPTION
## Summary
- derive the current rehydrated and re-quarantined file lists from tools/autofix_manifest.csv
- capture aggregate counts and preserved sources in manifest_audit_summary.txt for quick follow-up

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce7f43bb40832589226ebb60257f43