### PR TITLE
Refine config defaults for index widgets

### DIFF
--- a/blocks/index/forum_posts.php
+++ b/blocks/index/forum_posts.php
@@ -1,25 +1,24 @@
 <?php
-
 declare(strict_types=1);
 
 require_once __DIR__ . '/../../include/runtime_safe.php';
-
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
-use PU239\Config\ConfigRepository;
 
+/** @var \DI\Container $container */
 global $container, $CURUSER;
 
 $db = $container->get(Database::class);
 $cache = $container->get(Cache::class);
 /** @var ConfigRepository $config */
 $config = $container->get(ConfigRepository::class);
-$latestPostsLimit = (int) $config->get('latest.posts_limit');
-$latestPostsExpire = (int) $config->get('expires.latestposts');
-$baseurl = (string) $config->get('paths.baseurl');
-$imagesBaseurl = (string) $config->get('paths.images_baseurl');
+$latestPostsLimit = max(1, $config->int('latest.posts_limit', 15));
+$latestPostsExpire = max(60, $config->int('expires.latestposts', 300));
+$baseurl = rtrim($config->str('paths.baseurl', ''), '/');
+$imagesBaseurl = rtrim($config->str('paths.images_baseurl', '/images'), '/') . '/';
 
 $forum_posts .= "
     <a id='latestforum-hash'></a>
@@ -112,9 +111,9 @@ if (!empty($topics) && is_array($topics)) {
         } else {
             $author = !empty($topicarr['tuser_id']) ? format_username((int) $topicarr['tuser_id']) : ($topicarr['tuser_id'] == '0' ? '<i>System</i>' : '<i>' . _('Unknown') . " [{$topicarr['tuser_id']}]</i>");
         }
-        $staffimg = $topicarr['min_class_read'] >= UC_STAFF ? "<img src='" . $imagesBaseurl . "staff.png' alt='Staff forum' class='tooltipper' title='Staff Forum'>" : '';
-        $stickyimg = $topicarr['sticky'] === 'yes' ? "<img src='" . $imagesBaseurl . "sticky.gif' alt='" . _('Sticky') . "' class='tooltipper right5 left5' title='" . _('Sticky Topic') . "'>" : '';
-        $lockedimg = $topicarr['locked'] === 'yes' ? "<img src='" . $imagesBaseurl . "forumicons/locked.gif' alt='" . _('Locked') . "' class='tooltipper right5' title='" . _('Locked Topic') . "'>" : '';
+        $staffimg = $topicarr['min_class_read'] >= UC_STAFF ? "<img src='{$imagesBaseurl}staff.png' alt='Staff forum' class='tooltipper' title='Staff Forum'>" : '';
+        $stickyimg = $topicarr['sticky'] === 'yes' ? "<img src='{$imagesBaseurl}sticky.gif' alt='" . _('Sticky') . "' class='tooltipper right5 left5' title='" . _('Sticky Topic') . "'>" : '';
+        $lockedimg = $topicarr['locked'] === 'yes' ? "<img src='{$imagesBaseurl}forumicons/locked.gif' alt='" . _('Locked') . "' class='tooltipper right5' title='" . _('Locked Topic') . "'>" : '';
         $topic_name = "<div class='level-left'>{$lockedimg}{$stickyimg}<a href='{$baseurl}/forums.php?action=view_topic&amp;topic_id=$topicid&amp;page=last#" . (int) $topicarr['last_post'] . "'><span class='torrent-name'>" . format_comment($topicarr['topic_name']) . "</span></a>{$staffimg}{$menu}</div><span class='size_3'>" . _fe('in {0} by {1} ({2})', "<a href='{$baseurl}/forums.php?action=view_forum&amp;forum_id=" . (int) $topicarr['forum_id'] . "'>" . format_comment($topicarr['name']) . '</a>', $author, $added) . '</span>';
         $forum_posts .= "
                     <tr>

--- a/blocks/index/latest_movies.php
+++ b/blocks/index/latest_movies.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../include/runtime_safe.php';
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
-use PU239\Config\ConfigRepository;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
 $user = check_user_status();
+/** @var \DI\Container $container */
 global $container;
 
 $db = $container->get(Database::class);
 $torrent = $container->get(Torrent::class);
 /** @var ConfigRepository $config */
 $config = $container->get(ConfigRepository::class);
-$movieCategories = $config->get('categories.movie');
-$imagesBaseurl = (string) $config->get('paths.images_baseurl');
+$movieCategories = $config->arr('categories.movie', ['Movie']);
+$imagesBaseurl = rtrim($config->str('paths.images_baseurl', '/images'), '/') . '/';
 $last5movietorrents = $torrent->get_latest($movieCategories);
 
 $latest_movies .= "

