### PR TITLE
DB purge rehydrated cleanup batch (offset=0)

### DIFF
--- a/cleanup/announcement_update.php
+++ b/cleanup/announcement_update.php
@@ -1,11 +1,12 @@
 <?php
 declare(strict_types=1);
 
-use Pu239\Database;
 use DI\DependencyException;
 use DI\NotFoundException;
+use Pu239\Database;
 
 global $container;
+/** @var Database $db */
 $db = $container->get(Database::class);
 
 /**
@@ -15,12 +16,12 @@ $db = $container->get(Database::class);
  * @throws NotFoundException
  * @throws \PDOException
  */
-function announcement_update($data)
+function announcement_update($data): void
 {
-    global $container, $db;
+    global $db;
 
     $time_start = microtime(true);
-    $db->run('DELETE FROM announcement_main WHERE expires < ?', [TIME_NOW]);
+    $db->run('DELETE FROM announcement_main WHERE expires < :expires', [':expires' => TIME_NOW]);
 
     $time_end = microtime(true);
     $run_time = $time_end - $time_start;

--- a/cleanup/cheatclean_update.php
+++ b/cleanup/cheatclean_update.php
@@ -1,11 +1,10 @@
 <?php
 declare(strict_types=1);
 
-
-
 use Pu239\Database;
 
 global $container;
+/** @var Database $db */
 $db = $container->get(Database::class);
 $now = defined('TIME_NOW') ? (int) TIME_NOW : time();
 
@@ -20,7 +19,7 @@ function cheatclean_update(array $data): void
 
     $time_start = microtime(true);
     $dt = $now - (30 * 86400);
-    $db->run('DELETE FROM cheaters WHERE added < ?', [$dt]);
+    $db->run('DELETE FROM cheaters WHERE added < :added', [':added' => $dt]);
     $time_end = microtime(true);
     $run_time = $time_end - $time_start;
     $text = " Run time: $run_time seconds";

--- a/cleanup/funds_table_update.php
+++ b/cleanup/funds_table_update.php
@@ -1,31 +1,28 @@
 <?php
 declare(strict_types=1);
 
-$db = $container->get(Database::class);
-
-
-
-
-
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
+use Pu239\Database;
+
+global $container;
+/** @var Database $db */
+$db = $container->get(Database::class);
 
 /**
- * @param $data
+ * @param mixed $data
  *
  * @throws DependencyException
  * @throws NotFoundException
  * @throws \PDOException
  */
-function funds_table_update($data)
+function funds_table_update($data): void
 {
-    global $container;
+    global $container, $db;
 
     $time_start = microtime(true);
-    $pdo = $container->get(PDO::class);
-    $stmt = $pdo->prepare('TRUNCATE table funds');
-    $stmt->execute();
+    $db->run('TRUNCATE TABLE funds');
     $cache = $container->get(Cache::class);
     $cache->delete('totalfunds_');
     if ($data['clean_log']) {

--- a/cleanup/hitrun_update.php
+++ b/cleanup/hitrun_update.php
@@ -1,27 +1,26 @@
 <?php
 declare(strict_types=1);
 
-$db = $container->get(Database::class);
-
-
-
-
-
 use DI\DependencyException;
 use DI\NotFoundException;
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
+use Pu239\Database;
 use Pu239\Snatched;
 use Pu239\User;
 
+global $container;
+/** @var Database $db */
+$db = $container->get(Database::class);
+
 /**
- * @param $data
+ * @param mixed $data
  *
  * @throws DependencyException
  * @throws NotFoundException
  * @throws \PDOException
  * @throws UnbegunTransaction
  */
-function hitrun_update($data)
+function hitrun_update($data): void
 {
     global $container, $site_config;
 

--- a/cleanup/tvmaze_schedule_update.php
+++ b/cleanup/tvmaze_schedule_update.php
@@ -1,20 +1,19 @@
 <?php
 declare(strict_types=1);
 
-$db = $container->get(Database::class);
-
-
-
-
-
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
+use Pu239\Database;
 use Pu239\Image;
 use Spatie\Image\Exceptions\InvalidManipulation;
 
+global $container;
+/** @var Database $db */
+$db = $container->get(Database::class);
+
 /**
- * @param $data
+ * @param mixed $data
  *
  * @throws InvalidManipulation
  * @throws DependencyException
@@ -22,7 +21,7 @@ use Spatie\Image\Exceptions\InvalidManipulation;
  * @throws \PDOException
  * @throws Exception
  */
-function tvmaze_schedule_update($data)
+function tvmaze_schedule_update($data): void
 {
     global $container, $BLOCKS;
 

--- a/migration-report.md
+++ b/migration-report.md
@@ -161,6 +161,7 @@ $ rg "mysqli_|sql_query\(|sqlesc\(" blocks
 No matches.
 
 ## cleanup
+- (Rehydrated v3) `cleanup/announcement_update.php`, `cleanup/cheatclean_update.php`, `cleanup/funds_table_update.php`, `cleanup/hitrun_update.php`, `cleanup/tvmaze_schedule_update.php`: restored the shared `$db` bootstrap wiring and converted remaining deletes/truncates to named parameter bindings.
 - `cleanup/optimizedb.php`: migrated from `sql_query`/`mysqli_fetch_assoc`/`sqlesc` to `Pu239\Database` with bound parameters; standardized bootstrap and strict typing.
 
 - `cleanup/announcement_update.php`: migrated from legacy `sql_query` to `Pu239\Database` with bound parameters; standardized bootstrap and strict typing.

--- a/tools/db_purge_rehydrated_v3_lint.txt
+++ b/tools/db_purge_rehydrated_v3_lint.txt
@@ -1,0 +1,15 @@
+php -l cleanup/announcement_update.php
+No syntax errors detected in cleanup/announcement_update.php
+
+php -l cleanup/cheatclean_update.php
+No syntax errors detected in cleanup/cheatclean_update.php
+
+php -l cleanup/funds_table_update.php
+No syntax errors detected in cleanup/funds_table_update.php
+
+php -l cleanup/hitrun_update.php
+No syntax errors detected in cleanup/hitrun_update.php
+
+php -l cleanup/tvmaze_schedule_update.php
+No syntax errors detected in cleanup/tvmaze_schedule_update.php
+

--- a/tools/db_purge_rehydrated_v3_report.csv
+++ b/tools/db_purge_rehydrated_v3_report.csv
@@ -1,0 +1,6 @@
+file,replaced_patterns,in_clause_used,limit_bind_ok,select_star_flag,notes
+cleanup/announcement_update.php,DELETE placeholder → named param,false,n/a,false,Ensured shared $db bootstrap and TIME_NOW binding.
+cleanup/cheatclean_update.php,DELETE placeholder → named param,false,n/a,false,Converted cleanup delete to named binding.
+cleanup/funds_table_update.php,PDO::prepare → $db->run,false,n/a,false,Replaced direct PDO truncate with database service.
+cleanup/hitrun_update.php,Bootstrap restored,false,n/a,false,Rehydrated shared $db wiring; logic unchanged.
+cleanup/tvmaze_schedule_update.php,Bootstrap restored,false,n/a,false,Aligned with Database service bootstrap.


### PR DESCRIPTION
## Summary
- restore the shared Database bootstrap wiring in rehydrated cleanup helpers
- convert DELETE/TRUNCATE statements to named parameter bindings via Pu239\Database
- refresh the migration report and add lint/report artifacts for this batch

## Testing
- php -l cleanup/announcement_update.php
- php -l cleanup/cheatclean_update.php
- php -l cleanup/funds_table_update.php
- php -l cleanup/hitrun_update.php
- php -l cleanup/tvmaze_schedule_update.php

------
https://chatgpt.com/codex/tasks/task_e_68ce88e661ec8325ac30d802b97e90dc