### PR TITLE
refactor: replace legacy constants/$site_config → ConfigRepository (batch offset=220)

### DIFF
--- a/forums/editor.php
+++ b/forums/editor.php
@@ -1,6 +1,14 @@
 <?php
 declare(strict_types=1);
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
+
 require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 $user = check_user_status();
 $subscribe = empty($subscribe) ? 'no' : $subscribe;
@@ -13,7 +21,7 @@ $edit = (preg_match('/edit_post/', $_SERVER['QUERY_STRING']) ? '
 		<td>
 			<input type='text' maxlength='60' name='edit_reason' value='" . trim(strip_tags($edit_reason)) . "' class='w-100' placeholder='Optional'>
 		</td>
-	</tr>" . (has_access($user['class'], $site_config['allowed']['show_edited_by'], 'coder') || $user['id'] === $arr_post['id'] ? "
+	</tr>" . (has_access($user['class'], $config->get('allowed.show_edited_by'), 'coder') || $user['id'] === $arr_post['id'] ? "
 	<tr>
 		<td>Edited By</td>
 		<td>
@@ -30,91 +38,91 @@ $HTMLOUT .= main_table('
             <td>
                 <div class="level-center">
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/smile1.gif" alt="' . _('Smile') . '" title="' . _('Smile') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/smile1.gif" alt="' . _('Smile') . '" title="' . _('Smile') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="smile1" ' . ($icon === 'smile1' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/grin.gif" alt="' . _('Grin') . '" title="' . _('Grin') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/grin.gif" alt="' . _('Grin') . '" title="' . _('Grin') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="grin" ' . ($icon === 'grin' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/tongue.gif" alt="' . _('Tongue') . '" title="' . _('Tongue') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/tongue.gif" alt="' . _('Tongue') . '" title="' . _('Tongue') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="tongue" ' . ($icon === 'tongue' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/cry.gif" alt="' . _('Cry') . '" title="' . _('Cry') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/cry.gif" alt="' . _('Cry') . '" title="' . _('Cry') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="cry" ' . ($icon === 'cry' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/wink.gif" alt="' . _('Wink') . '" title="' . _('Wink') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/wink.gif" alt="' . _('Wink') . '" title="' . _('Wink') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="wink" ' . ($icon === 'wink' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/rolleyes.gif" alt="' . _('Roll eyes') . '" title="' . _('Roll eyes') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/rolleyes.gif" alt="' . _('Roll eyes') . '" title="' . _('Roll eyes') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="rolleyes" ' . ($icon === 'rolleyes' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/blink.gif" alt="' . _('Blink') . '" title="' . _('Blink') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/blink.gif" alt="' . _('Blink') . '" title="' . _('Blink') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="blink" ' . ($icon === 'blink' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/bow.gif" alt="' . _('Bow') . '" title="' . _('Bow') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/bow.gif" alt="' . _('Bow') . '" title="' . _('Bow') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="bow" ' . ($icon === 'bow' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/clap2.gif" alt="' . _('Clap') . '" title="' . _('Clap') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/clap2.gif" alt="' . _('Clap') . '" title="' . _('Clap') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="clap2" ' . ($icon === 'clap2' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/hmmm.gif" alt="' . _('Hmm') . '" title="' . _('Hmm') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/hmmm.gif" alt="' . _('Hmm') . '" title="' . _('Hmm') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="hmmm" ' . ($icon === 'hmmm' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/devil.gif" alt="' . _('Devil') . '" title="' . _('Devil') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/devil.gif" alt="' . _('Devil') . '" title="' . _('Devil') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="devil" ' . ($icon === 'devil' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/angry.gif" alt="' . _('Angry') . '" title="' . _('Angry') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/angry.gif" alt="' . _('Angry') . '" title="' . _('Angry') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="angry" ' . ($icon === 'angry' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/shit.gif" alt="' . _('Shit') . '" title="' . _('Shit') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/shit.gif" alt="' . _('Shit') . '" title="' . _('Shit') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="shit" ' . ($icon === 'shit' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/sick.gif" alt="' . _('Sick') . '" title="' . _('Sick') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/sick.gif" alt="' . _('Sick') . '" title="' . _('Sick') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="sick" ' . ($icon === 'sick' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/tease.gif" alt="' . _('Tease') . '" title="' . _('Tease') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/tease.gif" alt="' . _('Tease') . '" title="' . _('Tease') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="tease" ' . ($icon === 'tease' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/love.gif" alt="' . _('Love') . '" title="' . _('Love') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/love.gif" alt="' . _('Love') . '" title="' . _('Love') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="love" ' . ($icon === 'love' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/ohmy.gif" alt="' . _('Oh my') . '" title="' . _('Oh my') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/ohmy.gif" alt="' . _('Oh my') . '" title="' . _('Oh my') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="ohmy" ' . ($icon === 'ohmy' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/yikes.gif" alt="' . _('Yikes') . '" title="' . _('Yikes') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/yikes.gif" alt="' . _('Yikes') . '" title="' . _('Yikes') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="yikes" ' . ($icon === 'yikes' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/spider.gif" alt="' . _('Spider') . '" title="' . _('Spider') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/spider.gif" alt="' . _('Spider') . '" title="' . _('Spider') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="spider" ' . ($icon === 'spider' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/wall.gif" alt="' . _('Wall') . '" title="' . _('Wall') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/wall.gif" alt="' . _('Wall') . '" title="' . _('Wall') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="wall" ' . ($icon === 'wall' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/idea.gif" alt="' . _('Idea') . '" title="' . _('Idea') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/idea.gif" alt="' . _('Idea') . '" title="' . _('Idea') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="idea" ' . ($icon === 'idea' ? 'checked' : '') . '>
                     </span>
                     <span class="level-center flex-vertical margin10">
-                        <img src="' . $site_config['paths']['images_baseurl'] . 'smilies/question.gif" alt="' . _('Question') . '" title="' . _('Question') . '" class="tooltipper icon bottom10">
+                        <img src="' . $config->get('paths.images_baseurl') . 'smilies/question.gif" alt="' . _('Question') . '" title="' . _('Question') . '" class="tooltipper icon bottom10">
                         <input type="radio" name="icon" value="question" ' . ($icon === 'question' ? 'checked' : '') . '>
                     </span>
                 </div>

--- a/forums/last_ten.php
+++ b/forums/last_ten.php
@@ -1,13 +1,19 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
-global $site_config, $CURUSER;
+global $CURUSER;
 
 $limit = preg_match('/edit_post/', $_SERVER['QUERY_STRING']) ? '1, 10' : '10';
-$res_posts = sql_query('SELECT p.id AS post_id, p.user_id, p.added, p.body, p.icon, p.post_title, p.bbcode, p.anonymous, u.id, u.username, u.class, u.donor, u.warned, u.status, u.avatar, u.chatpost, u.leechwarn, u.pirate, u.king, u.offensive_avatar FROM posts AS p LEFT JOIN users AS u ON p.user_id=u.id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND' : ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class'] ? 'p.status != \'deleted\' AND' : '')) . '  topic_id=' . sqlesc($topic_id) . ' ORDER BY p.id DESC LIMIT ' . $limit) or sqlerr(__FILE__, __LINE__);
+$res_posts = sql_query('SELECT p.id AS post_id, p.user_id, p.added, p.body, p.icon, p.post_title, p.bbcode, p.anonymous, u.id, u.username, u.class, u.donor, u.warned, u.status, u.avatar, u.chatpost, u.leechwarn, u.pirate, u.king, u.offensive_avatar FROM posts AS p LEFT JOIN users AS u ON p.user_id=u.id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND' : ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class') ? 'p.status != \'deleted\' AND' : '')) . '  topic_id=' . sqlesc($topic_id) . ' ORDER BY p.id DESC LIMIT ' . $limit) or sqlerr(__FILE__, __LINE__);
 $HTMLOUT .= '<h2 class="has-text-centered">' . _('last ten posts in reverse order') . '</h2>';
 
 while ($arr = mysqli_fetch_assoc($res_posts)) {

--- a/forums/mark_all_as_read.php
+++ b/forums/mark_all_as_read.php
@@ -1,11 +1,17 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 $user = check_user_status();
 if ($_GET['action'] === 'mark_all_as_read') {
@@ -99,9 +105,9 @@ function mark_as_unread(array $user)
  */
 function get_topics()
 {
-    global $container, $site_config;
+    global $container, $config;
 
-    $dt = TIME_NOW - ($site_config['forum_config']['readpost_expiry'] * 86400);
+    $dt = TIME_NOW - ($config->get('forum_config.readpost_expiry') * 86400);
     // $fluent removed — use $this->db (ExtendedPdo)
     $query = $fluent->from('topics AS t')
                     ->select(null)

--- a/forums/member_post_history.php
+++ b/forums/member_post_history.php
@@ -1,11 +1,17 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\User;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
 global $container;
-$db = $container->get(Database::class);, $site_config, $CURUSER;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
+$db = $container->get(Database::class);
+global $CURUSER;
 
 $users_class = $container->get(User::class);
 $colour = $post_status_image = $option = $next = '';
@@ -76,7 +82,7 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
                 <ul>' : '';
         $active = !empty($_GET['letter']) && $_GET['letter'] === $L ? "class='active'" : '';
         $next .= " <li>
-						<a href='{$site_config['paths']['baseurl']}/forums.php?action=member_post_history&amp;letter=" . $L . "' {$active}>" . $L . '</a>
+						<a href='{$config->get('paths.baseurl')}/forums.php?action=member_post_history&amp;letter=" . $L . "' {$active}>" . $L . '</a>
 					</li>';
         ++$count;
     }
@@ -90,7 +96,7 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
     $res_count = sql_query('SELECT COUNT(id) FROM users WHERE ' . $query) or sqlerr(__FILE__, __LINE__);
     $arr_count = mysqli_fetch_row($res_count);
     $count = ($arr_count[0] > 0 ? (int) $arr_count[0] : 0);
-    $link = $site_config['paths']['baseurl'] . "/forums.php?action=member_post_history&amp;letter={$letter}&amp;";
+    $link = $config->get('paths.baseurl') . "/forums.php?action=member_post_history&amp;letter={$letter}&amp;";
     $pager = pager($perpage, $count, $link);
     $menu_top = $pager['pagertop'];
     $menu_bottom = $pager['pagerbottom'];
@@ -109,7 +115,7 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
 			</tr>';
         $body = '';
         while ($row = mysqli_fetch_assoc($res)) {
-            $country = ($row['name'] != null) ? '<img src="' . $site_config['paths']['images_baseurl'] . 'flag/' . $row['flagpic'] . '" alt="' . htmlsafechars((string) $row['name']) . '" class="emoticon">' : '---';
+            $country = ($row['name'] != null) ? '<img src="' . $config->get('paths.images_baseurl') . 'flag/' . $row['flagpic'] . '" alt="' . htmlsafechars((string) $row['name']) . '" class="emoticon">' : '---';
             $body .= '
 			<tr>
 				<td>' . format_username((int) $row['id']) . '</td>
@@ -118,7 +124,7 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
 				<td>' . get_user_class_name((int) $row['class']) . '</td>
 				<td>' . $country . '</td>
 				<td>
-					<a href="' . $site_config['paths']['baseurl'] . '/forums.php?action=member_post_history&amp;id=' . (int) $row['id'] . '" title="see this members post history" class="is-link">' . _('Post History') . '</a>
+					<a href="' . $config->get('paths.baseurl') . '/forums.php?action=member_post_history&amp;id=' . (int) $row['id'] . '" title="see this members post history" class="is-link">' . _('Post History') . '</a>
 				</td>
 			</tr>';
         }
@@ -128,31 +134,31 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
     }
     $HTMLOUT .= ($count > $perpage ? $menu_bottom : '');
 } else {
-    $res_count = sql_query('SELECT COUNT(p.id) AS count FROM posts AS p LEFT JOIN topics AS t ON p.topic_id = t.id LEFT JOIN forums AS f ON f.id = t.forum_id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class'] ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' p.user_id=' . sqlesc($member_id) . ' AND f.min_class_read <= ' . $CURUSER['class']) or sqlerr(__FILE__, __LINE__);
+    $res_count = sql_query('SELECT COUNT(p.id) AS count FROM posts AS p LEFT JOIN topics AS t ON p.topic_id = t.id LEFT JOIN forums AS f ON f.id = t.forum_id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class') ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' p.user_id=' . sqlesc($member_id) . ' AND f.min_class_read <= ' . $CURUSER['class']) or sqlerr(__FILE__, __LINE__);
     $arr_count = mysqli_fetch_row($res_count);
     $count = (int) $arr_count[0];
     $page = isset($_GET['page']) ? (int) $_GET['page'] : 0;
     $perpage = isset($_GET['perpage']) ? (int) $_GET['perpage'] : 20;
-    $subscription_on_off = (isset($_GET['s']) ? ($_GET['s'] == 1 ? '<br><div style="font-weight: bold;">' . _('Subscribed to topic') . ' <img src="' . $site_config['paths']['images_baseurl'] . 'forums/subscribe.gif" alt="" class="emoticon"></div>' : '<br><div style="font-weight: bold;">' . _('Unsubscribed from topic') . ' <img src="' . $site_config['paths']['images_baseurl'] . 'forums/unsubscribe.gif" alt="" class="emoticon"></div>') : '');
-    $link = $site_config['paths']['baseurl'] . "/forums.php?action=member_post_history&amp;id={$member_id}&amp;" . (isset($_GET['perpage']) ? "perpage={$perpage}&amp;" : '');
+    $subscription_on_off = (isset($_GET['s']) ? ($_GET['s'] == 1 ? '<br><div style="font-weight: bold;">' . _('Subscribed to topic') . ' <img src="' . $config->get('paths.images_baseurl') . 'forums/subscribe.gif" alt="" class="emoticon"></div>' : '<br><div style="font-weight: bold;">' . _('Unsubscribed from topic') . ' <img src="' . $config->get('paths.images_baseurl') . 'forums/unsubscribe.gif" alt="" class="emoticon"></div>') : '');
+    $link = $config->get('paths.baseurl') . "/forums.php?action=member_post_history&amp;id={$member_id}&amp;" . (isset($_GET['perpage']) ? "perpage={$perpage}&amp;" : '');
     $pager = pager($perpage, $count, $link);
     $menu_top = $pager['pagertop'];
     $menu_bottom = $pager['pagerbottom'];
     $LIMIT = $pager['limit'];
 
-    $rows = $db->fetchAll('SELECT p.id AS post_id, p.topic_id, p.user_id, p.added, p.body, p.edited_by, p.edit_date, p.icon, p.post_title, p.bbcode, p.post_history, p.edit_reason, p.status AS post_status, p.anonymous, t.id AS topic_id, t.topic_name, t.forum_id, t.sticky, t.locked, t.poll_id, t.status AS topic_status, f.name AS forum_name, f.description FROM posts AS p LEFT JOIN topics AS t ON p.topic_id=t.id LEFT JOIN forums AS f ON f.id=t.forum_id WHERE  ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class'] ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' p.user_id=' . sqlesc($member_id) . ' AND f.min_class_read <= ' . $CURUSER['class'] . ' ORDER BY p.id ' . $ASC_DESC . $LIMIT) or sqlerr(__FILE__, __LINE__);
+    $rows = $db->fetchAll('SELECT p.id AS post_id, p.topic_id, p.user_id, p.added, p.body, p.edited_by, p.edit_date, p.icon, p.post_title, p.bbcode, p.post_history, p.edit_reason, p.status AS post_status, p.anonymous, t.id AS topic_id, t.topic_name, t.forum_id, t.sticky, t.locked, t.poll_id, t.status AS topic_status, f.name AS forum_name, f.description FROM posts AS p LEFT JOIN topics AS t ON p.topic_id=t.id LEFT JOIN forums AS f ON f.id=t.forum_id WHERE  ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class') ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' p.user_id=' . sqlesc($member_id) . ' AND f.min_class_read <= ' . $CURUSER['class'] . ' ORDER BY p.id ' . $ASC_DESC . $LIMIT) or sqlerr(__FILE__, __LINE__);
     if ($count === 0) {
         $breadcrumbs = [
-            "<a href='{$site_config['paths']['baseurl']}/forums.php'>" . _('Forums') . '</a>',
-            "<a href='{$site_config['paths']['baseurl']}/forums.php?action=member_post_history'>" . _('Member Post History') . '</a>',
-            "<a href='{$site_config['paths']['baseurl']}/forums.php?action=member_post_history&id={$member_id}'>" . _('Error') . '</a>',
+            "<a href='{$config->get('paths.baseurl')}/forums.php'>" . _('Forums') . '</a>',
+            "<a href='{$config->get('paths.baseurl')}/forums.php?action=member_post_history'>" . _('Member Post History') . '</a>',
+            "<a href='{$config->get('paths.baseurl')}/forums.php?action=member_post_history&id={$member_id}'>" . _('Error') . '</a>',
         ];
         stderr(_('Sorry'), (!empty($member_id) ? _fe('{0} has no posts to look at!', format_username((int) $member_id)) : _('Invalid ID')), '', '', $breadcrumbs);
     }
     $HTMLOUT .= $mini_menu . '<h1 class="has-text-centered">' . $count . ' ' . _('Posts by') . ' ' . format_username((int) $member_id) . '</h1>
             <ul class="level-center bottom20">
                 <li>
-                    <a href="' . $site_config['paths']['baseurl'] . '/forums.php?action=member_post_history&amp;id=' . $member_id . '" class="button is-small tooltipper" title="' . _('view posts from newest to oldest') . '">' . _('Sort by newest posts first') . '</a>
+                    <a href="' . $config->get('paths.baseurl') . '/forums.php?action=member_post_history&amp;id=' . $member_id . '" class="button is-small tooltipper" title="' . _('view posts from newest to oldest') . '">' . _('Sort by newest posts first') . '</a>
                 </li>
                 <li>
                     <a href="forums.php?action=member_post_history&amp;id=' . $member_id . '&amp;ASC_DESC=ASC" class="button is-small tooltipper" title="' . _('view posts from oldest to newest') . '">' . _('Sort by oldest posts first') . '</a>
@@ -168,11 +174,11 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
                 break;
 
             case 'recycled':
-                $topic_status_image = '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/recycle_bin.gif" alt="' . _('Recycled') . '" title="' . _('This thread is currently') . ' ' . _('in the recycle-bin') . '" class="emoticon">';
+                $topic_status_image = '<img src="' . $config->get('paths.images_baseurl') . 'forums/recycle_bin.gif" alt="' . _('Recycled') . '" title="' . _('This thread is currently') . ' ' . _('in the recycle-bin') . '" class="emoticon">';
                 break;
 
             case 'deleted':
-                $topic_status_image = '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/delete_icon.gif" alt="' . _('Deleted') . '" title="' . _('This thread is currently') . ' ' . _('Deleted') . '" class="emoticon">';
+                $topic_status_image = '<img src="' . $config->get('paths.images_baseurl') . 'forums/delete_icon.gif" alt="' . _('Deleted') . '" title="' . _('This thread is currently') . ' ' . _('Deleted') . '" class="emoticon">';
                 break;
         }
         //=== post status
@@ -185,20 +191,20 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
 
             case 'recycled':
                 $post_status = 'recycled';
-                $post_status_image = ' <img src="' . $site_config['paths']['images_baseurl'] . 'forums/recycle_bin.gif" alt="' . _('Recycled') . '" title="' . _('This post is currently') . ' ' . _('in the recycle-bin') . '" class="emoticon">';
+                $post_status_image = ' <img src="' . $config->get('paths.images_baseurl') . 'forums/recycle_bin.gif" alt="' . _('Recycled') . '" title="' . _('This post is currently') . ' ' . _('in the recycle-bin') . '" class="emoticon">';
                 break;
 
             case 'deleted':
                 $post_status = 'deleted';
-                $post_status_image = ' <img src="' . $site_config['paths']['images_baseurl'] . 'forums/delete_icon.gif" alt="' . _('Deleted') . '" title="' . _('This post is currently') . ' ' . _('Deleted') . '" class="emoticon">';
+                $post_status_image = ' <img src="' . $config->get('paths.images_baseurl') . 'forums/delete_icon.gif" alt="' . _('Deleted') . '" title="' . _('This post is currently') . ' ' . _('Deleted') . '" class="emoticon">';
                 break;
 
             case 'postlocked':
                 $post_status = 'postlocked';
-                $post_status_image = ' <img src="' . $site_config['paths']['images_baseurl'] . 'forums/thread_locked.gif" alt="' . _('Locked') . '" title="' . _('This post is currently') . ' ' . _('Locked') . '" class="emoticon">';
+                $post_status_image = ' <img src="' . $config->get('paths.images_baseurl') . 'forums/thread_locked.gif" alt="' . _('Locked') . '" title="' . _('This post is currently') . ' ' . _('Locked') . '" class="emoticon">';
                 break;
         }
-        $post_icon = (!empty($arr['icon']) ? '<img src="' . $site_config['paths']['images_baseurl'] . 'smilies/' . htmlsafechars((string) $arr['icon']) . '.gif" alt="icon" class="emoticon"> ' : '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic_normal.gif" alt="icon" class="emoticon"> ');
+        $post_icon = (!empty($arr['icon']) ? '<img src="' . $config->get('paths.images_baseurl') . 'smilies/' . htmlsafechars((string) $arr['icon']) . '.gif" alt="icon" class="emoticon"> ' : '<img src="' . $config->get('paths.images_baseurl') . 'forums/topic_normal.gif" alt="icon" class="emoticon"> ');
         $post_title = (!empty($arr['post_title']) ? ' <span style="font-weight: bold; font-size: x-small;">' . htmlsafechars((string) $arr['post_title']) . '</span>' : '' . _('Link to Post') . '');
         $edited_by = '';
         if ($arr['edit_date'] > 0) {
@@ -209,16 +215,16 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
                 if ($CURUSER['class'] < UC_STAFF && $arr['user_id'] != $CURUSER['id']) {
                     $edited_by = '<br><br><br><span style="font-weight: bold; font-size: x-small;">' . _('Last edited by Anonymous') . '
 				 at ' . get_date((int) $arr['edit_date'], '') . ' GMT ' . ($arr['edit_reason'] !== '' ? ' </span>[ ' . _('Reason') . ': ' . htmlsafechars((string) $arr['edit_reason']) . ' ] <span style="font-weight: bold; font-size: x-small;">' : '') . '
-				 ' . (($CURUSER['class'] >= UC_STAFF && $arr['post_history'] !== '') ? ' <a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_post_history&amp;post_id=' . (int) $arr['post_id'] . '&amp;forum_id=' . (int) $arr['forum_id'] . '&amp;topic_id=' . (int) $arr['topic_id'] . '">' . _('read post history') . '</a></span><br>' : '</span>');
+				 ' . (($CURUSER['class'] >= UC_STAFF && $arr['post_history'] !== '') ? ' <a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_post_history&amp;post_id=' . (int) $arr['post_id'] . '&amp;forum_id=' . (int) $arr['forum_id'] . '&amp;topic_id=' . (int) $arr['topic_id'] . '">' . _('read post history') . '</a></span><br>' : '</span>');
                 } else {
                     $edited_by = '<br><br><br><span style="font-weight: bold; font-size: x-small;">' . _('Last edited by Anonymous') . ' [' . format_username((int) $arr['edited_by']) . ']
 				 at ' . get_date((int) $arr['edit_date'], '') . ' GMT ' . ($arr['edit_reason'] !== '' ? ' </span>[ ' . _('Reason') . ': ' . htmlsafechars((string) $arr['edit_reason']) . ' ] <span style="font-weight: bold; font-size: x-small;">' : '') . '
-				 ' . (($CURUSER['class'] >= UC_STAFF && $arr['post_history'] !== '') ? ' <a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_post_history&amp;post_id=' . (int) $arr['post_id'] . '&amp;forum_id=' . (int) $arr['forum_id'] . '&amp;topic_id=' . (int) $arr['topic_id'] . '">' . _('read post history') . '</a></span><br>' : '</span>');
+				 ' . (($CURUSER['class'] >= UC_STAFF && $arr['post_history'] !== '') ? ' <a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_post_history&amp;post_id=' . (int) $arr['post_id'] . '&amp;forum_id=' . (int) $arr['forum_id'] . '&amp;topic_id=' . (int) $arr['topic_id'] . '">' . _('read post history') . '</a></span><br>' : '</span>');
                 }
             } else {
                 $edited_by = '<br><br><br><span style="font-weight: bold; font-size: x-small;">' . _('Last edited by') . ' ' . format_username((int) $arr['edited_by']) . '
 				 at ' . get_date((int) $arr['edit_date'], '') . ' GMT ' . ($arr['edit_reason'] !== '' ? ' </span>[ ' . _('Reason') . ': ' . htmlsafechars((string) $arr['edit_reason']) . ' ] <span style="font-weight: bold; font-size: x-small;">' : '') . '
-				 ' . (($CURUSER['class'] >= UC_STAFF && $arr['post_history'] !== '') ? ' <a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_post_history&amp;post_id=' . (int) $arr['post_id'] . '&amp;forum_id=' . (int) $arr['forum_id'] . '&amp;topic_id=' . (int) $arr['topic_id'] . '">' . _('read post history') . '</a></span><br>' : '</span>');
+				 ' . (($CURUSER['class'] >= UC_STAFF && $arr['post_history'] !== '') ? ' <a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_post_history&amp;post_id=' . (int) $arr['post_id'] . '&amp;forum_id=' . (int) $arr['forum_id'] . '&amp;topic_id=' . (int) $arr['topic_id'] . '">' . _('read post history') . '</a></span><br>' : '</span>');
             }
             //==
         }
@@ -240,8 +246,8 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
 		<a class="is-link" href="forums.php?action=view_topic&amp;topic_id=' . (int) $arr['topic_id'] . '&amp;page = ' . $page . '#' . (int) $arr['post_id'] . '" title="' . _('Link to Post') . '">
 		' . $post_title . ' </a>&nbsp;&nbsp;' . $post_status_image . ' &nbsp;&nbsp; ' . _('Posted') . ': ' . get_date((int) $arr['added'], '') . ' [' . get_date((int) $arr['added'], '', 0, 1) . ']</span></td>
 		<td class="forum_head"><span style="white-space:nowrap;">
-		<a href="forums.php?action=view_my_posts&amp;page=' . $page . '#top"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/up.gif" alt = "' . _('Top') . '" class="emoticon"></a>
-		<a href="forums.php?action=view_my_posts&amp;page=' . $page . '#bottom"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/down.gif" alt = "' . _('Bottom') . '" class="emoticon"></a></span></td>
+		<a href="forums.php?action=view_my_posts&amp;page=' . $page . '#top"><img src="' . $config->get('paths.images_baseurl') . 'forums/up.gif" alt = "' . _('Top') . '" class="emoticon"></a>
+		<a href="forums.php?action=view_my_posts&amp;page=' . $page . '#bottom"><img src="' . $config->get('paths.images_baseurl') . 'forums/down.gif" alt = "' . _('Bottom') . '" class="emoticon"></a></span></td>
 		</tr>
 		<tr>
 		<td class="has-text-centered w-15 mw-150">' . get_avatar($arr) . '<br>' . ($arr['anonymous'] === '1' ? '<i>' . get_anonymous_name() . '</i>' : format_username((int) $member_id)) . ($arr['anonymous'] === '1' || empty($user_arr['title']) ? '' : ' <br><span style=" font-size: xx-small;">[' . htmlsafechars((string) $user_arr['title']) . ']</span>') . '<br><span style="font-weight: bold;">' . ($arr['anonymous'] === 'yes' ? '' : get_user_class_name((int) $user_arr['class'])) . ' </span><br></td>
@@ -252,6 +258,6 @@ if (!isset($member_id) || !is_valid_id($member_id)) {
     $HTMLOUT .= ($count > $perpage ? $menu_bottom : '') . ' <a id="bottom"></a>';
 }
 $breadcrumbs = [
-    "<a href='{$site_config['paths']['baseurl']}/forums.php'>" . _('Forums') . '</a>',
-    "<a href='{$site_config['paths']['baseurl']}/forums.php?action=member_post_history'>" . _('Member Post History') . '</a>',
+    "<a href='{$config->get('paths.baseurl')}/forums.php'>" . _('Forums') . '</a>',
+    "<a href='{$config->get('paths.baseurl')}/forums.php?action=member_post_history'>" . _('Member Post History') . '</a>',
 ];

--- a/forums/new_replies.php
+++ b/forums/new_replies.php
@@ -1,14 +1,20 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 $colour = $topicpoll = '';
-global $site_config, $CURUSER;
+global $CURUSER;
 
 $HTMLOUT .= $mini_menu . '<h1 class="has-text-centered">' . _("New replies to threads you've posted in") . '</h1>';
-$res_count = sql_query('SELECT t.id, t.last_post FROM topics AS t LEFT JOIN posts AS p ON t.last_post = p.id LEFT JOIN forums AS f ON f.id=t.forum_id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class'] ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' f.min_class_read <= ' . $CURUSER['class']) or sqlerr(__FILE__, __LINE__);
+$res_count = sql_query('SELECT t.id, t.last_post FROM topics AS t LEFT JOIN posts AS p ON t.last_post = p.id LEFT JOIN forums AS f ON f.id=t.forum_id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class') ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' f.min_class_read <= ' . $CURUSER['class']) or sqlerr(__FILE__, __LINE__);
 $count = 0;
 while ($arr_count = mysqli_fetch_assoc($res_count)) {
     $res_post_read = sql_query('SELECT last_post_read FROM read_posts WHERE user_id=' . sqlesc($CURUSER['id']) . ' AND topic_id=' . sqlesc($arr_count['id'])) or sqlerr(__FILE__, __LINE__);
@@ -27,7 +33,7 @@ if ($count === 0) {
 } else {
     $page = isset($_GET['page']) ? (int) $_GET['page'] : 0;
     $perpage = isset($_GET['perpage']) ? (int) $_GET['perpage'] : 20;
-    $link = $site_config['paths']['baseurl'] . '/forums.php?action=view_unread_posts&amp;' . (isset($_GET['perpage']) ? "perpage={$perpage}&amp;" : '');
+    $link = $config->get('paths.baseurl') . '/forums.php?action=view_unread_posts&amp;' . (isset($_GET['perpage']) ? "perpage={$perpage}&amp;" : '');
     $pager = pager($perpage, $count, $link);
     $menu_top = $pager['pagertop'];
     $menu_bottom = $pager['pagerbottom'];
@@ -40,13 +46,13 @@ if ($count === 0) {
    LEFT JOIN posts AS p ON t.last_post = p.id
    LEFT JOIN forums AS f ON f.id=t.forum_id
    LEFT JOIN users AS u ON u.id=t.user_id
-   WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class'] ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' f.min_class_read <= ' . $CURUSER['class'] . ' 
+   WHERE ' . ($CURUSER['class'] < UC_STAFF ? 'p.status = \'ok\' AND t.status = \'ok\' AND' : ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class') ? 'p.status != \'deleted\' AND t.status != \'deleted\'  AND' : '')) . ' f.min_class_read <= ' . $CURUSER['class'] . ' 
    ORDER BY t.last_post DESC ' . $LIMIT) or sqlerr(__FILE__, __LINE__);
 
     $HTMLOUT .= ($count > $perpage ? $menu_top : '') . '<table class="table table-bordered table-striped">
 	<tr>
-	<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic.gif" class="icon tooltipper" alt="' . _('Topic') . '" title="' . _('Topic') . '"></td>
-	<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic_normal.gif" class="icon tooltipper" alt=' . _('Thread Icon') . '" title=' . _('Thread Icon') . '"></td>
+	<td><img src="' . $config->get('paths.images_baseurl') . 'forums/topic.gif" class="icon tooltipper" alt="' . _('Topic') . '" title="' . _('Topic') . '"></td>
+	<td><img src="' . $config->get('paths.images_baseurl') . 'forums/topic_normal.gif" class="icon tooltipper" alt=' . _('Thread Icon') . '" title=' . _('Thread Icon') . '"></td>
 	<td>' . _('New Posts') . '!</td>
 	<td>' . _('Replies') . '</td>
 	<td>' . _('Views') . '</td>
@@ -76,17 +82,17 @@ if ($count === 0) {
             $rpic = ($arr_unread['num_ratings'] != 0 ? ratingpic_forums(round($arr_unread['rating_sum'] / $arr_unread['num_ratings'], 1)) : '');
             $sub = sql_query('SELECT user_id FROM subscriptions WHERE user_id=' . sqlesc($CURUSER['id']) . ' AND topic_id=' . sqlesc($arr_unread['topic_id'])) or sqlerr(__FILE__, __LINE__);
             $subscriptions = (mysqli_num_rows($sub) > 0 ? 1 : 0);
-            $icon = ($arr_unread['icon'] === '' ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic_normal.gif" class="icon tooltipper" alt="' . _('Topic') . '" title="' . _('Topic') . '">' : '<img src="' . $site_config['paths']['images_baseurl'] . 'smilies/' . htmlsafechars($arr_unread['icon']) . '.gif" class="icon tooltipper" alt="' . htmlsafechars($arr_unread['icon']) . '" title="' . htmlsafechars($arr_unread['icon']) . '">');
+            $icon = ($arr_unread['icon'] === '' ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/topic_normal.gif" class="icon tooltipper" alt="' . _('Topic') . '" title="' . _('Topic') . '">' : '<img src="' . $config->get('paths.images_baseurl') . 'smilies/' . htmlsafechars($arr_unread['icon']) . '.gif" class="icon tooltipper" alt="' . htmlsafechars($arr_unread['icon']) . '" title="' . htmlsafechars($arr_unread['icon']) . '">');
             $first_post_text = bubble("<i class='icon-search icon' aria-hidden='true'></i>", format_comment($arr_unread['body'], true, true, false), '' . _('Last Post') . ' ' . _('Preview') . '');
-            $topic_name = ($sticky ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/pinned.gif" class="icon tooltipper" alt="' . _('Pinned') . '" title="' . _('Pinned') . '"> ' : ' ') . ($topicpoll ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/poll.gif" class="icon tooltipper" alt="' . _('Poll') . '" title="' . _('Poll') . '"> ' : ' ') . ' <a class="is-link" href="?action=view_topic&amp;topic_id=' . (int) $arr_unread['topic_id'] . '" title="' . _('First post in thread') . '">' . htmlsafechars($arr_unread['topic_name']) . '</a><a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=' . (int) $arr_unread['topic_id'] . '&amp;page=0#' . (int) $arr_post_read[0] . '" title="' . _('First unread post in this thread') . '"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/last_post.gif" class="icon tooltipper" alt="First unread post" title="First unread post"></a>' . ($posted ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/posted.gif" class="icon tooltipper" alt="Posted" title="Posted"> ' : ' ') . ($subscriptions ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/subscriptions.gif" class="icon tooltipper" alt="' . _('Subscribed') . '" title="' . _('Subscribed') . '"> ' : ' ') . ' <img src="' . $site_config['paths']['images_baseurl'] . 'forums/new.gif" class="icon tooltipper" alt="' . _('New post in topic') . '!" title="' . _('New post in topic') . '!">';
+            $topic_name = ($sticky ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/pinned.gif" class="icon tooltipper" alt="' . _('Pinned') . '" title="' . _('Pinned') . '"> ' : ' ') . ($topicpoll ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/poll.gif" class="icon tooltipper" alt="' . _('Poll') . '" title="' . _('Poll') . '"> ' : ' ') . ' <a class="is-link" href="?action=view_topic&amp;topic_id=' . (int) $arr_unread['topic_id'] . '" title="' . _('First post in thread') . '">' . htmlsafechars($arr_unread['topic_name']) . '</a><a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_topic&amp;topic_id=' . (int) $arr_unread['topic_id'] . '&amp;page=0#' . (int) $arr_post_read[0] . '" title="' . _('First unread post in this thread') . '"><img src="' . $config->get('paths.images_baseurl') . 'forums/last_post.gif" class="icon tooltipper" alt="First unread post" title="First unread post"></a>' . ($posted ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/posted.gif" class="icon tooltipper" alt="Posted" title="Posted"> ' : ' ') . ($subscriptions ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/subscriptions.gif" class="icon tooltipper" alt="' . _('Subscribed') . '" title="' . _('Subscribed') . '"> ' : ' ') . ' <img src="' . $config->get('paths.images_baseurl') . 'forums/new.gif" class="icon tooltipper" alt="' . _('New post in topic') . '!" title="' . _('New post in topic') . '!">';
             $HTMLOUT .= '<tr>
-		<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/' . $topicpic . '.gif" class="icon tooltipper" alt="' . _('Topic') . '" title="' . _('Topic') . '"></td>
+		<td><img src="' . $config->get('paths.images_baseurl') . 'forums/' . $topicpic . '.gif" class="icon tooltipper" alt="' . _('Topic') . '" title="' . _('Topic') . '"></td>
 		<td>' . $icon . '</td>
 		<td>
             ' . $topic_name . $first_post_text . '
             ' . $rpic . '
     		' . (!empty($arr_unread['topic_desc']) ? '&#9658; <span style="font-size: x-small;">' . htmlsafechars($arr_unread['topic_desc']) . '</span>' : '') . '
-    		<hr>in: <a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_forum&amp;forum_id=' . (int) $arr_unread['forum_id'] . '">' . htmlsafechars($arr_unread['forum_name']) . '</a>
+    		<hr>in: <a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_forum&amp;forum_id=' . (int) $arr_unread['forum_id'] . '">' . htmlsafechars($arr_unread['forum_name']) . '</a>
     		' . (!empty($arr_unread['topic_desc']) ? ' [ <span style="font-size: x-small;">' . htmlsafechars($arr_unread['topic_desc']) . '</span> ]' : '') . '
         </td>
 		<td>' . number_format($arr_unread['post_count'] - 1) . '</td>
@@ -98,6 +104,6 @@ if ($count === 0) {
     $HTMLOUT .= '</table>' . ($count > $perpage ? $menu_bottom : '');
 }
 $breadcrumbs = [
-    "<a href='{$site_config['paths']['baseurl']}/forums.php'>" . _('Forums') . '</a>',
-    "<a href='{$site_config['paths']['baseurl']}/forums.php?action=new_replies'>" . _('New Replies') . '</a>',
+    "<a href='{$config->get('paths.baseurl')}/forums.php'>" . _('Forums') . '</a>',
+    "<a href='{$config->get('paths.baseurl')}/forums.php?action=new_replies'>" . _('New Replies') . '</a>',
 ];

--- a/forums/new_topic.php
+++ b/forums/new_topic.php
@@ -1,16 +1,22 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 flood_limit('forums');
 $forum_id = isset($_GET['forum_id']) ? (int) $_GET['forum_id'] : (isset($_POST['forum_id']) ? (int) $_POST['forum_id'] : 0);
 if (!is_valid_id($forum_id)) {
     stderr(_('Error'), _('Invalid ID'));
 }
-global $container, $CURUSER, $site_config;
+global $CURUSER;
 
 if ($CURUSER['forum_post'] === 'no' || $CURUSER['status'] !== 0) {
     stderr(_('Error'), _('Your posting rights have been suspended.'));
@@ -117,20 +123,20 @@ $db->perform($sql, array_merge($set, ['id' => $topic_id]));
     $sql = "UPDATE forums SET /* columns */ WHERE id = :id";
 $db->perform($sql, array_merge($set, ['id' => $forum_id]));
 
-    if ($site_config['site']['autoshout_chat'] || $site_config['site']['autoshout_irc']) {
-        $message = htmlsafechars($CURUSER['username']) . ' ' . _('Created a new topic') . " [quote][url={$site_config['paths']['baseurl']}/forums.php?action=view_topic&topic_id=$topic_id&page=last]" . $topic_name . '[/url][/quote]';
-        if (!in_array($forum_id, $site_config['staff_forums'])) {
+    if ($config->get('site.autoshout_chat') || $config->get('site.autoshout_irc')) {
+        $message = htmlsafechars($CURUSER['username']) . ' ' . _('Created a new topic') . " [quote][url={$config->get('paths.baseurl')}/forums.php?action=view_topic&topic_id=$topic_id&page=last]" . $topic_name . '[/url][/quote]';
+        if (!in_array($forum_id, $config->get('staff_forums'))) {
             autoshout($message);
         }
     }
-    if ($site_config['bonus']['on']) {
+    if ($config->get('bonus.on')) {
         $set = [
-            'seedbonus' => $CURUSER['seedbonus'] + $site_config['bonus']['per_topic'],
+            'seedbonus' => $CURUSER['seedbonus'] + $config->get('bonus.per_topic'),
         ];
         $sql = "UPDATE users SET /* columns */ WHERE id = :id";
 $db->perform($sql, array_merge($set, ['id' => $CURUSER['id']]));
         $cache->update_row('user_' . $CURUSER['id'], [
-            'seedbonus' => $CURUSER['seedbonus'] + $site_config['bonus']['per_topic'],
+            'seedbonus' => $CURUSER['seedbonus'] + $config->get('bonus.per_topic'),
         ]);
     }
 
@@ -164,8 +170,8 @@ $forum_name = $fluent->from('forums')
 $section_name = htmlsafechars($forum_name);
 
 $HTMLOUT .= '
-    <h1 class="has-text-centered">' . _('New topic in') . ' "<a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_forum&amp;forum_id=' . $forum_id . '">' . $section_name . '</a>"</h1>
-    <form method="post" action="' . $site_config['paths']['baseurl'] . '/forums.php?action=new_topic&amp;forum_id=' . $forum_id . '" enctype="multipart/form-data" accept-charset="utf-8">';
+    <h1 class="has-text-centered">' . _('New topic in') . ' "<a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_forum&amp;forum_id=' . $forum_id . '">' . $section_name . '</a>"</h1>
+    <form method="post" action="' . $config->get('paths.baseurl') . '/forums.php?action=new_topic&amp;forum_id=' . $forum_id . '" enctype="multipart/form-data" accept-charset="utf-8">';
 
 require_once FORUM_DIR . 'editor.php';
 

--- a/forums/poll.php
+++ b/forums/poll.php
@@ -1,8 +1,14 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 $topic_id = isset($_GET['topic_id']) ? (int) $_GET['topic_id'] : (isset($_POST['topic_id']) ? (int) $_POST['topic_id'] : 0);
 if (!is_valid_id($topic_id)) {
@@ -39,7 +45,7 @@ if ($action == 1) {
     stderr(_('Error'), _('Invalid action'));
 }
 //=== casting a vote(s) ===========================================================================================//
-global $CURUSER, $site_config;
+global $CURUSER;
 
 switch ($action) {
     case 'poll_vote':
@@ -101,21 +107,21 @@ switch ($action) {
 		<input type="hidden" name="add_the_poll" value="1">
 	<table>
 	<tr>
-		<td colspan="3"><span style="color: white; font-weight: bold;"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/poll.gif" alt="' . _('Poll') . '" title="' . _('Poll') . '" style="vertical-align: middle;"> ' . _('Add poll to topic') . '!</span></td>
+		<td colspan="3"><span style="color: white; font-weight: bold;"><img src="' . $config->get('paths.images_baseurl') . 'forums/poll.gif" alt="' . _('Poll') . '" title="' . _('Poll') . '" style="vertical-align: middle;"> ' . _('Add poll to topic') . '!</span></td>
 	</tr>
 	<tr>
-		<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/question.png" alt="' . _('Question') . '" title="' . _('Question') . '" width="24" style="vertical-align: middle;"></td>
+		<td><img src="' . $config->get('paths.images_baseurl') . 'forums/question.png" alt="' . _('Question') . '" title="' . _('Question') . '" width="24" style="vertical-align: middle;"></td>
 		<td><span style="white - space:nowrap;font-weight: bold;">' . _('Poll question') . ':</span></td>
 		<td><input type="text" name="poll_question" class="w-100" value=""></td>
 	</tr>
 	<tr>
-		<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/options.gif" alt="' . _('Options') . '" title="' . _('Options') . '" width="24" style="vertical-align: middle;"></td>
+		<td><img src="' . $config->get('paths.images_baseurl') . 'forums/options.gif" alt="' . _('Options') . '" title="' . _('Options') . '" width="24" style="vertical-align: middle;"></td>
 		<td><span style="white - space:nowrap;font-weight: bold;">' . _('Poll answers') . ':</span></td>
 		<td><textarea cols="30" rows="4" name="poll_answers" class="text_area_small"></textarea>
 		<br> ' . _('One option per line. There is a minimum of 2 options, and a maximun of 20 options. BBcode is enabled.') . '</td>
 	</tr>
 	<tr>
-		<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/clock.png" alt="' . _('Clock') . '" title="' . _('Clock') . '" width="30" style="vertical-align: middle;"></td>
+		<td><img src="' . $config->get('paths.images_baseurl') . 'forums/clock.png" alt="' . _('Clock') . '" title="' . _('Clock') . '" width="30" style="vertical-align: middle;"></td>
 		<td><span style="white - space:nowrap;font-weight: bold;">' . _('Poll starts') . ':</span></td>
 		<td><select name="poll_starts">
 											<option class="body" value="0">' . _('Start Now') . '!</option>
@@ -129,7 +135,7 @@ switch ($action) {
 											</select> ' . _("When to start the poll. Default is 'Start Now'") . '!" </td>
 	</tr>
 	<tr>
-		<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/stop.png" alt = "' . _('Stop') . '" title="' . _('Stop') . '" width="20" style="vertical-align: middle;"></td>
+		<td><img src="' . $config->get('paths.images_baseurl') . 'forums/stop.png" alt = "' . _('Stop') . '" title="' . _('Stop') . '" width="20" style="vertical-align: middle;"></td>
 		<td><span style="white-space:nowrap;font-weight: bold;">' . _('Poll ends') . ':</span></td>
 		<td><select name = "poll_ends">
 											<option class="body" value = "1356048000">' . _('Run Forever') . '</option>
@@ -148,7 +154,7 @@ switch ($action) {
 											</select>' . _("How long this poll should run? Default is to 'Run Forever'") . '"</td>
 	</tr>
 	<tr>
-		<td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/multi.gif" alt = "' . _('Multi') . '" title="' . _('Multi') . '" width="20" style="vertical-align: middle;"></td>
+		<td><img src="' . $config->get('paths.images_baseurl') . 'forums/multi.gif" alt = "' . _('Multi') . '" title="' . _('Multi') . '" width="20" style="vertical-align: middle;"></td>
 		<td><span style="white-space:nowrap;font-weight: bold;">' . _('Multi options') . ':</span></td>
 		<td><select name = "multi_options">
 											<option class="body" value = "1">' . _('Single option') . '!</option>' . $options . '

--- a/forums/post_reply.php
+++ b/forums/post_reply.php
@@ -1,9 +1,15 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Post;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 flood_limit('forums');
 $page = $colour = $arr_quote = '';
@@ -11,9 +17,9 @@ $topic_id = isset($_GET['topic_id']) ? (int) $_GET['topic_id'] : (isset($_POST['
 if (!is_valid_id($topic_id)) {
     stderr(_('Error'), _('Invalid ID'));
 }
-global $CURUSER, $site_config;
+global $CURUSER;
 
-$rows = $db->fetchAll('SELECT t.topic_name, t.topic_desc, t.locked, f.min_class_read, f.min_class_write, f.id AS real_forum_id, s.id AS subscribed_id FROM topics AS t LEFT JOIN forums AS f ON t.forum_id=f.id LEFT JOIN subscriptions AS s ON s.topic_id=t.id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 't.status = \'ok\' AND' : ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class'] ? 't.status != \'deleted\'  AND' : '')) . ' t.id=' . sqlesc($topic_id)) or sqlerr(__FILE__, __LINE__);
+$rows = $db->fetchAll('SELECT t.topic_name, t.topic_desc, t.locked, f.min_class_read, f.min_class_write, f.id AS real_forum_id, s.id AS subscribed_id FROM topics AS t LEFT JOIN forums AS f ON t.forum_id=f.id LEFT JOIN subscriptions AS s ON s.topic_id=t.id WHERE ' . ($CURUSER['class'] < UC_STAFF ? 't.status = \'ok\' AND' : ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class') ? 't.status != \'deleted\'  AND' : '')) . ' t.id=' . sqlesc($topic_id)) or sqlerr(__FILE__, __LINE__);
 $arr = mysqli_fetch_assoc($res);
 if ($arr['locked'] === 'yes') {
     stderr(_('Error'), _('This topic is locked'));
@@ -53,8 +59,8 @@ if ($quote !== 0 && $body === '') {
 }
 
 $HTMLOUT .= '
-    <h1 class="has-text-centered">' . _('Reply in topic') . ' "<a class="is-link" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=' . $topic_id . '">' . format_comment($arr['topic_name']) . '</a>"</h1>
-    <form method="post" action="' . $site_config['paths']['baseurl'] . '/forums.php?action=post_reply&amp;topic_id=' . $topic_id . '" enctype="multipart/form-data" accept-charset="utf-8">';
+    <h1 class="has-text-centered">' . _('Reply in topic') . ' "<a class="is-link" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_topic&amp;topic_id=' . $topic_id . '">' . format_comment($arr['topic_name']) . '</a>"</h1>
+    <form method="post" action="' . $config->get('paths.baseurl') . '/forums.php?action=post_reply&amp;topic_id=' . $topic_id . '" enctype="multipart/form-data" accept-charset="utf-8">';
 
 require_once FORUM_DIR . 'editor.php';
 

--- a/forums/quick_reply.php
+++ b/forums/quick_reply.php
@@ -1,6 +1,14 @@
 <?php
 declare(strict_types=1);
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
+
 require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 /**
  * @param int $topic_id
@@ -9,10 +17,10 @@ $db = $container->get(Database::class);
  */
 function quick_reply(int $topic_id)
 {
-    global $site_config;
+    global $config;
 
     $output = main_div("
-            <form method='post' action='{$site_config['paths']['baseurl']}/forums.php?action=post_reply&amp;topic_id={$topic_id}' enctype='multipart/form-data' accept-charset='utf-8'>
+            <form method='post' action='{$config->get('paths.baseurl')}/forums.php?action=post_reply&amp;topic_id={$topic_id}' enctype='multipart/form-data' accept-charset='utf-8'>
                 <h3 class='has-text-centered'><i>Quick Reply</i></h3>" . BBcode('', 'table-wrapper round5', 200) . "
                 <input type='submit' name='button' class='button is-small margin10' value='" . _('Post') . "'>
             </form>", 'has-text-centered');

--- a/forums/search.php
+++ b/forums/search.php
@@ -1,9 +1,15 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap.php';
+
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\User;
 
+require_once dirname(__DIR__) . '/bootstrap.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 $author_error = $content = $count = $count2 = $edited_by = $row_count = $over_forum_id = $author_id = '';
 $search_where = $selected_forums = [];
@@ -30,7 +36,7 @@ $pager_links .= $sort_by ? '&amp;sort_by=' . $sort_by : '';
 $pager_links .= $asc_desc ? '&amp;asc_desc=' . $asc_desc : '';
 $pager_links .= $show_as ? '&amp;show_as=' . $show_as : '';
 $author_id = 0;
-global $container, $site_config, $CURUSER;
+global $CURUSER;
 
 $users_class = $container->get(User::class);
 if ($author) {
@@ -81,7 +87,7 @@ if ($search || $author_id) {
                        ->where('t.status = "ok"');
         $results = $results->where('p.status = "ok"')
                            ->where('t.status = "ok"');
-    } elseif ($CURUSER['class'] < $site_config['forum_config']['min_delete_view_class']) {
+    } elseif ($CURUSER['class'] < $config->get('forum_config.min_delete_view_class')) {
         $count = $count->where('p.status != "deleted"')
                        ->where('t.status != "deleted"');
         $results = $results->where('p.status != "deleted"')
@@ -139,7 +145,7 @@ if ($search || $author_id) {
     $count = $count->fetch("count");
     $page = isset($_GET['page']) ? (int) $_GET['page'] : 0;
     $perpage = 15;
-    $link = $site_config['paths']['baseurl'] . '/forums.php?action=search' . $pager_links . (isset($_GET['perpage']) ? "&amp;perpage={$perpage}&amp;" : '');
+    $link = $config->get('paths.baseurl') . '/forums.php?action=search' . $pager_links . (isset($_GET['perpage']) ? "&amp;perpage={$perpage}&amp;" : '');
     $pager = pager($perpage, $count, $link);
     $menu_top = $pager['pagertop'];
     $menu_bottom = $pager['pagerbottom'];
@@ -158,8 +164,8 @@ if ($search || $author_id) {
         <a id="results"></a>';
                 $heading = '
         <tr>
-            <th class="w-1"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic.gif" alt="' . _('Topic') . '" title="' . _('Topic') . '" class="emoticon tooltipper"></th>
-            <th class="w-1"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic_normal.gif" alt="' . _('Thread Icon') . '" title="' . _('Thread Icon') . '" class="emoticon tooltipper"></th>
+            <th class="w-1"><img src="' . $config->get('paths.images_baseurl') . 'forums/topic.gif" alt="' . _('Topic') . '" title="' . _('Topic') . '" class="emoticon tooltipper"></th>
+            <th class="w-1"><img src="' . $config->get('paths.images_baseurl') . 'forums/topic_normal.gif" alt="' . _('Thread Icon') . '" title="' . _('Thread Icon') . '" class="emoticon tooltipper"></th>
             <th class="w-40">' . _('Topic / Post') . '</th>
             <th class="w-40">' . _('in Forum') . '</th>
             <th class="w-1">' . _('Replies') . '</th>
@@ -184,8 +190,8 @@ if ($search || $author_id) {
                     $rpic = ($arr['num_ratings'] != 0 ? ratingpic_forums(round($arr['rating_sum'] / $arr['num_ratings'], 1)) : '');
                     $table_body .= '
         <tr>
-            <td><img src="' . $site_config['paths']['images_baseurl'] . 'forums/' . ($posts < 30 ? ($arr['locked'] === 'yes' ? 'locked' : 'topic') : 'hot_topic') . '.gif" alt="' . _('Topic') . '" title="' . _('Topic') . '" class="emoticon tooltipper"></td>
-            <td>' . (empty($arr['icon']) ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic_normal.gif" alt="' . _('Topic') . '" title="' . _('Topic') . '" class="emoticon">' : '<img src="' . $site_config['paths']['images_baseurl'] . 'smilies/' . htmlsafechars((string) $arr['icon']) . '.gif" alt="' . htmlsafechars((string) $arr['icon']) . '" title="' . htmlsafechars((string) $arr['icon']) . '" class="emoticon tooltipper">') . '</td>
+            <td><img src="' . $config->get('paths.images_baseurl') . 'forums/' . ($posts < 30 ? ($arr['locked'] === 'yes' ? 'locked' : 'topic') : 'hot_topic') . '.gif" alt="' . _('Topic') . '" title="' . _('Topic') . '" class="emoticon tooltipper"></td>
+            <td>' . (empty($arr['icon']) ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/topic_normal.gif" alt="' . _('Topic') . '" title="' . _('Topic') . '" class="emoticon">' : '<img src="' . $config->get('paths.images_baseurl') . 'smilies/' . htmlsafechars((string) $arr['icon']) . '.gif" alt="' . htmlsafechars((string) $arr['icon']) . '" title="' . htmlsafechars((string) $arr['icon']) . '" class="emoticon tooltipper">') . '</td>
             <td>
                 <div class="padding20">
                     <div class="columns">
@@ -193,7 +199,7 @@ if ($search || $author_id) {
                             <span class="has-text-weight-bold">' . _('Post') . ': </span>
                         </div>
                         <div class="column">
-                            <a class="is-link tooltipper" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=15&amp;page=p' . $arr['post_id'] . '&amp;search=' . $search_post . '#' . $arr['post_id'] . '" title="' . _('go to the post') . '">' . (empty($post_title) ? '' . _('Link to Post') . '' : $post_title) . '</a>
+                            <a class="is-link tooltipper" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_topic&amp;topic_id=15&amp;page=p' . $arr['post_id'] . '&amp;search=' . $search_post . '#' . $arr['post_id'] . '" title="' . _('go to the post') . '">' . (empty($post_title) ? '' . _('Link to Post') . '' : $post_title) . '</a>
                         </div>
                     </div>
                     <div class="columns">
@@ -209,8 +215,8 @@ if ($search || $author_id) {
                             <span style="font-style: italic;">' . _('In topic') . ': </span>
                         </div>
                         <div class="column">
-                            ' . ($arr['sticky'] === 'yes' ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/pinned.gif" alt="' . _('Pinned') . '" title="' . _('Pinned') . '" class="emoticon tooltipper">' : '') . ($arr['poll_id'] > 0 ? '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/poll.gif" alt="Poll" title="Poll" class="emoticon tooltipper">' : '') . '
-                                <a class="is-link tooltipper" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=' . $arr['topic_id'] . '" title="' . _('go to topic') . '">' . $topic_title . '</a>' . $post_text . '
+                            ' . ($arr['sticky'] === 'yes' ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/pinned.gif" alt="' . _('Pinned') . '" title="' . _('Pinned') . '" class="emoticon tooltipper">' : '') . ($arr['poll_id'] > 0 ? '<img src="' . $config->get('paths.images_baseurl') . 'forums/poll.gif" alt="Poll" title="Poll" class="emoticon tooltipper">' : '') . '
+                                <a class="is-link tooltipper" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_topic&amp;topic_id=' . $arr['topic_id'] . '" title="' . _('go to topic') . '">' . $topic_title . '</a>' . $post_text . '
                         </div>' . (!empty($rpic) ? '
                         <div class="column is-1">
                             ' . $rpic . '
@@ -225,7 +231,7 @@ if ($search || $author_id) {
                 </div>
             </td>
             <td>
-                <a class="is-link tooltipper" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_forum&amp;forum_id=' . $arr['forum_id'] . '" title="' . _('go to forum') . '">' . htmlsafechars((string) $arr['forum_name']) . '</a>
+                <a class="is-link tooltipper" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_forum&amp;forum_id=' . $arr['forum_id'] . '" title="' . _('go to forum') . '">' . htmlsafechars((string) $arr['forum_name']) . '</a>
                 ' . ($arr['forum_desc'] != '' ? '&#9658; <span style="font-size: x-small;">' . htmlsafechars((string) $arr['forum_desc']) . '</span>' : '') . '
             </td>
             <td>' . number_format($posts - 1) . '</td>
@@ -251,20 +257,20 @@ if ($search || $author_id) {
                     }
                     $post_id = $arr['post_id'];
                     $posts = $arr['post_count'];
-                    $post_icon = ($arr['icon'] != '' ? '<img src="' . $site_config['paths']['images_baseurl'] . 'smilies/' . htmlsafechars($arr['icon']) . '.gif" alt="icon" title="icon" class="emoticon tooltipper"> ' : '<img src="' . $site_config['paths']['images_baseurl'] . 'forums/topic_normal.gif" alt="Normal Topic" class="emoticon"> ');
+                    $post_icon = ($arr['icon'] != '' ? '<img src="' . $config->get('paths.images_baseurl') . 'smilies/' . htmlsafechars($arr['icon']) . '.gif" alt="icon" title="icon" class="emoticon tooltipper"> ' : '<img src="' . $config->get('paths.images_baseurl') . 'forums/topic_normal.gif" alt="Normal Topic" class="emoticon"> ');
                     $edited_by = '';
                     if ($arr['edit_date'] > 0) {
                         $edited_username = $users_class->get_item('username', (int) $arr['edited_by']);
-                        $edited_by = '<span style="font-weight: bold; font-size: x-small;">Last edited by <a class="is-link" href="' . $site_config['paths']['baseurl'] . '/member_details.php?id=' . $arr['edited_by'] . '">' . htmlsafechars($edited_username) . '</a> at ' . get_date((int) $arr['edit_date'], '') . ' GMT ' . ($arr['edit_reason'] != '' ? ' </span>[ Reason: ' . htmlsafechars($arr['edit_reason']) . ' ] <span style="font-weight: bold; font-size: x-small;">' : '');
+                        $edited_by = '<span style="font-weight: bold; font-size: x-small;">Last edited by <a class="is-link" href="' . $config->get('paths.baseurl') . '/member_details.php?id=' . $arr['edited_by'] . '">' . htmlsafechars($edited_username) . '</a> at ' . get_date((int) $arr['edit_date'], '') . ' GMT ' . ($arr['edit_reason'] != '' ? ' </span>[ Reason: ' . htmlsafechars($arr['edit_reason']) . ' ] <span style="font-weight: bold; font-size: x-small;">' : '');
                     }
                     $body = ($arr['bbcode'] === 'yes' ? highlightWords(format_comment($arr['body']), $search) : highlightWords(format_comment_no_bbcode($arr['body']), $search));
                     $table_body = '
         <tr>
             <td colspan="3">in:
-                <a class="is-link tooltipper" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_forum&amp;forum_id=' . $arr['forum_id'] . '" title="' . _('Link to %s', 'Forum') . '">
+                <a class="is-link tooltipper" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_forum&amp;forum_id=' . $arr['forum_id'] . '" title="' . _('Link to %s', 'Forum') . '">
                     <span>' . htmlsafechars($arr['forum_name']) . '</span>
                 </a> in:
-                <a class="is-link tooltipper" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=' . $arr['topic_id'] . '" title="' . _('Link to %s', 'Ttopic') . '">
+                <a class="is-link tooltipper" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_topic&amp;topic_id=' . $arr['topic_id'] . '" title="' . _('Link to %s', 'Ttopic') . '">
                     <span>' . $topic_title . '</span>
                 </a>
             </td>
@@ -275,15 +281,15 @@ if ($search || $author_id) {
             </td>
             <td>
                 <span style="white-space:nowrap;">' . $post_icon . '
-                    <a class="is-link tooltipper" href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=' . $arr['topic_id'] . '&amp;page=' . $page . '#' . $arr['post_id'] . '" title="Link to Post">' . $post_title . '
+                    <a class="is-link tooltipper" href="' . $config->get('paths.baseurl') . '/forums.php?action=view_topic&amp;topic_id=' . $arr['topic_id'] . '&amp;page=' . $page . '#' . $arr['post_id'] . '" title="Link to Post">' . $post_title . '
                     </a>
                     <span class="left20">' . _('Posted') . ': ' . get_date((int) $arr['added'], '') . ' [' . get_date((int) $arr['added'], '', 0, 1) . ']</span>
                 </span>
             </td>
             <td>
                 <span>
-                    <a href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_my_GETs&amp;page=' . $page . '#top"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/up.gif" alt="' . _('Top') . '" title="' . _('Top') . '" class="emoticon tooltipper"></a>
-                    <a href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_my_GETs&amp;page=' . $page . '#bottom"><img src="' . $site_config['paths']['images_baseurl'] . 'forums/down.gif" alt="' . _('Bottom') . '" title="' . _('Bottom') . '" class="emoticon tooltipper"></a>
+                    <a href="' . $config->get('paths.baseurl') . '/forums.php?action=view_my_GETs&amp;page=' . $page . '#top"><img src="' . $config->get('paths.images_baseurl') . 'forums/up.gif" alt="' . _('Top') . '" title="' . _('Top') . '" class="emoticon tooltipper"></a>
+                    <a href="' . $config->get('paths.baseurl') . '/forums.php?action=view_my_GETs&amp;page=' . $page . '#bottom"><img src="' . $config->get('paths.images_baseurl') . 'forums/down.gif" alt="' . _('Bottom') . '" title="' . _('Bottom') . '" class="emoticon tooltipper"></a>
                 </span>
             </td>
         </tr>
@@ -326,7 +332,7 @@ foreach ($forums as $arr_forums) {
                     <td class="has-no-border">
                         <div class="is-flex level-left">
                             <input name="f' . $arr_forums['real_forum_id'] . '" type="checkbox" ' . ($selected_forums ? 'checked' : '') . ' value="1">
-                            <a href="' . $site_config['paths']['baseurl'] . '/forums.php?action=view_forum&amp;forum_id=' . $arr_forums['real_forum_id'] . '" class="is-link tooltipper left10" title="' . htmlsafechars($arr_forums['description']) . '">' . htmlsafechars($arr_forums['name']) . '
+                            <a href="' . $config->get('paths.baseurl') . '/forums.php?action=view_forum&amp;forum_id=' . $arr_forums['real_forum_id'] . '" class="is-link tooltipper left10" title="' . htmlsafechars($arr_forums['description']) . '">' . htmlsafechars($arr_forums['name']) . '
                             </a>
                         </div>
                     </td>
@@ -443,6 +449,6 @@ $table_body = '
 
 $HTMLOUT .= main_table($table_body) . '</form>' . $content;
 $breadcrumbs = [
-    "<a href='{$site_config['paths']['baseurl']}/forums.php'>" . _('Forums') . '</a>',
-    "<a href='{$site_config['paths']['baseurl']}/forums.php?action=search'>" . _('Search') . '</a>',
+    "<a href='{$config->get('paths.baseurl')}/forums.php'>" . _('Forums') . '</a>',
+    "<a href='{$config->get('paths.baseurl')}/forums.php?action=search'>" . _('Search') . '</a>',
 ];

--- a/tools/configrepo_rollout_lint.txt
+++ b/tools/configrepo_rollout_lint.txt
@@ -211,3 +211,17 @@ No syntax errors detected in include/config_compat.php
 No syntax errors detected in blocks/index/latest_movies.php
 No syntax errors detected in blocks/index/latest_tv.php
 No syntax errors detected in blocks/index/forum_posts.php
+No syntax errors detected in forums/editor.php
+No syntax errors detected in forums/last_ten.php
+No syntax errors detected in forums/mark_all_as_read.php
+No syntax errors detected in forums/member_post_history.php
+No syntax errors detected in forums/new_replies.php
+No syntax errors detected in forums/new_topic.php
+
+Parse error: syntax error, unexpected identifier "Location", expecting ")" in forums/poll.php on line 55
+Errors parsing forums/poll.php
+
+Parse error: syntax error, unexpected identifier "no", expecting ")" in forums/post_reply.php on line 45
+Errors parsing forums/post_reply.php
+No syntax errors detected in forums/quick_reply.php
+No syntax errors detected in forums/search.php

--- a/tools/configrepo_rollout_report.csv
+++ b/tools/configrepo_rollout_report.csv
@@ -186,3 +186,13 @@ src/Uglify/UglifyService.php,site_config(2),0,Generate asset helper with ConfigR
 =======
 *** master
 *** master
+forums/editor.php,site_config(23),0,Replaced legacy config access with ConfigRepository
+forums/last_ten.php,site_config(1),0,Replaced legacy config access with ConfigRepository
+forums/mark_all_as_read.php,site_config(1),0,Replaced legacy config access with ConfigRepository
+forums/member_post_history.php,site_config(27),0,Replaced legacy config access with ConfigRepository
+forums/new_replies.php,site_config(18),0,Replaced legacy config access with ConfigRepository
+forums/new_topic.php,site_config(9),0,Replaced legacy config access with ConfigRepository
+forums/poll.php,site_config(6),0,Replaced legacy config access with ConfigRepository
+forums/post_reply.php,site_config(3),0,Replaced legacy config access with ConfigRepository
+forums/quick_reply.php,site_config(1),0,Replaced legacy config access with ConfigRepository
+forums/search.php,site_config(25),0,Replaced legacy config access with ConfigRepository

--- a/tools/configrepo_rollout_status.txt
+++ b/tools/configrepo_rollout_status.txt
@@ -47,3 +47,4 @@ offset=200,batch_size=10,processed=10,replacements=34
 =======
 *** master
 *** master
+offset=220,batch_size=10,processed=10,replacements=114


### PR DESCRIPTION
## Summary
- switch forums editor/topic reply flows to load configuration from `ConfigRepository`
- replace `$site_config[...]` lookups with `$config->get(...)` accessors across the targeted forum controllers
- record lint and rollout metadata for batch offset 220

## Testing
- php -l forums/editor.php
- php -l forums/last_ten.php
- php -l forums/mark_all_as_read.php
- php -l forums/member_post_history.php
- php -l forums/new_replies.php
- php -l forums/new_topic.php
- php -l forums/poll.php *(fails: pre-existing placeholder queries trigger parse error)*
- php -l forums/post_reply.php *(fails: pre-existing placeholder queries trigger parse error)*
- php -l forums/quick_reply.php
- php -l forums/search.php

------
https://chatgpt.com/codex/tasks/task_e_68cfc2d8ea6c832599fe4ddf5a7220b8