--- a/blocks/index/latest_tv.php
+++ b/blocks/index/latest_tv.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../include/runtime_safe.php';
 require_once __DIR__ . '/../../include/bootstrap_pdo.php';
 
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Image;
 use Pu239\Torrent;
-use PU239\Config\ConfigRepository;
 
 require_once PARTIALS_DIR . 'torrent_table.php';
+$user = check_user_status();
+/** @var \DI\Container $container */
 global $container, $CURUSER;
 
 $db = $container->get(Database::class);
 $torrent = $container->get(Torrent::class);
 /** @var ConfigRepository $config */
 $config = $container->get(ConfigRepository::class);
-$tvCategories = $config->get('categories.tv');
-$imagesBaseurl = (string) $config->get('paths.images_baseurl');
+$tvCategories = $config->arr('categories.tv', ['TV']);
+$imagesBaseurl = rtrim($config->str('paths.images_baseurl', '/images'), '/') . '/';
 $last5tvtorrents = $torrent->get_latest($tvCategories);
 
 $latest_tv .= "

--- a/config/categories.php
+++ b/config/categories.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 return [
-    // Used by latest movie/TV widgets; adjust to your actual category names.
     'movie' => ['Movie'],
     'tv'    => ['TV'],
 ];

--- a/config/expires.php
+++ b/config/expires.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 
 return [
-    'latestposts' => 300, // seconds
+    'latestposts' => 300,
 ];

--- a/include/config_compat.php
+++ b/include/config_compat.php
@@ -1,15 +1,46 @@
 <?php
 declare(strict_types=1);
 
-use PU239\Config\ConfigRepository;
+use Pu239\Config\ConfigRepository;
 use Psr\Log\LoggerInterface;
 
+/** @var \DI\Container $container */
 if (!isset($container) || !$container->has(ConfigRepository::class)) {
     return;
 }
 
 /** @var ConfigRepository $config */
 $config = $container->get(ConfigRepository::class);
+$compat = [];
+
+// Legacy constants → new keys (only if missing)
+if (defined('SITE_URL') && $config->get('app.url') === null) {
+    $compat['app']['url'] = (string) SITE_URL;
+}
+if (defined('SQL_DEBUG') && $config->get('app.debug') === null) {
+    $compat['app']['debug'] = (bool) SQL_DEBUG;
+}
+if (defined('COOKIE_DOMAIN') && $config->get('security.cookies.domain') === null) {
+    $compat['security']['cookies']['domain'] = (string) COOKIE_DOMAIN;
+}
+if (defined('ANNOUNCE_URL') && $config->get('app.announce_url') === null) {
+    $compat['app']['announce_url'] = (string) ANNOUNCE_URL;
+}
+
+// Web path fallbacks (seed only if absent) — DO NOT touch config/paths.php
+if ($config->get('paths.baseurl') === null) {
+    $compat['paths']['baseurl'] = '/';
+}
+if ($config->get('paths.images_baseurl') === null) {
+    $compat['paths']['images_baseurl'] = '/images';
+}
+if ($config->get('paths.avatars_baseurl') === null) {
+    $compat['paths']['avatars_baseurl'] = '/images/avatars';
+}
+
+if (!empty($compat)) {
+    $config->merge($compat);
+}
 $logger = null;
 if ($container->has(LoggerInterface::class)) {
     $logger = $container->get(LoggerInterface::class);

--- a/tools/configrepo_rollout_lint.txt
+++ b/tools/configrepo_rollout_lint.txt
@@ -206,3 +206,8 @@ Deprecated: Pu239\Torrent::remove_torrent(): Implicitly marking parameter $owner
 Deprecated: Pu239\Torrent::remove_torrent(): Implicitly marking parameter $added as nullable is deprecated, the explicit nullable type must be used instead in src/Torrent.php on line 348
 No syntax errors detected in src/Torrent.php
 No syntax errors detected in src/Uglify/UglifyService.php
+No syntax errors detected in classes/Config/ConfigRepository.php
+No syntax errors detected in include/config_compat.php
+No syntax errors detected in blocks/index/latest_movies.php
+No syntax errors detected in blocks/index/latest_tv.php
+No syntax errors detected in blocks/index/forum_posts.php


### PR DESCRIPTION
## Summary
- ensure ConfigRepository is wired for legacy constant fallbacks and web path defaults via config_compat
- rely on typed accessors for latest movie/TV/forum blocks with safe fallbacks for categories and asset paths
- document successful lint runs in the rollout log and standardize config category/expiry defaults

## Testing
- php -l classes/Config/ConfigRepository.php
- php -l include/config_compat.php
- php -l blocks/index/latest_movies.php
- php -l blocks/index/latest_tv.php
- php -l blocks/index/forum_posts.php

------
https://chatgpt.com/codex/tasks/task_e_68cfc04c701c83258722406d4b9e2abe