### PR TITLE
refactor: replace legacy constants/$site_config → ConfigRepository (batch offset=240)

### DIFF
--- a/include/class/class_check.php
+++ b/include/class/class_check.php
@@ -10,10 +10,15 @@ use Delight\Auth\Auth;
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Roles;
 use Pu239\Session;
 use Pu239\User;
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 
 require_once INCL_DIR . 'function_autopost.php';
 require_once INCL_DIR . 'function_html.php';
@@ -29,18 +34,20 @@ require_once INCL_DIR . 'function_staff.php';
  */
 function class_check(int $class = UC_STAFF)
 {
-    global $container, $site_config;
+    global $container, $config;
 
     $user = check_user_status();
     if (empty($user)) {
-        header("Location: {$site_config['paths']['baseurl']}/404.html");
+        $baseurl = (string) $config->get('paths.baseurl');
+        header('Location: ' . $baseurl . '/404.html');
         app_halt('Exit called');
     }
     $auth = $container->get(Auth::class);
     if ($auth->isRemembered()) {
         $session = $container->get(Session::class);
         $session->set('is-danger', _('Please confirm your password.'));
-        header("Location: {$site_config['paths']['baseurl']}/verify.php?page=" . urlencode($_SERVER['REQUEST_URI']));
+        $baseurl = $baseurl ?? (string) $config->get('paths.baseurl');
+        header('Location: ' . $baseurl . '/verify.php?page=' . urlencode($_SERVER['REQUEST_URI']));
         app_halt('Exit called');
     }
     $userid = $user['id'];
@@ -48,11 +55,14 @@ function class_check(int $class = UC_STAFF)
         write_info("{$user['username']} attempted to access a staff page");
         stderr(_('Error'), 'No Permission. Page is for ' . get_user_class_name((int) $class) . ' and above. Read the FAQ.');
     }
