### PR TITLE
Harden web session cookie defaults

### DIFF
--- a/bootstrap_web.php
+++ b/bootstrap_web.php
@@ -11,6 +11,7 @@ if (file_exists(__DIR__ . '/include/app.php')) {
 }
 require_once __DIR__ . '/include/bootstrap_pdo.php';
 require_once __DIR__ . '/include/config_compat.php';
+require_once __DIR__ . '/include/helpers/cookies.php';
 require_once __DIR__ . '/include/session_bootstrap.php';
 
 $cacheDir = __DIR__ . '/storage/cache';

--- a/include/helpers/cookies.php
+++ b/include/helpers/cookies.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * set_app_cookie sets a cookie with security defaults.
+ */
+function set_app_cookie(
+    string $name,
+    string $value,
+    array $opts = []
+): void {
+    $ttl = (int) ($opts['ttl'] ?? 0);
+    $expires = $ttl > 0 ? time() + $ttl : 0;
+    $path = $opts['path'] ?? '/';
+    $domain = $opts['domain'] ?? '';
+    $secure = $opts['secure'] ?? true;
+    $httponly = $opts['httponly'] ?? true;
+    $samesite = $opts['samesite'] ?? 'Lax';
+
+    // >>>>>> PU239:cookie-helper-2
+    // PHP 7.3+ array syntax for setcookie
+    setcookie($name, $value, [
+        'expires' => $expires,
+        'path' => $path,
+        'domain' => $domain,
+        'secure' => $secure,
+        'httponly' => $httponly,
+        'samesite' => $samesite,
+    ]);
+    // >>>>>> PU239:cookie-use-3
+    // >>>>>> PU239:cookie-use-4
+    // >>>>>> PU239:cookie-use-5
+    // >>>>>> PU239:cookie-use-6
+}

--- a/include/session_bootstrap.php
+++ b/include/session_bootstrap.php
@@ -59,6 +59,14 @@ if (isset($sessionConfig['handler']) && is_string($sessionConfig['handler']) && 
 
 $startMode = is_string($sessionConfig['start_mode'] ?? null) ? $sessionConfig['start_mode'] : 'Strict';
 
+ini_set('session.use_strict_mode', '1');
+ini_set('session.cookie_secure', '1');
+ini_set('session.cookie_httponly', '1');
+ini_set('session.cookie_samesite', 'Lax');
+ini_set('session.use_only_cookies', '1');
+ini_set('session.cookie_lifetime', '0');
+// >>>>>> PU239:session-bootstrap-1
+
 if (session_status() !== PHP_SESSION_ACTIVE) {
     Session::start($startMode);
 }

--- a/tools/cookie_candidates.txt
+++ b/tools/cookie_candidates.txt
@@ -1,0 +1,3 @@
+bootstrap_web.php
+include/helpers/cookies.php
+include/session_bootstrap.php

--- a/tools/security_harden_lint.txt
+++ b/tools/security_harden_lint.txt
@@ -367,3 +367,6 @@ No syntax errors detected in public/wiki.php
 >>>>>> master
 >>>>>> master
 >>>>>> master
+No syntax errors detected in bootstrap_web.php
+No syntax errors detected in include/session_bootstrap.php
+No syntax errors detected in include/helpers/cookies.php

--- a/tools/security_harden_report.csv
+++ b/tools/security_harden_report.csv
@@ -349,3 +349,6 @@ public/wiki.php,false,true,2,false,"offset 110 run added wiki nav input escaping
 >>>>>> master
 >>>>>> master
 >>>>>> master
+bootstrap_web.php,0,false,0,Added cookie helper bootstrap include
+include/session_bootstrap.php,0,true,0,Forced session cookie ini defaults
+include/helpers/cookies.php,1,false,0,Created secure cookie helper

--- a/tools/security_harden_status.txt
+++ b/tools/security_harden_status.txt
@@ -1,1 +1,2 @@
 offset=105,batch_size=5: processed public/takethankyou.php, public/takeupload.php, public/tenpercent.php, public/upcoming.php, public/uploadapp.php
+2025-09-28T17:54:02Z, offset=0, size=3, changed=3, skipped=0, lint_fail=0, markers_used=6


### PR DESCRIPTION
## Summary
- enforce secure session cookie defaults before starting sessions
- add a centralized cookie helper with secure defaults and load it in the web bootstrap
- refresh security hardening artifacts for the current batch

## Testing
- php -l bootstrap_web.php
- php -l include/session_bootstrap.php
- php -l include/helpers/cookies.php

------
https://chatgpt.com/codex/tasks/task_e_68d97589c7248325b02ff031e4eb6b7b