### PR TITLE
refactor: replace legacy constants/$site_config → ConfigRepository (batch offset=115)

### DIFF
--- a/public/clear_announcement.php
+++ b/public/clear_announcement.php
@@ -1,33 +1,38 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap_web.php';
-
-$db = $container->get(Database::class);
-
-
-
-
 
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
+
+require_once dirname(__DIR__) . '/bootstrap_web.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
+/** @var Database $db */
+$db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/bittorrent.php';
 $user = check_user_status();
-global $container, $site_config;
-$set = [
-    'curr_ann_id' => 0,
-    'curr_ann_last_check' => 0,
-];
-// $fluent removed — use $this->db (ExtendedPdo)
-$fluent->update('users')
-       ->set($set)
-       ->where('id = ?', $user['id'])
-       ->where('curr_ann_id != 0')
-       ->execute();
+
+$db->run(
+    'UPDATE users SET curr_ann_id = :curr_ann_id, curr_ann_last_check = :curr_ann_last_check WHERE id = :id AND curr_ann_id != 0',
+    [
+        ':curr_ann_id' => 0,
+        ':curr_ann_last_check' => 0,
+        ':id' => $user['id'],
+    ],
+);
 
 $cache = $container->get(Cache::class);
-$cache->update_row('user_' . $user['id'], [
-    'curr_ann_id' => 0,
-    'curr_ann_last_check' => 0,
-], $site_config['expires']['user_cache']);
-header("Location: {$site_config['paths']['baseurl']}");
+$cache->update_row(
+    'user_' . $user['id'],
+    [
+        'curr_ann_id' => 0,
+        'curr_ann_last_check' => 0,
+    ],
+    $config->get('expires.user_cache'),
+);
+
+header('Location: ' . $config->get('paths.baseurl'));

--- a/public/contactstaff.php
+++ b/public/contactstaff.php
@@ -1,12 +1,17 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap_web.php';
 
-use Pu239\Database;
 use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 use Pu239\Session;
 
-global $container, $site_config;
+require_once dirname(__DIR__) . '/bootstrap_web.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
+/** @var Database $db */
 $db = $container->get(Database::class);
 
 require_once __DIR__ . '/../include/bittorrent.php';
@@ -47,7 +52,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->rowCount()) {
             $cache->delete('staff_mess_');
             $session->set('is-success', _('Message was sent! Wait for staff to respond now!'));
-            header('Location: ' . $site_config['paths']['baseurl']);
+            header('Location: ' . $config->get('paths.baseurl'));
         } else {
             $session->set('is-warning', _('There was something wrong!'));
         }

--- a/public/delete.php
+++ b/public/delete.php
@@ -1,23 +1,24 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap_web.php';
 
-$db = $container->get(Database::class);
-
-
-
-
-
+use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\Message;
 use Pu239\Session;
 use Pu239\Torrent;
 use Pu239\User;
 
+require_once dirname(__DIR__) . '/bootstrap_web.php';
+
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
+/** @var Database $db */
+$db = $container->get(Database::class);
+
 require_once __DIR__ . '/../include/bittorrent.php';
 require_once CLASS_DIR . 'class_user_options_2.php';
 $user = check_user_status();
