### PR TITLE
chore(security): rate-limit tuning (redis, retry-after, per-route)

### DIFF
--- a/admin/bans.php
+++ b/admin/bans.php
@@ -28,6 +28,11 @@ $db = $container->get(Database::class);
 $fluent = $db;
 $s = $s ?? static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 $self = $s($_SERVER['PHP_SELF'] ?? '');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // >>>>>> PU239:ratelimiter-tune-4
+    rate_limit_or_fail();
+}
 $baseurl = $s($config->get('paths.baseurl'));
 $remove = isset($_GET['remove']) ? (int) $_GET['remove'] : 0;
 if ($remove > 0) {

--- a/admin/inactive.php
+++ b/admin/inactive.php
@@ -26,6 +26,11 @@ $session = $container->get(Session::class);
 $class = get_access(basename($_SERVER['REQUEST_URI']));
 class_check($class);
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // >>>>>> PU239:ratelimiter-tune-5
+    rate_limit_or_fail();
+}
+
 $s = $s ?? static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 $self = $s($_SERVER['PHP_SELF'] ?? '');
 $baseurlRaw = (string) $config->get('paths.baseurl');

--- a/classes/Security/RateLimiter.php
+++ b/classes/Security/RateLimiter.php
@@ -1,0 +1,439 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Security;
+
+use JsonException;
+use Redis;
+use RedisException;
+
+final class RateLimiter
+{
+    private const PREFIX = 'pu239:ratelimit:';
+    private const FS_GC_THRESHOLD = 50;
+
+    /**
+     * Enforce the rate limit for the current request.
+     *
+     * @return array{0: bool, 1: int} [allowed, retryAfterSeconds]
+     */
+    public static function check(?int $limit = null, ?int $window = null): array
+    {
+        if (!isset($_SERVER['REQUEST_METHOD']) || strtoupper((string) $_SERVER['REQUEST_METHOD']) !== 'POST') {
+            return [true, 0];
+        }
+
+        $ip = (string) ($_SERVER['REMOTE_ADDR'] ?? 'unknown');
+        $path = self::currentPath();
+
+        if (self::isAllowlisted($ip, $path)) {
+            return [true, 0];
+        }
+
+        $limit = $limit ?? self::defaultLimit();
+        $window = $window ?? self::defaultWindow();
+        $window = max(1, $window);
+
+        $key = self::cacheKey($ip, $path, $limit, $window);
+        $now = time();
+
+        $driver = self::driver();
+        if ($driver === 'redis') {
+            return self::checkRedis($key, $limit, $window);
+        }
+        if ($driver === 'fs') {
+            return self::checkFilesystem($key, $limit, $window, $now);
+        }
+
+        return self::checkApcu($key, $limit, $window, $now);
+    }
+
+    private static function defaultLimit(): int
+    {
+        $limit = getenv('RATE_DEFAULT_LIMIT');
+        $limit = is_string($limit) && $limit !== '' ? (int) $limit : 10;
+
+        return max(1, $limit);
+    }
+
+    private static function defaultWindow(): int
+    {
+        $window = getenv('RATE_DEFAULT_WINDOW');
+        $window = is_string($window) && $window !== '' ? (int) $window : 60;
+
+        return max(1, $window);
+    }
+
+    public static function loginDefaults(): array
+    {
+        $limit = getenv('RATE_LOGIN_LIMIT');
+        $window = getenv('RATE_LOGIN_WINDOW');
+
+        $limit = is_string($limit) && $limit !== '' ? (int) $limit : 5;
+        $window = is_string($window) && $window !== '' ? (int) $window : 60;
+
+        return [max(1, $limit), max(1, $window)];
+    }
+
+    private static function cacheKey(string $ip, string $path, int $limit, int $window): string
+    {
+        $hash = hash('sha256', implode('|', [$ip, $path, $limit, $window]));
+
+        return self::PREFIX . $hash;
+    }
+
+    private static function driver(): string
+    {
+        static $driver;
+        if ($driver !== null) {
+            return $driver;
+        }
+
+        $candidate = strtolower((string) getenv('RATE_DRIVER'));
+        if ($candidate === '') {
+            $candidate = 'apcu';
+        }
+
+        if ($candidate === 'redis' && self::redisClient() === null) {
+            $candidate = self::apcuAvailable() ? 'apcu' : 'fs';
+        } elseif ($candidate === 'apcu' && !self::apcuAvailable()) {
+            $candidate = self::redisClient() !== null ? 'redis' : 'fs';
+        }
+
+        if ($candidate !== 'redis' && $candidate !== 'apcu' && $candidate !== 'fs') {
+            $candidate = self::apcuAvailable() ? 'apcu' : 'fs';
+        }
+
+        if ($candidate === 'fs') {
+            self::ensureFilesystemStorage();
+        }
+
+        $driver = $candidate;
+
+        return $driver;
+    }
+
+    private static function checkRedis(string $key, int $limit, int $window): array
+    {
+        $redis = self::redisClient();
+        if ($redis === null) {
+            return self::checkApcu($key, $limit, $window, time());
+        }
+
+        try {
+            $count = (int) $redis->incr($key);
+            if ($count === 1) {
+                $redis->expire($key, $window);
+            }
+
+            $ttl = (int) $redis->ttl($key);
+            if ($ttl < 0) {
+                $redis->expire($key, $window);
+                $ttl = $window;
+            }
+
+            if ($count > $limit) {
+                return [false, max(1, $ttl)];
+            }
+
+            return [true, max(0, $ttl)];
+        } catch (RedisException $e) {
+            error_log('RateLimiter redis failure: ' . $e->getMessage());
+
+            return self::checkApcu($key, $limit, $window, time());
+        }
+    }
+
+    private static function checkApcu(string $key, int $limit, int $window, int $now): array
+    {
+        if (!self::apcuAvailable()) {
+            return self::checkFilesystem($key, $limit, $window, $now);
+        }
+
+        $data = apcu_fetch($key);
+        if (!is_array($data) || !isset($data['count'], $data['expires_at']) || $data['expires_at'] < $now) {
+            $data = [
+                'count' => 0,
+                'expires_at' => $now + $window,
+            ];
+        }
+
+        if ($data['count'] >= $limit) {
+            $retryAfter = max(1, $data['expires_at'] - $now);
+            apcu_store($key, $data, $window);
+
+            return [false, $retryAfter];
+        }
+
+        $data['count']++;
+        apcu_store($key, $data, $window);
+
+        return [true, max(0, $data['expires_at'] - $now)];
+    }
+
+    private static function checkFilesystem(string $key, int $limit, int $window, int $now): array
+    {
+        $dir = self::filesystemStorage();
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0755, true);
+        }
+
+        $file = $dir . DIRECTORY_SEPARATOR . $key . '.json';
+        $data = null;
+        if (is_file($file)) {
+            $json = file_get_contents($file);
+            if (is_string($json) && $json !== '') {
+                try {
+                    $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+                    if (is_array($decoded)) {
+                        $data = $decoded;
+                    }
+                } catch (JsonException) {
+                    $data = null;
+                }
+            }
+        }
+
+        if (!is_array($data) || !isset($data['count'], $data['expires_at']) || $data['expires_at'] < $now) {
+            $data = [
+                'count' => 0,
+                'expires_at' => $now + $window,
+            ];
+        }
+
+        if ($data['count'] >= $limit) {
+            $retryAfter = max(1, $data['expires_at'] - $now);
+            self::writeFilesystem($file, $data);
+
+            return [false, $retryAfter];
+        }
+
+        $data['count']++;
+        self::writeFilesystem($file, $data);
+        self::maybePruneFilesystem($dir, $now);
+
+        return [true, max(0, $data['expires_at'] - $now)];
+    }
+
+    private static function writeFilesystem(string $file, array $data): void
+    {
+        try {
+            file_put_contents($file, json_encode($data, JSON_THROW_ON_ERROR), LOCK_EX);
+        } catch (JsonException) {
+            // Fallback to best-effort encoding without exceptions
+            file_put_contents($file, json_encode($data), LOCK_EX);
+        }
+
+        if (isset($data['expires_at']) && is_int($data['expires_at'])) {
+            @touch($file, $data['expires_at']);
+        }
+    }
+
+    private static function maybePruneFilesystem(string $dir, int $now): void
+    {
+        static $pruned = false;
+        if ($pruned) {
+            return;
+        }
+
+        if (mt_rand(1, self::FS_GC_THRESHOLD) !== 1) {
+            return;
+        }
+
+        $pruned = true;
+        $files = glob($dir . DIRECTORY_SEPARATOR . '*.json');
+        if ($files === false) {
+            return;
+        }
+
+        foreach ($files as $file) {
+            $expiresAt = @filemtime($file);
+            if ($expiresAt !== false && $expiresAt < $now) {
+                @unlink($file);
+            }
+        }
+    }
+
+    private static function ensureFilesystemStorage(): void
+    {
+        $dir = self::filesystemStorage();
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0755, true);
+        }
+    }
+
+    private static function filesystemStorage(): string
+    {
+        $root = defined('ROOT_DIR') ? (string) ROOT_DIR : dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+
+        return rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'storage' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'ratelimit';
+    }
+
+    private static function currentPath(): string
+    {
+        $path = $_SERVER['SCRIPT_NAME'] ?? ($_SERVER['REQUEST_URI'] ?? '');
+        $path = is_string($path) ? $path : '';
+
+        return $path === '' ? '/' : $path;
+    }
+
+    private static function isAllowlisted(string $ip, string $path): bool
+    {
+        foreach (self::allowIps() as $allowedIp) {
+            if ($allowedIp !== '' && strcasecmp($allowedIp, $ip) === 0) {
+                return true;
+            }
+        }
+
+        $normalizedPath = '/' . ltrim($path, '/');
+        foreach (self::allowPaths() as $prefix) {
+            if ($prefix === '') {
+                continue;
+            }
+            $normalizedPrefix = '/' . ltrim($prefix, '/');
+            if (str_starts_with($normalizedPath, $normalizedPrefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function allowIps(): array
+    {
+        static $ips;
+        if ($ips !== null) {
+            return $ips;
+        }
+
+        $raw = getenv('RATE_ALLOW_IPS');
+        if (!is_string($raw) || trim($raw) === '') {
+            $ips = [];
+
+            return $ips;
+        }
+
+        $parts = array_map(static fn(string $value): string => trim($value), explode(',', $raw));
+        $ips = array_values(array_filter($parts, static fn(string $value): bool => $value !== ''));
+
+        return $ips;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function allowPaths(): array
+    {
+        static $paths;
+        if ($paths !== null) {
+            return $paths;
+        }
+
+        $raw = getenv('RATE_ALLOW_PATHS');
+        if (!is_string($raw) || trim($raw) === '') {
+            $paths = [];
+
+            return $paths;
+        }
+
+        $parts = array_map(static fn(string $value): string => trim($value), explode(',', $raw));
+        $paths = array_values(array_filter($parts, static fn(string $value): bool => $value !== ''));
+
+        return $paths;
+    }
+
+    private static function apcuAvailable(): bool
+    {
+        if (!function_exists('apcu_fetch')) {
+            return false;
+        }
+
+        $enabled = (bool) ini_get('apc.enabled');
+        if (PHP_SAPI === 'cli') {
+            $enabled = $enabled && (bool) ini_get('apc.enable_cli');
+        }
+
+        return $enabled;
+    }
+
+    private static function redisClient(): ?Redis
+    {
+        static $client;
+        static $attempted = false;
+        if ($client instanceof Redis) {
+            return $client;
+        }
+        if ($attempted) {
+            return null;
+        }
+        $attempted = true;
+
+        if (!class_exists(Redis::class)) {
+            return null;
+        }
+
+        $dsn = getenv('REDIS_DSN');
+        $host = '127.0.0.1';
+        $port = 6379;
+        $password = null;
+        $database = null;
+        $timeout = 1.0;
+
+        if (is_string($dsn) && $dsn !== '') {
+            $parts = parse_url($dsn);
+            if ($parts !== false) {
+                $host = $parts['host'] ?? $host;
+                $port = isset($parts['port']) ? (int) $parts['port'] : $port;
+                if (isset($parts['user']) || isset($parts['pass'])) {
+                    $authUser = $parts['user'] ?? '';
+                    $authPass = $parts['pass'] ?? '';
+                    $password = $authPass !== '' ? $authPass : ($authUser !== '' ? $authUser : null);
+                }
+                if (!empty($parts['path'])) {
+                    $dbPath = ltrim($parts['path'], '/');
+                    if ($dbPath !== '') {
+                        $database = (int) $dbPath;
+                    }
+                }
+                if (!empty($parts['query'])) {
+                    parse_str($parts['query'], $query);
+                    if (isset($query['db'])) {
+                        $database = (int) $query['db'];
+                    }
+                    if (isset($query['timeout'])) {
+                        $timeout = (float) $query['timeout'];
+                    }
+                }
+            }
+        } else {
+            $envHost = getenv('REDIS_HOST');
+            $envPort = getenv('REDIS_PORT');
+            if (is_string($envHost) && $envHost !== '') {
+                $host = $envHost;
+            }
+            if (is_string($envPort) && $envPort !== '') {
+                $port = (int) $envPort;
+            }
+        }
+
+        try {
+            $redis = new Redis();
+            $redis->connect($host, $port, $timeout);
+            if ($password !== null && $password !== '') {
+                $redis->auth($password);
+            }
+            if ($database !== null) {
+                $redis->select($database);
+            }
+            $client = $redis;
+        } catch (RedisException $e) {
+            error_log('RateLimiter redis connect failure: ' . $e->getMessage());
+            $client = null;
+        }
+
+        return $client;
+    }
+}

--- a/include/helpers/http.php
+++ b/include/helpers/http.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use PU239\Security\RateLimiter;
+
 if (!function_exists('json_out')) {
     /**
      * Outputs JSON with correct headers and throws on encoding errors.
@@ -17,6 +19,33 @@ if (!function_exists('json_out')) {
         }
         echo json_encode($payload, JSON_THROW_ON_ERROR);
         exit;
+    }
+}
+
+if (!function_exists('http_too_many_requests')) {
+    /**
+     * Emit a 429 response with a friendly message.
+     */
+    function http_too_many_requests(int $retryAfter): never
+    {
+        if (!headers_sent()) {
+            http_response_code(429);
+            header('Content-Type: text/plain; charset=utf-8');
+            header('Retry-After: ' . max(1, $retryAfter));
+        }
+        echo 'Too many requests. Please try again in ' . max(1, $retryAfter) . ' seconds.';
+        exit;
+    }
+}
+
+if (!function_exists('rate_limit_or_fail')) {
+    function rate_limit_or_fail(?int $limit = null, ?int $window = null): void
+    {
+        // >>>>>> PU239:ratelimiter-tune-1
+        [$allowed, $retryAfter] = RateLimiter::check($limit, $window);
+        if (!$allowed) {
+            http_too_many_requests($retryAfter);
+        }
     }
 }
 

--- a/public/login.php
+++ b/public/login.php
@@ -29,6 +29,11 @@ if ($auth->isLoggedIn()) {
     app_halt('Exit called');
 }
 get_template();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // >>>>>> PU239:ratelimiter-tune-2
+    [$loginLimit, $loginWindow] = \PU239\Security\RateLimiter::loginDefaults();
+    rate_limit_or_fail($loginLimit, $loginWindow);
+}
 $bans_class = $container->get(Ban::class);
 if ($bans_class->get_count($ip = getip(0)) > 0) {
     stderr(_('Error'), _fe('This IP ({0}) address has been banned.', $ip));

--- a/public/signup.php
+++ b/public/signup.php
@@ -32,6 +32,8 @@ if ($auth->isLoggedIn()) {
 }
 get_template();
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // >>>>>> PU239:ratelimiter-tune-3
+    rate_limit_or_fail();
     // TODO(2025): add CSRF verification
     $user = $container->get(User::class);
     $validator = $container->get(Validator::class);

--- a/staffpanel/index.php
+++ b/staffpanel/index.php
@@ -58,6 +58,11 @@ $sanitize = static fn(mixed $value): string => htmlspecialchars((string) $value,
 
 class_check(UC_STAFF);
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // >>>>>> PU239:ratelimiter-tune-6
+    rate_limit_or_fail();
+}
+
 // TODO(2025): map legacy key "site.staffpanel_online" to appropriate config path
 if (!$config->bool('site.staffpanel_online', true)) {
     stderr(_('Information'), _('The staffpanel is currently offline for maintenance work'));

--- a/tools/security_harden_lint.txt
+++ b/tools/security_harden_lint.txt
@@ -653,3 +653,19 @@ No syntax errors detected in staffpanel/index.php
 >>>>>> master
 >>>>>> master
 >>>>>> master
+No syntax errors detected in classes/Security/RateLimiter.php
+No syntax errors detected in include/helpers/http.php
+No syntax errors detected in public/login.php
+No syntax errors detected in public/signup.php
+
+Parse error: syntax error, unexpected token "<<", expecting end of file in admin/acpmanage.php on line 14
+Errors parsing admin/acpmanage.php
+
+Parse error: syntax error, unexpected token "<<", expecting end of file in admin/adduser.php on line 18
+Errors parsing admin/adduser.php
+No syntax errors detected in staffpanel/index.php
+No syntax errors detected in admin/bans.php
+No syntax errors detected in admin/inactive.php
+No syntax errors detected in classes/Security/RateLimiter.php
+No syntax errors detected in classes/Security/RateLimiter.php
+No syntax errors detected in classes/Security/RateLimiter.php

--- a/tools/security_harden_report.csv
+++ b/tools/security_harden_report.csv
@@ -636,3 +636,10 @@ staffpanel/index.php,true,staff_any,true,
 >>>>>> master
 >>>>>> master
 >>>>>> master
+file,driver,limit,window,allowlist_hit,notes
+classes/Security/RateLimiter.php,redis,0,0,false,"Added Redis/apcu/fs support with allowlists"
+public/login.php,redis,5,60,false,"Login attempts limited"
+public/signup.php,redis,10,60,false,"Signup POST limited"
+admin/bans.php,redis,10,60,false,"Admin actions limited"
+admin/inactive.php,redis,10,60,false,"Inactive cleanup limited"
+staffpanel/index.php,redis,10,60,false,"Staffpanel POST limited"


### PR DESCRIPTION
## Summary
- introduce `PU239\Security\RateLimiter` supporting redis/apcu/fs storage, per-route defaults, and allowlists
- add reusable HTTP helper to emit 429 responses and gate POST handlers through the new rate limiter
- apply tuned POST rate limiting to login, signup, admin bans, inactive cleanup, and staff panel endpoints with reporting updates

## Testing
- php -l classes/Security/RateLimiter.php include/helpers/http.php public/login.php public/signup.php admin/bans.php admin/inactive.php staffpanel/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e002d9d0f88325828edd4e9da25490