### PR TITLE
Add audit logging to torrent uploads (offset 180)

### DIFF
--- a/classes/Support/Audit.php
+++ b/classes/Support/Audit.php
@@ -43,7 +43,6 @@ final class Audit
 }
 
 // >>>>>> PU239:audit-helper-1
-// >>>>>> PU239:audit-hook-2
 // >>>>>> PU239:audit-hook-3
 // >>>>>> PU239:audit-hook-4
 // >>>>>> PU239:audit-hook-5

--- a/public/recover.php
+++ b/public/recover.php
@@ -8,6 +8,7 @@ use Delight\Auth\InvalidSelectorTokenPairException;
 use Delight\Auth\ResetDisabledException;
 use Delight\Auth\TokenExpiredException;
 use Delight\Auth\TooManyRequestsException;
+use PU239\Support\Audit;
 use Pu239\Config\ConfigRepository;
 use Pu239\User;
 use Rakit\Validation\Validator;
@@ -69,6 +70,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($_POST['selector'])) {
         app_halt('Exit called');
     }
     $user->reset_password($post, false);
+    Audit::log($CURUSER['id'] ?? null, 'password.change', ['target' => $CURUSER['id'] ?? null]);
+    // >>>>>> PU239:audit-hook-2
 } elseif ($_SERVER['REQUEST_METHOD'] === 'GET' && !empty($_GET)) {
     $get = $_GET;
     unset($_POST, $_GET, $_FILES);

--- a/public/requests.php
+++ b/public/requests.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use PU239\Support\Audit;
 use Pu239\Bounty;
 use Pu239\Comment;
 use Pu239\Config\ConfigRepository;
@@ -12,7 +13,6 @@ use Pu239\User;
 use Rakit\Validation\Validator;
 
 require_once dirname(__DIR__) . '/bootstrap_web.php';
-require_once dirname(__DIR__) . '/include/helpers/audit.php';
 
 global $container;
 /** @var ConfigRepository $config */
@@ -383,7 +383,7 @@ if ($has_access) {
         $update = main_div($update, 'has-text-centered w-75 min-350', 'padding20');
     } elseif ($delete && is_valid_id($id)) {
         if ($request_class->delete($id, $user['class'] >= UC_STAFF, $user['id']) === 1) {
-            audit_log(
+            Audit::log(
                 $user['id'] ?? null,
                 'torrent.moderate',
                 [

--- a/public/restoreclass.php
+++ b/public/restoreclass.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
+use PU239\Support\Audit;
 use Pu239\Cache;
 use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\User;
 
 require_once dirname(__DIR__) . '/bootstrap_web.php';
-require_once dirname(__DIR__) . '/include/helpers/audit.php';
 
 global $container;
 /** @var ConfigRepository $config */
@@ -25,7 +25,7 @@ $set = [
 $previousOverride = $user['override_class'] ?? null;
 $users_class = $container->get(User::class);
 $users_class->update($set, $user['id']);
-audit_log(
+Audit::log(
     $user['id'] ?? null,
     'role.change',
     [

--- a/public/setclass.php
+++ b/public/setclass.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/bootstrap_web.php';
 
+use PU239\Support\Audit;
 use Pu239\Cache;
 use Pu239\Config\ConfigRepository;
 use Pu239\Database;
@@ -27,10 +28,21 @@ if ($user['class'] < UC_STAFF || $user['override_class'] != 255) {
 if (isset($_GET['action']) && htmlsafechars($_GET['action']) === 'editclass') {
     $newclass = (int) $_GET['class'];
     $returnto = htmlsafechars($_GET['returnto']);
+    $oldRole = $user['override_class'] ?? null;
     $set = [
         'override_class' => $newclass,
     ];
     $users_class->update($set, $user['id']);
+    Audit::log(
+        $user['id'] ?? null,
+        'role.change',
+        [
+            'target' => $user['id'] ?? null,
+            'from' => $oldRole,
+            'to' => $newclass,
+        ]
+    );
+    // >>>>>> PU239:audit-hook-2
     // $fluent removed — use $this->db (ExtendedPdo)
     $sql = "DELETE FROM ajax_chat_online WHERE userID = :userID";
     $db->perform($sql, ['userID' => $user['id']]);

--- a/public/take_theme.php
+++ b/public/take_theme.php
@@ -2,8 +2,7 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/bootstrap_web.php';
-require_once dirname(__DIR__) . '/include/helpers/audit.php';
-
+use PU239\Support\Audit;
 use Pu239\Config\ConfigRepository;
 use Pu239\Database;
 use Pu239\User;
@@ -25,7 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         ];
         $users_class = $container->get(User::class);
         $users_class->update($set, $user['id']);
-        audit_log(
+        Audit::log(
             $user['id'] ?? null,
             'config.update',
             [
@@ -33,6 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
                 'target' => $user['id'] ?? null,
             ]
         );
+        // >>>>>> PU239:audit-hook-3
     }
 }
 

--- a/public/takereseed.php
+++ b/public/takereseed.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
 require_once dirname(__DIR__) . '/bootstrap_web.php';
-require_once dirname(__DIR__) . '/include/helpers/audit.php';
 
+use PU239\Support\Audit;
 use Pu239\Cache;
 use Pu239\Config\ConfigRepository;
 use Pu239\Database;
@@ -94,7 +94,7 @@ if ($bonusEnabled) {
     );
 }
 
-audit_log(
+Audit::log(
     $user['id'] ?? null,
     'torrent.moderate',
     [
@@ -103,5 +103,6 @@ audit_log(
         'pm_scope' => $pm_what,
     ]
 );
+// >>>>>> PU239:audit-hook-4
 
 header("Refresh: 0; url={$baseUrl}/details.php?id=$reseedid");

--- a/public/takeupload.php
+++ b/public/takeupload.php
@@ -2,8 +2,6 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/bootstrap_web.php';
-require_once dirname(__DIR__) . '/include/helpers/audit.php';
-
 use Envms\FluentPDO\Literal;
 use Pu239\Cache;
 use Pu239\Config\ConfigRepository;
@@ -16,6 +14,7 @@ use Pu239\Session;
 use Pu239\Torrent;
 use Pu239\User;
 use Pu239\Usersachiev;
+use PU239\Support\Audit;
 
 require_once __DIR__ . '/../include/bittorrent.php';
 require_once CLASS_DIR . 'class.bencdec.php';
@@ -415,7 +414,8 @@ if (!$id) {
     why_die(_('Upload failed!'));
 }
 
-audit_log(
+// >>>>>> PU239:audit-hook-2
+Audit::log(
     $owner_id ?? null,
     'torrent.moderate',
     [

--- a/tools/audit_candidates.txt
+++ b/tools/audit_candidates.txt
@@ -1,9 +1,6 @@
 admin/acpmanage.php
 admin/adduser.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 admin/allagents.php
-=======
->>>>>> master
 admin/backup.php
 admin/banclient.php
 admin/bannedemails.php
@@ -11,10 +8,7 @@ admin/bans.php
 admin/block.settings.php
 admin/bonusmanage.php
 admin/categories.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 admin/changelog.php
-=======
->>>>>> master
 admin/cheaters.php
 admin/class_config.php
 admin/cleanup_manager.php
@@ -22,10 +16,7 @@ admin/cloudview.php
 admin/datareset.php
 admin/deathrow.php
 admin/delacct.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 admin/donations.php
-=======
->>>>>> master
 admin/doubleusers.php
 admin/edit_moods.php
 admin/editlog.php
@@ -36,33 +27,23 @@ admin/forum_config.php
 admin/forum_manage.php
 admin/freeleech.php
 admin/freeusers.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 admin/goaccess.php
-=======
->>>>>> master
 admin/grouppm.php
 admin/hit_and_run.php
 admin/hit_and_run_settings.php
 admin/hnrwarn.php
 admin/inactive.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 admin/invite_tree.php
 admin/ipcheck.php
 admin/iphistory.php
 admin/ipsearch.php
 admin/leechwarn.php
 admin/load.php
-=======
-admin/iphistory.php
-admin/ipsearch.php
-admin/leechwarn.php
->>>>>> master
 admin/log_viewer.php
 admin/manage_images.php
 admin/mass_bonus_for_members.php
 admin/mega_search.php
 admin/memcache.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 admin/modded_torrents.php
 admin/modtask.php
 admin/mysql_overview.php
@@ -88,27 +69,11 @@ admin/upgrade_database.php
 admin/uploadapps.php
 admin/uploader_info.php
 admin/user_hits.php
-=======
-admin/modtask.php
-admin/mysql_overview.php
-admin/news.php
-admin/over_forums.php
-admin/polls_manager.php
-admin/promo.php
-admin/reputation_settings.php
-admin/site_settings.php
-admin/sysoplog.php
-admin/themes.php
-admin/trivia_config.php
-admin/upgrade_database.php
-admin/uploadapps.php
->>>>>> master
 admin/usersearch.php
 admin/view_peers.php
 admin/watched_users.php
 public/achievementbonus.php
 public/achievementhistory.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/achievementlist.php
 public/ajax/adminer.css
 public/ajax/ajax_tooltips.php
@@ -125,14 +90,6 @@ public/ajax/isbn_lookup.php
 public/ajax/like.php
 public/ajax/member_input.php
 public/ajax/namecheck.php
-=======
-public/ajax/adminer.css
-public/ajax/bookmarks.php
-public/ajax/cooker_notify.php
-public/ajax/imdb_lookup.php
-public/ajax/like.php
-public/ajax/member_input.php
->>>>>> master
 public/ajax/offer_notify.php
 public/ajax/offer_status.php
 public/ajax/offer_vote.php
@@ -146,7 +103,6 @@ public/ajax/take_url_upload.php
 public/ajax/thanks.php
 public/ajax/torrents_lookup.php
 public/ajax/trivia_answers.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/ajax/trivia_lookup.php
 public/ajax/tvmaze_lookup.php
 public/ajax/usersearch.php
@@ -160,33 +116,21 @@ public/arcade.php
 public/arcade_top_scores.php
 public/bitbucket.php
 public/bjstats.php
-=======
-public/anatomy.php
-public/announce.php
-public/announcement.php
-public/bitbucket.php
->>>>>> master
 public/blackjack.php
 public/bookmarks.php
 public/bot_triggers.php
 public/browse.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/browserconfig.xml
 public/bugs.php
 public/casino.php
 public/catalog.php
 public/categoryids.php
 public/chat.php
-=======
-public/bugs.php
-public/casino.php
->>>>>> master
 public/clear_announcement.php
 public/contactstaff.php
 public/delete.php
 public/details.php
 public/download.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/download_multi.php
 public/downloadsub.php
 public/edit.php
@@ -215,97 +159,32 @@ public/peerlist.php
 public/polls_take_vote.php
 public/port_check.php
 public/recover.php
-=======
-public/edit.php
-public/faq.php
-public/fastdelete.php
-public/flash.php
-public/forums.php
-public/hnrs.php
-public/images/achievements/ul7.png
-public/images/anonymous_1.png
-public/images/flag/stlucia.gif
-public/images/games/asteroids.png
-public/images/games/autobahn.png
-public/images/smilies/starwars.gif
-public/images/smilies/yay.gif
-public/login.php
-public/media/flash_games/4wheelmadness.swf
-public/media/flash_games/DAbuddy_latest.swf
-public/media/flash_games/ExtremeRacing2.swf
-public/media/flash_games/Interactive_Buddy.swf
-public/media/flash_games/Solitaire.swf
-public/media/flash_games/SuperFlashMarioBrosSte.swf
-public/media/flash_games/alloyarena.swf
-public/media/flash_games/assin.swf
-public/media/flash_games/blackknight.swf
-public/media/flash_games/chainreactionGS.swf
-public/media/flash_games/demonicdefense.swf
-public/media/flash_games/galaga.swf
-public/media/flash_games/ghosts-and-goblins.swf
-public/media/flash_games/mario-cart.swf
-public/media/flash_games/mice_vs_hammers.swf
-public/media/flash_games/monster_mash.swf
-public/media/flash_games/monstermash.swf
-public/media/flash_games/psol.swf
-public/media/flash_games/sonicblox.swf
-public/media/flash_games/starcraft.swf
-public/media/flash_games/starcraftfa3.swf
-public/media/flash_games/summergames04.swf
-public/media/flash_games/supersplashBH.swf
-public/media/flash_games/trappedinawell.swf
-public/media/flash_games/yeti10.swf
-public/media/flash_games/yeti5pro.swf
-public/media/flash_games/yeti6.swf
-public/media/flash_games/yeti6snd.swf
-public/media/flash_games/yeti7.swf
-public/media/flash_games/yeti9v32JS.swf
-public/media/flash_games/yeti_sports_10.swf
-public/media/sounds/sound_2.mp3
-public/media/sounds/sound_3.wav
-public/media/sounds/sound_7.wav
-public/mybonus.php
-public/mytorrents.php
-public/offers.php
-public/polls_take_vote.php
->>>>>> master
 public/report.php
 public/requests.php
 public/restoreclass.php
 public/rss.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/rss_pdo_demo.php
 public/rsstfreak.php
 public/rules.php
 public/scrape.php
-=======
-public/rules.php
->>>>>> master
 public/search.php
 public/setclass.php
 public/sharemarks.php
 public/signup.php
 public/snatches.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/staff.php
 public/subtitles.php
 public/tags.php
-=======
-public/subtitles.php
->>>>>> master
 public/take_theme.php
 public/takereseed.php
 public/takethankyou.php
 public/takeupload.php
 public/tenpercent.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/tmovies.php
 public/topmoods.php
 public/topten.php
 public/trivia_results.php
 public/tvshows.php
-=======
->>>>>> master
 public/upcoming.php
 public/upload.php
 public/uploadapp.php
@@ -316,13 +195,10 @@ public/usercomment.php
 public/userdetails.php
 public/userhistory.php
 public/verify.php
-<<<<<< codex/add-centralized-audit-logging-95hh7k
 public/verify_email.php
 public/videoformats.php
 public/view_announce_history.php
 public/view_sql.php
 public/viewnfo.php
-=======
->>>>>> master
 public/wiki.php
 staffpanel/index.php

--- a/tools/security_harden_lint.txt
+++ b/tools/security_harden_lint.txt
@@ -381,3 +381,13 @@ No syntax errors detected in public/login.php
 >>>>>> master
 >>>>>> master
 >>>>>> master
+No syntax errors detected in classes/Support/Audit.php
+No syntax errors detected in public/recover.php
+No syntax errors detected in public/restoreclass.php
+No syntax errors detected in public/requests.php
+No syntax errors detected in classes/Support/Audit.php
+No syntax errors detected in public/setclass.php
+No syntax errors detected in public/take_theme.php
+No syntax errors detected in public/takereseed.php
+No syntax errors detected in classes/Support/Audit.php
+No syntax errors detected in public/takeupload.php

--- a/tools/security_harden_report.csv
+++ b/tools/security_harden_report.csv
@@ -436,3 +436,13 @@ public/login.php,1,[login.success],true,added audit log for login success
 >>>>>> master
 >>>>>> master
 >>>>>> master
+classes/Support/Audit.php,0,"[]",true,"batch offset=160"
+public/recover.php,1,"['password.change']",false,"password reset flow"
+public/restoreclass.php,1,"['role.change']",false,"override reset"
+public/requests.php,1,"['torrent.moderate']",false,"request deletion"
+classes/Support/Audit.php,0,"[]",true,"batch offset=170"
+public/setclass.php,1,"['role.change']",false,"override class edit"
+public/take_theme.php,1,"['config.update']",false,"stylesheet preference"
+public/takereseed.php,1,"['torrent.moderate']",false,"reseed request"
+classes/Support/Audit.php,0,"[]",true,"batch offset=180"
+public/takeupload.php,1,"['torrent.moderate']",false,"upload handler"

--- a/tools/security_harden_status.txt
+++ b/tools/security_harden_status.txt
@@ -104,3 +104,6 @@ offset=105,batch_size=5: processed public/takethankyou.php, public/takeupload.ph
 >>>>>> master
 >>>>>> master
 >>>>>> master
+2025-10-01T04:03:28Z, offset=160, size=10, changed=3, skipped=7, lint_fail=0, markers_used=6
+2025-10-01T04:15:30Z, offset=170, size=10, changed=3, skipped=7, lint_fail=0, markers_used=6
+2025-10-01T04:25:30Z, offset=180, size=10, changed=2, skipped=8, lint_fail=0, markers_used=6


### PR DESCRIPTION
## Summary
- wire PU239\Support\Audit into the class override handler to capture role changes and drop the legacy helper requirement
- add centralized audit coverage for theme changes and reseed requests while cleaning up helper dependencies
- extend the batch-170 lint/report/status logs and record the offset-180 bookkeeping alongside the helper comment markers
- hook the torrent upload handler into PU239\Support\Audit so successful uploads emit `torrent.moderate` events without the include-based helper

## Testing
- php -l classes/Support/Audit.php
- php -l public/takeupload.php

------
https://chatgpt.com/codex/tasks/task_e_68dca6dcf8a08325b238eb39f2d21734