-    if ($user['class'] > UC_MAX || (!in_array($user['id'], $site_config['is_staff']) && (!$user['roles_mask'] & Roles::CODER))) {
+    $isStaff = (array) $config->get('is_staff');
+    if ($user['class'] > UC_MAX || (!in_array($user['id'], $isStaff) && (!$user['roles_mask'] & Roles::CODER))) {
         $ip = getip($user['id']);
-        $body = "User: [url={$site_config['paths']['baseurl']}/userdetails.php?id={$user['id']}][color=user]{$user['username']}[/color][/url] - {$ip}[br]Class {$user['class']}[br]Current page: {$_SERVER['PHP_SELF']}[br]Previous page: " . (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'no referer') . '[br]Action: ' . $_SERVER['REQUEST_URI'] . '[br] Member has been disabled and demoted by class check system.';
+        $baseurl = $baseurl ?? (string) $config->get('paths.baseurl');
+        $body = 'User: [url=' . $baseurl . '/userdetails.php?id=' . $user['id'] . '][color=user]' . $user['username'] . '[/color][/url] - ' . $ip . '[br]Class ' . $user['class'] . '[br]Current page: ' . $_SERVER['PHP_SELF'] . '[br]Previous page: ' . (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'no referer') . '[br]Action: ' . $_SERVER['REQUEST_URI'] . '[br] Member has been disabled and demoted by class check system.';
         $subject = 'Warning Class Check System!';
-        if (user_exists($site_config['chatbot']['id'])) {
+        $chatbotId = (int) $config->get('chatbot.id');
+        if (user_exists($chatbotId)) {
             $post_info = auto_post($subject, $body);
             $update = [
                 'class' => UC_MIN,
@@ -60,7 +70,7 @@ function class_check(int $class = UC_STAFF)
             ];
             $users_class = $container->get(User::class);
             $users_class->update($update, $userid);
-            write_log('Class Check System Initialized [url=' . $site_config['paths']['baseurl'] . '/forums.php?action=view_topic&amp;topic_id=' . $post_info['topicid'] . '&amp;page=last#' . $post_info['postid'] . ']VIEW[/url]');
+            write_log('Class Check System Initialized [url=' . $baseurl . '/forums.php?action=view_topic&amp;topic_id=' . $post_info['topicid'] . '&amp;page=last#' . $post_info['postid'] . ']VIEW[/url]');
             stderr(_('Error'), _('You dont have the correct credentials to be here!'));
         }
     }

--- a/include/function_autopost.php
+++ b/include/function_autopost.php
@@ -12,9 +12,14 @@ use DI\NotFoundException;
 
 use MatthiasMullie\Scrapbook\Exception\UnbegunTransaction;
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Message;
 use Spatie\Image\Exceptions\InvalidManipulation;
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 
 /**
  * @param string $subject
@@ -33,20 +38,21 @@ use Spatie\Image\Exceptions\InvalidManipulation;
  */
 function auto_post($subject = 'Error - Subject Missing', $body = 'Error - No Body')
 {
-    global $container, $site_config, $CURUSER;
+    global $container, $config, $CURUSER;
 
     // $fluent removed — use $this->db (ExtendedPdo)
-    if (user_exists($site_config['chatbot']['id'])) {
+    $chatbotId = (int) $config->get('chatbot.id');
+    if (user_exists($chatbotId)) {
         $topicid = $fluent->from('topics')
                           ->select(null)
                           ->select('id')
-                          ->where('forum_id = ?', $site_config['staff_forums'][0])
+                          ->where('forum_id = ?', (int) $config->get('staff_forums.0'))
                           ->where('topic_name = ?', $subject)
                           ->fetch('id');
         if (!$topicid) {
             $values = [
-                'user_id' => $site_config['chatbot']['id'],
-                'forum_id' => $site_config['staff_forums'][0],
+                'user_id' => $chatbotId,
+                'forum_id' => (int) $config->get('staff_forums.0'),
                 'topic_name' => $subject,
             ];
             $sql = "INSERT INTO topics (/* columns */) VALUES (/* values */)";
@@ -56,12 +62,12 @@ $topicid = $db->perform($sql, $values);
                 'topic_count' => new Literal('topic_count + 1'),
             ];
             $sql = "UPDATE forums SET /* columns */ WHERE id = :id";
-$db->perform($sql, array_merge($set, ['id' => $site_config['staff_forums'][0]]));
+$db->perform($sql, array_merge($set, ['id' => (int) $config->get('staff_forums.0')]));
         }
 
         $values = [
             'topic_id' => $topicid,
-            'user_id' => $site_config['chatbot']['id'],
+            'user_id' => $chatbotId,
             'added' => TIME_NOW,
             'body' => $body,
         ];
@@ -78,7 +84,7 @@ $db->perform($sql, array_merge($set, ['id' => $topicid]));
             'post_count' => new Literal('post_count + 1'),
         ];
         $sql = "UPDATE forums SET /* columns */ WHERE id = :id";
-$db->perform($sql, array_merge($set, ['id' => $site_config['staff_forums'][0]]));
+$db->perform($sql, array_merge($set, ['id' => (int) $config->get('staff_forums.0')]));
 
         $cache = $container->get(Cache::class);
         $cache->delete('last_posts_' . $CURUSER['class']);
@@ -86,7 +92,7 @@ $db->perform($sql, array_merge($set, ['id' => $site_config['staff_forums'][0]]))
 
         unset($values);
         $values[] = [
-            'receiver' => $site_config['site']['owner'],
+            'receiver' => (int) $config->get('site.owner'),
             'added' => TIME_NOW,
             'subject' => $subject,
             'msg' => $body,

--- a/include/function_bbcode.php
+++ b/include/function_bbcode.php
@@ -7,8 +7,13 @@ require_once __DIR__ . '/runtime_safe.php';
 
 use DI\DependencyException;
 use DI\NotFoundException;
+use Pu239\Config\ConfigRepository;
 use Pu239\User;
 use Spatie\Image\Exceptions\InvalidManipulation;
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 
 require_once INCL_DIR . 'function_html.php';
 
@@ -24,16 +29,17 @@ require_once INCL_DIR . 'function_users.php';
  */
 function smilies_frame($smilies_set)
 {
-    global $site_config;
+    global $config;
 
     $image = placeholder_image();
+    $imagesBaseUrl = (string) $config->get('paths.images_baseurl');
     $list = $emoticons = '';
     foreach ($smilies_set as $code => $url) {
         $list .= "
             <span class='margin10 mw-50 is-flex tooltipper' title='{$code}'>
                 <span class='bordered bg-03'>
                     <a href='#'>
-                        <img src='{$image}' data-src='{$site_config['paths']['images_baseurl']}smilies/" . $url . "' alt='{$code}' class='lazy w-100'>
+                        <img src='{$image}' data-src='{$imagesBaseUrl}smilies/" . $url . "' alt='{$code}' class='lazy w-100'>
                     </a>
                 </span>
             </span>";
@@ -56,9 +62,9 @@ function smilies_frame($smilies_set)
  */
 function BBcode(string $body = '', string $class = 'w-100', int $height = 600)
 {
-    global $site_config;
+    global $config;
 
-    if (!$site_config['site']['BBcode']) {
+    if (!(bool) $config->get('site.BBcode')) {
         $textarea = "
             <div class='$class'>
                 <textarea name='text' rows='10'></textarea>
@@ -198,8 +204,10 @@ function format_urls($s)
  */
 function format_comment(?string $text, bool $strip_html = true, bool $urls = true, bool $images = true)
 {
-    global $container, $site_config;
+    global $container, $config;
 
+    $baseurl = (string) $config->get('paths.baseurl');
+    $imagesBaseUrl = (string) $config->get('paths.images_baseurl');
     $users_class = $container->get(User::class);
     if (empty($text)) {
         return null;
@@ -330,9 +338,9 @@ function format_comment(?string $text, bool $strip_html = true, bool $urls = tru
         '<span class="text-\1">\2</span>',
         "<div style='margin-bottom: 5px;'><span class='flip button is-small'>Show Spoiler!</span><div class='panel spoiler' style='display:none;'>\\1</div></div><br>",
         "<div style='margin-bottom: 5px;'><span class='flip button is-small'>Show Hide!</span><div class='panel spoiler' style='display:none;'>\\1</div></div><br>",
-        "<div class='responsive-container'><iframe width='1920' height='1080' src='https://www.youtube.com/embed/\\1?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0&origin={$site_config['paths']['baseurl']}&vq=hd1080&wmode=opaque' allow='fullscreen; accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'></iframe></div>",
-        "<div class='responsive-container'><iframe width='1920' height='1080' src='https://www.youtube.com/embed/\\1?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0&origin={$site_config['paths']['baseurl']}&vq=hd1080&wmode=opaque' allow='fullscreen; accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'></iframe></div>",
-        "<div class='responsive-container'><iframe width='1920' height='1080' src='https://www.youtube.com/embed/\\1?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0&origin={$site_config['paths']['baseurl']}&vq=hd1080&wmode=opaque' allow='fullscreen; accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'></iframe></div>",
+        "<div class='responsive-container'><iframe width='1920' height='1080' src='https://www.youtube.com/embed/\\1?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0&origin={$baseurl}&vq=hd1080&wmode=opaque' allow='fullscreen; accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'></iframe></div>",
+        "<div class='responsive-container'><iframe width='1920' height='1080' src='https://www.youtube.com/embed/\\1?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0&origin={$baseurl}&vq=hd1080&wmode=opaque' allow='fullscreen; accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'></iframe></div>",
+        "<div class='responsive-container'><iframe width='1920' height='1080' src='https://www.youtube.com/embed/\\1?autoplay=0&fs=0&iv_load_policy=3&showinfo=0&rel=0&cc_load_policy=0&start=0&end=0&origin={$baseurl}&vq=hd1080&wmode=opaque' allow='fullscreen; accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'></iframe></div>",
         '<embed style="width:500px; height:410px;" id="VideoPlayback" align="middle" type="application/x-shockwave-flash" src="//video.google.com/googleplayer.swf?docId=\\1" allowScriptAccess="sameDomain" quality="best" bgcolor="#fff" scale="noScale" wmode="window" salign="TL"  FlashVars="playerMode=embedded">',
         '<span><video width="500" loop muted autoplay><source src="//i.imgur.com/\1.webm" type="video/webm"><source src="//i.imgur.com/\1.mp4" type="video/mp4">Your browser does not support the video tag.</video></span>',
         '<span><video width="500" controls preload="none"><source src="\1"><source src="\1" type="video/mp4">Your browser does not support the video tag.</video></span>',
@@ -439,9 +447,9 @@ function format_comment(?string $text, bool $strip_html = true, bool $urls = tru
             $s = preg_replace("#\s*(width|height)=['\"](auto|\d+)['\"]\s*#", '', $s);
         }
         // [img] proxied local images
-        $s = preg_replace("#\[img\](.*" . preg_quote($site_config['paths']['images_baseurl']) . "proxy/.*)\[/img\]#i", '<img src="' . $image . '" data-src="\\1" alt="" class="lazy"></a>', $s);
+        $s = preg_replace("#\[img\](.*" . preg_quote($imagesBaseUrl, '#') . "proxy/.*)\[/img\]#i", '<img src="' . $image . '" data-src="\\1" alt="" class="lazy"></a>', $s);
         // [img] local images
-        $s = preg_replace("#\[img\](.*" . preg_quote($site_config['paths']['images_baseurl']) . ".*)\[/img\]#i", '<img src="' . $image . '" data-src="\\1" alt="" class="lazy emoticon is-2x"></a>', $s);
+        $s = preg_replace("#\[img\](.*" . preg_quote($imagesBaseUrl, '#') . ".*)\[/img\]#i", '<img src="' . $image . '" data-src="\\1" alt="" class="lazy emoticon is-2x"></a>', $s);
     }
     // [mcom]Text[/mcom]
     if (stripos($s, '[mcom]') !== false) {
@@ -467,15 +475,15 @@ function format_comment(?string $text, bool $strip_html = true, bool $urls = tru
     $s = str_replace('  ', '&#160;&#160;', $s);
     $smilies = $container->get('smilies');
     foreach ($smilies as $code => $url) {
-        $s = str_replace($code, "<img src='{$image}' data-src='{$site_config['paths']['images_baseurl']}smilies/{$url}' alt='' class='lazy'>", $s);
+        $s = str_replace($code, "<img src='{$image}' data-src='{$imagesBaseUrl}smilies/{$url}' alt='' class='lazy'>", $s);
     }
     $staff_smilies = $container->get('staff_smilies');
     foreach ($staff_smilies as $code => $url) {
-        $s = str_replace($code, "<img src='{$image}' data-src='{$site_config['paths']['images_baseurl']}smilies/{$url}' alt='' class='lazy'>", $s);
+        $s = str_replace($code, "<img src='{$image}' data-src='{$imagesBaseUrl}smilies/{$url}' alt='' class='lazy'>", $s);
     }
     $custom_smilies = $container->get('custom_smilies');
     foreach ($custom_smilies as $code => $url) {
-        $s = str_replace($code, "<img src='{$image}' data-src='{$site_config['paths']['images_baseurl']}smilies/{$url}' alt='' class='lazy'>", $s);
+        $s = str_replace($code, "<img src='{$image}' data-src='{$imagesBaseUrl}smilies/{$url}' alt='' class='lazy'>", $s);
     }
     $s = format_quotes($s);
     $s = str_replace([

--- a/include/function_bluray.php
+++ b/include/function_bluray.php
@@ -8,9 +8,14 @@ require_once __DIR__ . '/runtime_safe.php';
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Image;
 use Spatie\Image\Exceptions\InvalidManipulation;
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 
 /**
  * @param bool $images
@@ -26,7 +31,7 @@ use Spatie\Image\Exceptions\InvalidManipulation;
  */
 function get_bluray_info(bool $images = false)
 {
-    global $container, $BLOCKS, $site_config;
+    global $container, $BLOCKS, $config;
 
     if (!$BLOCKS['bluray_com_api_on']) {
         return false;
@@ -72,7 +77,7 @@ function get_bluray_info(bool $images = false)
                     $poster_link = "https://images.static-bluray.com/movies/covers/{$match[2]}_large.jpg";
                 }
             }
-            $poster = $placeholder = $site_config['paths']['images_baseurl'] . 'noposter.png';
+            $poster = $placeholder = (string) $config->get('paths.images_baseurl') . 'noposter.png';
 
             if (!empty($poster_link)) {
                 $image = url_proxy($poster_link, true, 250);

--- a/include/function_bonus.php
+++ b/include/function_bonus.php
@@ -6,9 +6,12 @@ $db = $container->get(Database::class);
 require_once __DIR__ . '/runtime_safe.php';
 
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 
 global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 
 // $fluent removed — use $this->db (ExtendedPdo)
 $cache = $container->get(CACHE::class);
@@ -318,12 +321,12 @@ if ($total_fl['enabled'] === 'yes' || $total_du['enabled'] === 'yes' || $total_h
     $fl_header .= '</div>';
 }
 
-$bpt = $site_config['bonus']['per_duration'];
-$bmt = $site_config['bonus']['max_torrents'];
-$bonus_per_comment = $site_config['bonus']['per_comment'];
-$bonus_per_rating = $site_config['bonus']['per_rating'];
-$bonus_per_post = $site_config['bonus']['per_post'];
-$bonus_per_topic = $site_config['bonus']['per_topic'];
+$bpt = (float) $config->get('bonus.per_duration');
+$bmt = (int) $config->get('bonus.max_torrents');
+$bonus_per_comment = (float) $config->get('bonus.per_comment');
+$bonus_per_rating = (float) $config->get('bonus.per_rating');
+$bonus_per_post = (float) $config->get('bonus.per_post');
+$bonus_per_topic = (float) $config->get('bonus.per_topic');
 
 $at = $fluent->from('peers')
              ->select(null)

--- a/include/function_books.php
+++ b/include/function_books.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/runtime_safe.php';
 
 require_once INCL_DIR . 'function_html.php';
 
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Biblys\Isbn\Isbn;
 use DI\DependencyException;
@@ -16,6 +17,9 @@ use Pu239\Torrent;
 use Scriptotek\GoogleBooks\GoogleBooks;
 use Spatie\Image\Exceptions\InvalidManipulation;
 
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 
 /**
@@ -223,7 +227,7 @@ function format_ebook_html(array $ebook, int $api_hits)
  */
 function fetch_book_info(?string $isbn, ?string $name)
 {
-    global $container, $user, $site_config;
+    global $container, $user, $config;
 
     if (empty($isbn) && empty($name)) {
         return false;
@@ -236,7 +240,7 @@ function fetch_book_info(?string $isbn, ?string $name)
     $ebook = $cache->get('book_info_' . $hash);
     if ($ebook === false || is_null($ebook)) {
         $api_limit = 100;
-        if (!empty($site_config['api']['google_books'])) {
+        if (!empty($config->get('api.google_books'))) {
             $api_limit = 1000;
         }
         if ($api_hits >= $api_limit) {
@@ -333,7 +337,7 @@ function fetch_book_info(?string $isbn, ?string $name)
                 'zoom=2',
                 'zoom=1',
             ], 'zoom=0', $ebook['poster']);
-            $cache->set('book_info_' . $hash, $ebook, $site_config['expires']['book_info']);
+            $cache->set('book_info_' . $hash, $ebook, $config->get('expires.book_info'));
 
             return [
                 'ebook' => $ebook,

--- a/include/function_breadcrumbs.php
+++ b/include/function_breadcrumbs.php
@@ -5,6 +5,12 @@ $db = $container->get(Database::class);
 
 require_once __DIR__ . '/runtime_safe.php';
 
+use Pu239\Config\ConfigRepository;
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
+
 /**
  * @param array $breadcrumbs
  *
@@ -12,12 +18,13 @@ require_once __DIR__ . '/runtime_safe.php';
  */
 function breadcrumbs(array $breadcrumbs)
 {
-    global $site_config;
+    global $config;
 
+    $baseurl = (string) $config->get('paths.baseurl');
     $crumbs = "
                     <nav class='breadcrumb round5' aria-label='breadcrumbs'>
                         <ul>
-                            <li><a href='{$site_config['paths']['baseurl']}'>" . _('Home') . '</a></li>';
+                            <li><a href='{$baseurl}'>" . _('Home') . '</a></li>';
     foreach ($breadcrumbs as $link) {
         if (!empty($link)) {
             $link = str_replace(",", '', $link);

--- a/include/function_categories.php
+++ b/include/function_categories.php
@@ -8,7 +8,12 @@ require_once __DIR__ . '/runtime_safe.php';
 use DI\DependencyException;
 use DI\NotFoundException;
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
 
 /**
  *
@@ -22,7 +27,7 @@ use Pu239\Database;
  */
 function genrelist(bool $grouped)
 {
-    global $container, $site_config;
+    global $container, $config;
 
     $cache = $container->get(Cache::class);
     // $fluent removed — use $this->db (ExtendedPdo)
@@ -42,7 +47,7 @@ function genrelist(bool $grouped)
                 $ret[] = $parent;
             }
             if (!empty($ret)) {
-                $cache->set('genrelist_grouped_', $ret, $site_config['expires']['genrelist']);
+                $cache->set('genrelist_grouped_', $ret, (int) $config->get('expires.genrelist'));
             }
         }
     } else {
@@ -60,7 +65,7 @@ function genrelist(bool $grouped)
                 $ret[] = $cat;
             }
             if (!empty($ret)) {
-                $cache->set('genrelist_ordered_', $ret, $site_config['expires']['genrelist']);
+                $cache->set('genrelist_ordered_', $ret, (int) $config->get('expires.genrelist'));
             }
         }
     }

--- a/tools/configrepo_rollout_lint.txt
+++ b/tools/configrepo_rollout_lint.txt
@@ -307,3 +307,11 @@ No syntax errors detected in include/arcade.php
 php -l include/arcade.php
 =======
 *** master
+No syntax errors detected in include/class/class_check.php
+No syntax errors detected in include/function_autopost.php
+No syntax errors detected in include/function_bbcode.php
+No syntax errors detected in include/function_bluray.php
+No syntax errors detected in include/function_bonus.php
+No syntax errors detected in include/function_books.php
+No syntax errors detected in include/function_breadcrumbs.php
+No syntax errors detected in include/function_categories.php

--- a/tools/configrepo_rollout_report.csv
+++ b/tools/configrepo_rollout_report.csv
@@ -209,3 +209,13 @@ forums/view_unread_posts.php,site_config(24),0,Replaced legacy config access wit
 include/arcade.php,site_config(11),0,Replaced legacy config access with ConfigRepository
 =======
 *** master
+include/bittorrent.php,none,0,SKIPPED_EXPLICIT
+include/class/class_check.php,site_config(7),0,Replaced legacy config access with ConfigRepository
+include/cron_controller.php,none,0,SKIPPED_DB_ARRAY
+include/function_autopost.php,site_config(9),0,Replaced legacy config access with ConfigRepository
+include/function_bbcode.php,site_config(13),0,Replaced legacy config access with ConfigRepository
+include/function_bluray.php,site_config(2),0,Replaced legacy config access with ConfigRepository
+include/function_bonus.php,site_config(6),0,Replaced legacy config access with ConfigRepository
+include/function_books.php,site_config(3),0,Replaced legacy config access with ConfigRepository
+include/function_breadcrumbs.php,site_config(2),0,Replaced legacy config access with ConfigRepository
+include/function_categories.php,site_config(3),0,Replaced legacy config access with ConfigRepository

--- a/tools/configrepo_rollout_status.txt
+++ b/tools/configrepo_rollout_status.txt
@@ -52,3 +52,4 @@ offset=220,batch_size=10,processed=10,replacements=114
 offset=230,batch_size=10,processed=10,replacements=159
 =======
 *** master
+2025-09-21T10:13:14Z, offset=240, size=10, changed=8, skipped=2, lint_fail=0


### PR DESCRIPTION
## Summary
- replace legacy $site_config usage in the include helpers from the current batch with ConfigRepository lookups
- inject ConfigRepository wiring in each refactored include to initialize the repository before use
- update the configrepo rollout lint, report, and status artifacts for batch offset 240

## Testing
- php -l include/class/class_check.php
- php -l include/function_autopost.php
- php -l include/function_bbcode.php
- php -l include/function_bluray.php
- php -l include/function_bonus.php
- php -l include/function_books.php
- php -l include/function_breadcrumbs.php
- php -l include/function_categories.php

------
https://chatgpt.com/codex/tasks/task_e_68cfcdc2041483258257cb4619e00ed3