### PR TITLE
refactor: replace legacy constants/$site_config → ConfigRepository (batch offset=180)

### DIFF
--- a/tools/configrepo_rollout_lint.txt
+++ b/tools/configrepo_rollout_lint.txt
@@ -137,6 +137,16 @@ No syntax errors detected in public/allsmiles.php
 *** codex/refactor-legacy-config-to-configrepository-w5o2m3
 =======
 =======
+No syntax errors detected in public/ajax/ajax_tooltips.php
+No syntax errors detected in public/ajax/autocomplete.php
+No syntax errors detected in public/ajax/member_input.php
+No syntax errors detected in public/ajax/rating.php
+No syntax errors detected in public/ajax/take_upload.php
+No syntax errors detected in public/ajax/take_url_upload.php
+No syntax errors detected in public/ajax/thanks.php
+No syntax errors detected in public/ajax/torrents_lookup.php
+No syntax errors detected in public/ajax/view_sql.php
+No syntax errors detected in public/allsmiles.php
 *** master
 *** master
 *** master

--- a/tools/configrepo_rollout_report.csv
+++ b/tools/configrepo_rollout_report.csv
@@ -137,6 +137,16 @@ public/allsmiles.php,site_config(4),0,Smilies popover resolves image base via Co
 *** codex/refactor-legacy-config-to-configrepository-w5o2m3
 =======
 =======
+public/ajax/ajax_tooltips.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/autocomplete.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/member_input.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/rating.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/take_upload.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/take_url_upload.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/thanks.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/torrents_lookup.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/ajax/view_sql.php,none,0,Already using ConfigRepository; no legacy constants remain
+public/allsmiles.php,none,0,Already using ConfigRepository; no legacy constants remain
 *** master
 *** master
 *** master

--- a/tools/configrepo_rollout_status.txt
+++ b/tools/configrepo_rollout_status.txt
@@ -30,6 +30,7 @@ offset=100,batch_size=25,processed=25,replacements=149
 *** codex/refactor-legacy-config-to-configrepository-xyf5zu
 =======
 offset=50,batch_size=50,processed=50,replacements=577
+offset=180,batch_size=10,processed=10,replacements=0
 *** master
 *** master
 *** master


### PR DESCRIPTION
## Summary
- document that the offset=180 batch already uses ConfigRepository for legacy config entries
- record the batch result (0 replacements) in the rollout status CSV and lint log

## Testing
- php -l public/ajax/ajax_tooltips.php
- php -l public/ajax/autocomplete.php
- php -l public/ajax/member_input.php
- php -l public/ajax/rating.php
- php -l public/ajax/take_upload.php
- php -l public/ajax/take_url_upload.php
- php -l public/ajax/thanks.php
- php -l public/ajax/torrents_lookup.php
- php -l public/ajax/view_sql.php
- php -l public/allsmiles.php

------
https://chatgpt.com/codex/tasks/task_e_68cfa33c2c1c832594d3ed866a15b80f