-global $container, $site_config;
 
 $data = array_merge($_GET, $_POST);
 if (empty($data['id'])) {
@@ -27,20 +28,14 @@ $id = !empty($data['id']) ? (int) $data['id'] : 0;
 if (!is_valid_id($id)) {
     stderr(_('Error'), _('missing form data'));
 }
-$dt = TIME_NOW;
-// $fluent removed — use $this->db (ExtendedPdo)
-$row = $fluent->from('torrents AS t')
-              ->select(null)
-              ->select('t.id')
-              ->select('t.info_hash')
-              ->select('t.owner')
-              ->select('t.name')
-              ->select('t.seeders')
-              ->select('t.added')
-              ->select('u.seedbonus')
-              ->leftJoin('users AS u ON u.id=t.owner')
-              ->where('t.id = ?', $id)
-              ->fetch();
+$now = TIME_NOW;
+$row = $db->fetch(
+    'SELECT t.id, t.info_hash, t.owner, t.name, t.seeders, t.added, u.seedbonus
+    FROM torrents AS t
+    LEFT JOIN users AS u ON u.id = t.owner
+    WHERE t.id = :id',
+    [':id' => $id],
+);
 
 if (!$row) {
     stderr(_('Error'), _('Torrent does not exist'));
@@ -63,7 +58,7 @@ if ($rt === 1) {
     if (!$reason[2]) {
         stderr(_('Error'), _('Please describe the violated rule.'));
     }
-    $reasonstr = $site_config['site']['name'] . _(' rules broken: ') . trim($reason[2]);
+    $reasonstr = $config->get('site.name') . _(' rules broken: ') . trim($reason[2]);
 } else {
     if (!$reason[3]) {
         stderr(_('Error'), _('Please enter the reason for deleting this torrent.'));
@@ -75,14 +70,14 @@ $torrents_class->delete_by_id($row['id']);
 $torrents_class->remove_torrent($row['info_hash']);
 
 write_log(_fe('Torrent {0} ({1}) was deleted by {2} ({3})', $id, $row['name'], $user['username'], $reasonstr));
-if ($site_config['bonus']['on']) {
+if ($config->get('bonus.on')) {
     $user_class = $container->get(User::class);
-    $dt = sqlesc($dt - (14 * 86400));
-    if ($row['added'] > $dt) {
+    $cutoff = $now - (14 * 86400);
+    if ($row['added'] > $cutoff) {
         $owner = $user_class->getUserFromId($row['owner']);
         if (!empty($owner)) {
             $update = [
-                'seedbonus' => $owner['seedbonus'] - $site_config['bonus']['per_delete'],
+                'seedbonus' => $owner['seedbonus'] - $config->get('bonus.per_delete'),
             ];
             $user_class->update($update, $owner['id']);
         }
@@ -93,7 +88,7 @@ if ($user['id'] != $row['owner'] && ($user['opt2'] & class_user_options_2::PM_ON
     $subject = 'Torrent Deleted';
     $msgs_buffer[] = [
         'receiver' => $row['owner'],
-        'added' => $dt,
+        'added' => $now,
         'msg' => $msg,
         'subject' => $subject,
     ];
@@ -105,5 +100,5 @@ $session->set('is-success', $msg);
 if (!empty($data['returnto'])) {
     header('Location: ' . htmlsafechars($data['returnto']));
 } else {
-    header("Location: {$site_config['paths']['baseurl']}/browse.php");
+    header('Location: ' . $config->get('paths.baseurl') . '/browse.php');
 }

--- a/tools/configrepo_rollout_lint.txt
+++ b/tools/configrepo_rollout_lint.txt
@@ -565,3 +565,6 @@ No syntax errors detected in include/function_torrenttable.php
 >>>>>> master
 >>>>>> master
 >>>>>> master
+No syntax errors detected in public/clear_announcement.php
+No syntax errors detected in public/contactstaff.php
+No syntax errors detected in public/delete.php

--- a/tools/configrepo_rollout_report.csv
+++ b/tools/configrepo_rollout_report.csv
@@ -468,3 +468,6 @@ include/function_torrenttable.php,none,0,Removed stray global reuse after Config
 >>>>>> master
 >>>>>> master
 >>>>>> master
+public/clear_announcement.php,site_config,0,Replaced legacy site_config usage with ConfigRepository
+public/contactstaff.php,site_config,0,Replaced legacy site_config usage with ConfigRepository
+public/delete.php,site_config,0,Replaced legacy site_config usage with ConfigRepository


### PR DESCRIPTION
## Summary
- replace `site_config` usage in clear announcement, contact staff, and delete handlers with ConfigRepository lookups
- ensure affected scripts bootstrap ConfigRepository/Database correctly and clean up unused legacy code paths
- log lint results and report entries for the batch

## Testing
- php -l public/clear_announcement.php
- php -l public/contactstaff.php
- php -l public/delete.php

------
https://chatgpt.com/codex/tasks/task_e_68d21d58db108325b1e534dfeef77ffb