### PR TITLE
Introduce router front controller and middleware pipeline

### DIFF
--- a/admin/namechanger.php
+++ b/admin/namechanger.php
@@ -1,6 +1,12 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/../public/index.php';
+
+    return;
+}
+
 require_once dirname(__DIR__) . '/bootstrap_web.php';
 
 use PU239\Security\AuthZ;

--- a/admin/reports.php
+++ b/admin/reports.php
@@ -1,6 +1,12 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/../public/index.php';
+
+    return;
+}
+
 require_once dirname(__DIR__) . '/bootstrap_web.php';
 
 use PU239\Security\AuthZ;

--- a/classes/Http/Handlers/Admin/NamechangerHandler.php
+++ b/classes/Http/Handlers/Admin/NamechangerHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\Admin;
+
+final class NamechangerHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/admin/namechanger.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/Admin/ReportsHandler.php
+++ b/classes/Http/Handlers/Admin/ReportsHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\Admin;
+
+final class ReportsHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/admin/reports.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/HomeHandler.php
+++ b/classes/Http/Handlers/HomeHandler.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers;
+
+final class HomeHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 3) . '/public/index.legacy.php';
+
+        return null;
+    }
+}
+
+// >>>>>> PU239:http-handler-6

--- a/classes/Http/Handlers/PublicSite/CoinsHandler.php
+++ b/classes/Http/Handlers/PublicSite/CoinsHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class CoinsHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/coins.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/PublicSite/CreditsHandler.php
+++ b/classes/Http/Handlers/PublicSite/CreditsHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class CreditsHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/credits.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/PublicSite/FriendsHandler.php
+++ b/classes/Http/Handlers/PublicSite/FriendsHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class FriendsHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/friends.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/PublicSite/GiftHandler.php
+++ b/classes/Http/Handlers/PublicSite/GiftHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class GiftHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/gift.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/PublicSite/InviteHandler.php
+++ b/classes/Http/Handlers/PublicSite/InviteHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class InviteHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/invite.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/PublicSite/MessagesHandler.php
+++ b/classes/Http/Handlers/PublicSite/MessagesHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class MessagesHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/messages.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/PublicSite/ReputationHandler.php
+++ b/classes/Http/Handlers/PublicSite/ReputationHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\PublicSite;
+
+final class ReputationHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/public/reputation.php';
+
+        return null;
+    }
+}

--- a/classes/Http/Handlers/Staffpanel/IndexHandler.php
+++ b/classes/Http/Handlers/Staffpanel/IndexHandler.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Handlers\Staffpanel;
+
+final class IndexHandler
+{
+    public function handle(array $meta = []): mixed
+    {
+        if (!defined('PU239_ROUTED')) {
+            define('PU239_ROUTED', true);
+        }
+
+        require \dirname(__DIR__, 4) . '/staffpanel/index.php';
+
+        return null;
+    }
+}

--- a/classes/Http/MiddlewarePipeline.php
+++ b/classes/Http/MiddlewarePipeline.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http;
+
+use PU239\Http\Middlewares\AuthZGate;
+
+final class MiddlewarePipeline
+{
+    /** @var array<int, object> */
+    private array $stack;
+
+    public function __construct(array $stack)
+    {
+        $this->stack = $stack;
+    }
+
+    public function handle(Router $router): void
+    {
+        $next = static function () use ($router) {
+            [$handler, $meta] = $router->dispatch();
+            $runner = static function () use ($handler, $meta) {
+                if (!class_exists($handler)) {
+                    throw new \RuntimeException('Route handler not found: ' . $handler);
+                }
+                $instance = new $handler();
+                if (!method_exists($instance, 'handle')) {
+                    throw new \RuntimeException('Handler missing handle() method: ' . $handler);
+                }
+                return $instance->handle($meta);
+            };
+
+            if (isset($meta['authz'])) {
+                $gate = $meta['authz'];
+                if (!$gate instanceof AuthZGate) {
+                    $gate = new AuthZGate($gate);
+                }
+
+                return $gate->process($runner);
+            }
+
+            return $runner();
+        };
+
+        foreach (array_reverse($this->stack) as $middleware) {
+            $prev = $next;
+            $next = static function () use ($middleware, $prev) {
+                if (method_exists($middleware, 'process')) {
+                    return $middleware->process($prev);
+                }
+
+                return $prev();
+            };
+        }
+
+        $response = $next();
+
+        if ($response instanceof \Stringable) {
+            echo (string) $response;
+
+            return;
+        }
+
+        if (is_string($response)) {
+            echo $response;
+
+            return;
+        }
+
+        if ($response !== null && !is_bool($response)) {
+            echo (string) $response;
+        }
+    }
+}
+
+// >>>>>> PU239:http-pipeline-3

--- a/classes/Http/Middlewares/AuthZGate.php
+++ b/classes/Http/Middlewares/AuthZGate.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Middlewares;
+
+use PU239\Security\AuthZ;
+
+final class AuthZGate
+{
+    /** @param string|array $requirement */
+    public function __construct(private $requirement)
+    {
+    }
+
+    public function process(callable $next)
+    {
+        $requirement = $this->requirement;
+        if (is_array($requirement)) {
+            if (isset($requirement['any']) && is_array($requirement['any'])) {
+                AuthZ::requireAnyRole(array_map('strval', $requirement['any']));
+            } elseif (isset($requirement['all']) && is_array($requirement['all'])) {
+                foreach ($requirement['all'] as $role) {
+                    AuthZ::requireRole((string) $role);
+                }
+            } elseif (isset($requirement['role'])) {
+                AuthZ::requireRole((string) $requirement['role']);
+            }
+        } else {
+            AuthZ::requireRole((string) $requirement);
+        }
+
+        return $next();
+    }
+}
+
+// >>>>>> PU239:http-mw-5

--- a/classes/Http/Middlewares/CsrfGate.php
+++ b/classes/Http/Middlewares/CsrfGate.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Middlewares;
+
+use PU239\Support\Csrf;
+
+final class CsrfGate
+{
+    public function process(callable $next)
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        if ($method === 'POST') {
+            if (!Csrf::verify($_POST['csrf'] ?? '')) {
+                http_response_code(419);
+                exit('CSRF verification failed.');
+            }
+        }
+
+        return $next();
+    }
+}

--- a/classes/Http/Middlewares/JsonOut.php
+++ b/classes/Http/Middlewares/JsonOut.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Middlewares;
+
+use JsonSerializable;
+
+final class JsonOut
+{
+    public function process(callable $next)
+    {
+        $result = $next();
+        if (is_array($result) || $result instanceof JsonSerializable) {
+            if (!headers_sent()) {
+                header('Content-Type: application/json');
+            }
+
+            return json_encode($result, JSON_THROW_ON_ERROR);
+        }
+
+        return $result;
+    }
+}

--- a/classes/Http/Middlewares/RateLimitPost.php
+++ b/classes/Http/Middlewares/RateLimitPost.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Middlewares;
+
+use PU239\Security\RateLimiter;
+
+final class RateLimitPost
+{
+    public function __construct(private int $limit, private int $window)
+    {
+    }
+
+    public function process(callable $next)
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        if ($method === 'POST') {
+            $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+            $path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+            if (!RateLimiter::check($ip . ':' . $path, $this->limit, $this->window)) {
+                http_response_code(429);
+                header('Retry-After: ' . $this->window);
+                exit('Too Many Requests');
+            }
+        }
+
+        return $next();
+    }
+}

--- a/classes/Http/Middlewares/SecurityHeaders.php
+++ b/classes/Http/Middlewares/SecurityHeaders.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http\Middlewares;
+
+final class SecurityHeaders
+{
+    public function process(callable $next)
+    {
+        if (!headers_sent()) {
+            header('X-Content-Type-Options: nosniff');
+            header('Referrer-Policy: no-referrer-when-downgrade');
+            header('X-Frame-Options: DENY');
+        }
+
+        return $next();
+    }
+}
+
+// >>>>>> PU239:http-mw-4

--- a/classes/Http/Router.php
+++ b/classes/Http/Router.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\Http;
+
+final class Router
+{
+    /** @var array<string, array<int, array{handler: string, meta: array, path: string}>> */
+    private array $routes = ['GET' => [], 'POST' => []];
+
+    public function get(string $path, string $handler, array $meta = []): void
+    {
+        $this->routes['GET'][] = ['handler' => $handler, 'meta' => $meta, 'path' => $path];
+    }
+
+    public function post(string $path, string $handler, array $meta = []): void
+    {
+        $this->routes['POST'][] = ['handler' => $handler, 'meta' => $meta, 'path' => $path];
+    }
+
+    /**
+     * @return array{0: string, 1: array}
+     */
+    public function dispatch(): array
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $uri = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+        foreach ($this->routes[$method] ?? [] as $route) {
+            if ($route['path'] === $uri) {
+                return [$route['handler'], $route['meta']];
+            }
+        }
+        http_response_code(404);
+        exit('Not Found');
+    }
+}
+
+// >>>>>> PU239:http-router-2

--- a/classes/Security/PasswordHasher.php
+++ b/classes/Security/PasswordHasher.php
@@ -45,4 +45,3 @@ final class PasswordHasher
     }
 }
 
-// >>>>>> PU239:pwdlight-helper-1

--- a/public/coins.php
+++ b/public/coins.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/credits.php
+++ b/public/credits.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/friends.php
+++ b/public/friends.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/gift.php
+++ b/public/gift.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/index.legacy.php
+++ b/public/index.legacy.php
@@ -1,0 +1,361 @@
+<?php
+declare(strict_types=1);
+require_once dirname(__DIR__) . '/bootstrap_web.php';
+
+$db = $container->get(Database::class);
+
+
+
+
+
+use PU239\Config\ConfigRepository;
+use Pu239\Message;
+use Pu239\PollVoter;
+use Pu239\Session;
+use Pu239\Torrent;
+
+require_once __DIR__ . '/../include/bittorrent.php';
+require_once CLASS_DIR . 'class_user_options.php';
+require_once CLASS_DIR . 'class_user_options_2.php';
+$user = check_user_status();
+$stdhead = [
+    'css' => [
+        get_file_name('index_css'),
+    ],
+];
+$stdfoot = [
+    'js' => [
+        get_file_name('parallax_js'),
+        has_access($user['class'], UC_STAFF, '') ? get_file_name('offer_js') : '',
+    ],
+];
+if ((isset($_GET['act']) && $_GET['act'] === 'Arcade' && isset($_POST['gname'])) || (isset($_POST['module']) && $_POST['module'] === 'pnFlashGames')) {
+    include_once INCL_DIR . 'arcade.php';
+}
+$HTMLOUT = '';
+global $container;
+/** @var ConfigRepository $config */
+$config = $container->get(ConfigRepository::class);
+$messages_class = $container->get(Message::class);
+$unread = $messages_class->get_count($user['id'], $config->get('pm.inbox'), true);
+
+if ($unread >= 1) {
+    $session = $container->get(Session::class);
+    $session->set('is-link', [
+        'message' => _pfe('You have {0} unread message in your inbox', 'You have {0} unread messages in your inbox', $unread),
+        'link' => "{$config->get('paths.baseurl')}/messages.php",
+    ]);
+}
+
+$pollvoter_class = $container->get(PollVoter::class);
+$poll_data = $pollvoter_class->get_user_poll($user['id']);
+if ($config->get('poll.forced') && !empty($poll_data['pid']) && empty($poll_data['user_id'])) {
+    $stdfoot['js'] = array_merge($stdfoot['js'], [
+        get_file_name('scroll_to_poll_js'),
+    ]);
+}
+$above_columns = [];
+$below_columns = [
+    'disclaimer',
+];
+$left_column = [
+    'tfreak_feed',
+];
+$center_column = [
+    'glide',
+    'ajaxchat',
+    'torrents_scroller',
+    'cooker',
+    'requests',
+    'offers',
+    'torrents_mow',
+    'staffpicks',
+    'torrents_top',
+    'latest_torrents',
+    'latest_movies',
+    'latest_tv',
+    'forum_posts',
+    'site_poll',
+];
+$right_column = [
+    'trivia',
+    'advertise',
+    'site_news',
+    'site_stats',
+    'posted_comments',
+    'latest_user',
+    'birthday_users',
+    'active_users_irc',
+    'active_users',
+    'active_users_24',
+    'christmas_gift',
+];
+$christmas_gift = $posted_comments = $advertise = $active_users = $active_users_irc = $birthday_users = $active_users_24 = $forum_posts = $staffpicks = $disclaimer = $trivia = $glide = $ajaxchat = '';
+$tfreak_feed = $torrents_top = $site_stats = $site_poll = $site_news = $torrents_mow = $latest_user = $torrents_scroller = $latest_torrents = $latest_movies = $latest_tv = $cooker = $requests = $offers = '';
+$available_columns = array_merge($above_columns, $left_column, $center_column, $right_column, $below_columns);
+$remove_columns = $user['class'] < UC_STAFF ? $config->get('site.staff_blocks') : [];
+$torrents_class = $container->get(Torrent::class);
+$available_columns = $user['status'] === 0 ? array_diff($available_columns, $remove_columns) : [];
+$dir = BLOCK_DIR . 'index' . DIRECTORY_SEPARATOR;
+if (in_array('glide', $available_columns) && $torrents_class->get_torrent_count() >= 10 && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS_SLIDER && $BLOCKS['latest_torrents_slider_on']) {
+    $stdfoot = array_merge_recursive($stdfoot, [
+        'js' => [
+            get_file_name('glider_js'),
+        ],
+    ]);
+    include_once $dir . 'latest_torrents_glide.php';
+} else {
+    $remove_columns[] = 'glide';
+}
+
+if (in_array('ajaxchat', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::AJAXCHAT && $BLOCKS['ajaxchat_on'] && $user['chatpost'] === 1) {
+    $stdfoot = array_merge_recursive($stdfoot, [
+        'js' => [
+            get_file_name('trivia_js'),
+        ],
+    ]);
+    include_once $dir . 'ajaxchat.php';
+} else {
+    $remove_columns[] = 'ajaxchat';
+}
+
+if (in_array('trivia', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::TRIVIA && $BLOCKS['trivia_on']) {
+    include_once $dir . 'trivia.php';
+} else {
+    $remove_columns[] = 'trivia';
+}
+
+if (in_array('forum_posts', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::FORUMPOSTS && $BLOCKS['forum_posts_on']) {
+    include_once $dir . 'forum_posts.php';
+} else {
+    $remove_columns[] = 'forum_posts';
+}
+
+if (in_array('staffpicks', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::STAFF_PICKS && $BLOCKS['staff_picks_on']) {
+    include_once $dir . 'staff_picks.php';
+} else {
+    $remove_columns[] = 'staffpicks';
+}
+
+if (in_array('latest_user', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_USER && $BLOCKS['latest_user_on']) {
+    include_once $dir . 'latest_user.php';
+} else {
+    $remove_columns[] = 'latest_user';
+}
+
+if (in_array('birthday_users', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::BIRTHDAY_ACTIVE_USERS && $BLOCKS['active_birthday_users_on']) {
+    include_once $dir . 'active_birthday_users.php';
+} else {
+    $remove_columns[] = 'birthday_users';
+}
+
+if (in_array('active_users_irc', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::IRC_ACTIVE_USERS && $BLOCKS['active_irc_users_on']) {
+    include_once $dir . 'active_irc_users.php';
+} else {
+    $remove_columns[] = 'active_users_irc';
+}
+
+if (in_array('active_users', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::ACTIVE_USERS && $BLOCKS['active_users_on']) {
+    include_once $dir . 'active_users.php';
+} else {
+    $remove_columns[] = 'active_users';
+}
+
+if (in_array('cooker', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::COOKER && $BLOCKS['cooker_on']) {
+    include_once $dir . 'cooker.php';
+} else {
+    $remove_columns[] = 'cooker';
+}
+
+if (in_array('requests', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::REQUESTS && $BLOCKS['requests_on']) {
+    include_once $dir . 'requests.php';
+} else {
+    $remove_columns[] = 'requests';
+}
+
+if (in_array('offers', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::OFFERS && $BLOCKS['offers_on']) {
+    include_once $dir . 'offers.php';
+} else {
+    $remove_columns[] = 'offers';
+}
+
+if (in_array('active_users_24', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LAST_24_ACTIVE_USERS && $BLOCKS['active_24h_users_on']) {
+    include_once $dir . 'active_24h_users.php';
+} else {
+    $remove_columns[] = 'active_users_24';
+}
+
+if (in_array('site_poll', $available_columns) && !empty($poll_data) && $user['blocks']['index_page'] & class_blocks_index::ACTIVE_POLL && $BLOCKS['active_poll_on']) {
+    include_once $dir . 'poll.php';
+} else {
+    $remove_columns[] = 'site_poll';
+}
+
+if (in_array('site_stats', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::STATS && $BLOCKS['stats_on']) {
+    include_once $dir . 'stats.php';
+} else {
+    $remove_columns[] = 'site_stats';
+}
+
+if (in_array('christmas_gift', $available_columns) && Christmas() && $user['blocks']['index_page'] & class_blocks_index::CHRISTMAS_GIFT && $BLOCKS['christmas_gift_on']) {
+    include_once $dir . 'gift.php';
+} else {
+    $remove_columns[] = 'christmas_gift';
+}
+
+if (in_array('torrents_scroller', $available_columns) && $torrents_class->get_torrent_count() >= 10 && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS_SCROLL && $BLOCKS['latest_torrents_scroll_on']) {
+    $stdfoot = array_merge_recursive($stdfoot, [
+        'js' => [
+            get_file_name('scroller_js'),
+        ],
+    ]);
+    include_once $dir . 'latest_torrents_scroll.php';
+} else {
+    $remove_columns[] = 'torrents_scroller';
+}
+
+if (in_array('torrents_top', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS && $BLOCKS['latest_torrents_on']) {
+    include_once $dir . 'top_torrents.php';
+} else {
+    $remove_columns[] = 'torrents_top';
+}
+
+if (in_array('latest_torrents', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS && $BLOCKS['latest_torrents_on']) {
+    include_once $dir . 'latest_torrents.php';
+} else {
+    $remove_columns[] = 'latest_torrents';
+}
+
+if (in_array('latest_movies', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_MOVIES && $BLOCKS['latest_movies_on']) {
+    include_once $dir . 'latest_movies.php';
+} else {
+    $remove_columns[] = 'latest_movies';
+}
+
+if (in_array('latest_tv', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_TV && $BLOCKS['latest_tv_on']) {
+    include_once $dir . 'latest_tv.php';
+} else {
+    $remove_columns[] = 'latest_tv';
+}
+
+if (in_array('site_news', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::NEWS && $BLOCKS['news_on']) {
+    include_once $dir . 'news.php';
+} else {
+    $remove_columns[] = 'site_news';
+}
+
+if (in_array('advertise', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::ADVERTISEMENTS && $BLOCKS['ads_on']) {
+    include_once $dir . 'advertise.php';
+} else {
+    $remove_columns[] = 'advertise';
+}
+
+if (in_array('posted_comments', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATESTCOMMENTS && $BLOCKS['latest_comments_on']) {
+    include_once $dir . 'comments.php';
+} else {
+    $remove_columns[] = 'posted_comments';
+}
+
+if (in_array('torrents_mow', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::MOVIEOFWEEK && $BLOCKS['movie_ofthe_week_on']) {
+    include_once $dir . 'mow.php';
+} else {
+    $remove_columns[] = 'torrents_mow';
+}
+
+if (in_array('tfreak_feed', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::TORRENTFREAK && $BLOCKS['torrentfreak_on'] && $config->get('newsrss.tfreak')) {
+    include_once $dir . 'torrentfreak.php';
+} else {
+    $remove_columns[] = 'tfreak_feed';
+}
+
+if (in_array('disclaimer', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::DISCLAIMER && $BLOCKS['disclaimer_on']) {
+    include_once $dir . 'disclaimer.php';
+} else {
+    $remove_columns[] = 'disclaimer';
+}
+
+foreach ($remove_columns as $item) {
+    $above_columns = array_values(array_diff($above_columns, [$item]));
+    $left_column = array_values(array_diff($left_column, [$item]));
+    $center_column = array_values(array_diff($center_column, [$item]));
+    $right_column = array_values(array_diff($right_column, [$item]));
+    $below_columns = array_values(array_diff($below_columns, [$item]));
+}
+
+foreach ($above_columns as $item) {
+    $HTMLOUT .= wrap_it($item, ${$item});
+}
+
+$middle = 'is-8-desktop';
+$HTMLOUT .= "
+<div id='parallax' class='columns is-desktop is-variable is-0-mobile is-0-tablet is-1-desktop bottom20'>";
+if (!empty($left_column)) {
+    $middle = 'is-6-desktop';
+    $HTMLOUT .= "
+    <div class='column is-2-desktop fl-3'>
+        <div id='left_column' class='left_column'>";
+
+    foreach ($left_column as $item) {
+        $HTMLOUT .= wrap_it($item, ${$item});
+    }
+
+    $HTMLOUT .= '
+        </div>
+    </div>';
+} else {
+    $HTMLOUT .= "
+    <div class='column is-hidden fl-3'>
+        <div id='left_column' class='left_column'>
+        </div>
+    </div>";
+}
+
+$HTMLOUT .= "
+    <div class='column $middle fl-1'>
+        <div id='center_column'>";
+
+foreach ($center_column as $item) {
+    $HTMLOUT .= wrap_it($item, ${$item});
+}
+
+$HTMLOUT .= "
+        </div>
+    </div>
+    <div class='column is-4-desktop fl-2'>
+        <div id='right_column' class='right_column'>";
+
+foreach ($right_column as $item) {
+    $HTMLOUT .= wrap_it($item, ${$item});
+}
+
+$HTMLOUT .= '
+        </div>
+    </div>
+</div>';
+
+foreach ($below_columns as $item) {
+    $HTMLOUT .= "
+    <div class='top20'>" . wrap_it($item, ${$item}) . '</div>';
+}
+
+/**
+ * @param $item
+ * @param $data
+ *
+ * @return string
+ */
+function wrap_it(string $item, string $data)
+{
+    $class = $item === 'tfreak_feed' ? '' : "class='portlet'";
+    if (!empty($data)) {
+        return "
+    <div $class id='" . strtolower($item) . "_'>{$data}
+    </div>";
+    }
+
+    return '';
+}
+
+$title = _('Home');
+$breadcrumbs = [];
+echo stdhead($title, $stdhead, 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot($stdfoot);

--- a/public/index.php
+++ b/public/index.php
@@ -1,361 +1,52 @@
 <?php
 declare(strict_types=1);
-require_once dirname(__DIR__) . '/bootstrap_web.php';
 
-$db = $container->get(Database::class);
+require_once __DIR__ . '/../bootstrap_web.php';
 
+use PU239\Http\Handlers\Admin\NamechangerHandler;
+use PU239\Http\Handlers\Admin\ReportsHandler;
+use PU239\Http\Handlers\HomeHandler;
+use PU239\Http\Handlers\PublicSite\CoinsHandler;
+use PU239\Http\Handlers\PublicSite\CreditsHandler;
+use PU239\Http\Handlers\PublicSite\FriendsHandler;
+use PU239\Http\Handlers\PublicSite\GiftHandler;
+use PU239\Http\Handlers\PublicSite\InviteHandler;
+use PU239\Http\Handlers\PublicSite\MessagesHandler;
+use PU239\Http\Handlers\PublicSite\ReputationHandler;
+use PU239\Http\Handlers\Staffpanel\IndexHandler;
+use PU239\Http\MiddlewarePipeline;
+use PU239\Http\Middlewares\CsrfGate;
+use PU239\Http\Middlewares\JsonOut;
+use PU239\Http\Middlewares\RateLimitPost;
+use PU239\Http\Middlewares\SecurityHeaders;
+use PU239\Http\Router;
 
-
-
-
-use PU239\Config\ConfigRepository;
-use Pu239\Message;
-use Pu239\PollVoter;
-use Pu239\Session;
-use Pu239\Torrent;
-
-require_once __DIR__ . '/../include/bittorrent.php';
-require_once CLASS_DIR . 'class_user_options.php';
-require_once CLASS_DIR . 'class_user_options_2.php';
-$user = check_user_status();
-$stdhead = [
-    'css' => [
-        get_file_name('index_css'),
-    ],
-];
-$stdfoot = [
-    'js' => [
-        get_file_name('parallax_js'),
-        has_access($user['class'], UC_STAFF, '') ? get_file_name('offer_js') : '',
-    ],
-];
-if ((isset($_GET['act']) && $_GET['act'] === 'Arcade' && isset($_POST['gname'])) || (isset($_POST['module']) && $_POST['module'] === 'pnFlashGames')) {
-    include_once INCL_DIR . 'arcade.php';
-}
-$HTMLOUT = '';
-global $container;
-/** @var ConfigRepository $config */
-$config = $container->get(ConfigRepository::class);
-$messages_class = $container->get(Message::class);
-$unread = $messages_class->get_count($user['id'], $config->get('pm.inbox'), true);
-
-if ($unread >= 1) {
-    $session = $container->get(Session::class);
-    $session->set('is-link', [
-        'message' => _pfe('You have {0} unread message in your inbox', 'You have {0} unread messages in your inbox', $unread),
-        'link' => "{$config->get('paths.baseurl')}/messages.php",
-    ]);
+if (!defined('PU239_ROUTED')) {
+    define('PU239_ROUTED', true);
 }
 
-$pollvoter_class = $container->get(PollVoter::class);
-$poll_data = $pollvoter_class->get_user_poll($user['id']);
-if ($config->get('poll.forced') && !empty($poll_data['pid']) && empty($poll_data['user_id'])) {
-    $stdfoot['js'] = array_merge($stdfoot['js'], [
-        get_file_name('scroll_to_poll_js'),
-    ]);
-}
-$above_columns = [];
-$below_columns = [
-    'disclaimer',
-];
-$left_column = [
-    'tfreak_feed',
-];
-$center_column = [
-    'glide',
-    'ajaxchat',
-    'torrents_scroller',
-    'cooker',
-    'requests',
-    'offers',
-    'torrents_mow',
-    'staffpicks',
-    'torrents_top',
-    'latest_torrents',
-    'latest_movies',
-    'latest_tv',
-    'forum_posts',
-    'site_poll',
-];
-$right_column = [
-    'trivia',
-    'advertise',
-    'site_news',
-    'site_stats',
-    'posted_comments',
-    'latest_user',
-    'birthday_users',
-    'active_users_irc',
-    'active_users',
-    'active_users_24',
-    'christmas_gift',
-];
-$christmas_gift = $posted_comments = $advertise = $active_users = $active_users_irc = $birthday_users = $active_users_24 = $forum_posts = $staffpicks = $disclaimer = $trivia = $glide = $ajaxchat = '';
-$tfreak_feed = $torrents_top = $site_stats = $site_poll = $site_news = $torrents_mow = $latest_user = $torrents_scroller = $latest_torrents = $latest_movies = $latest_tv = $cooker = $requests = $offers = '';
-$available_columns = array_merge($above_columns, $left_column, $center_column, $right_column, $below_columns);
-$remove_columns = $user['class'] < UC_STAFF ? $config->get('site.staff_blocks') : [];
-$torrents_class = $container->get(Torrent::class);
-$available_columns = $user['status'] === 0 ? array_diff($available_columns, $remove_columns) : [];
-$dir = BLOCK_DIR . 'index' . DIRECTORY_SEPARATOR;
-if (in_array('glide', $available_columns) && $torrents_class->get_torrent_count() >= 10 && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS_SLIDER && $BLOCKS['latest_torrents_slider_on']) {
-    $stdfoot = array_merge_recursive($stdfoot, [
-        'js' => [
-            get_file_name('glider_js'),
-        ],
-    ]);
-    include_once $dir . 'latest_torrents_glide.php';
-} else {
-    $remove_columns[] = 'glide';
-}
+$router = new Router();
+$pipeline = new MiddlewarePipeline([
+    new SecurityHeaders(),
+    new RateLimitPost(10, 60),
+    new CsrfGate(),
+    new JsonOut(),
+]);
 
-if (in_array('ajaxchat', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::AJAXCHAT && $BLOCKS['ajaxchat_on'] && $user['chatpost'] === 1) {
-    $stdfoot = array_merge_recursive($stdfoot, [
-        'js' => [
-            get_file_name('trivia_js'),
-        ],
-    ]);
-    include_once $dir . 'ajaxchat.php';
-} else {
-    $remove_columns[] = 'ajaxchat';
-}
+$router->get('/', HomeHandler::class);
+$router->get('/index.php', HomeHandler::class);
+$router->get('/coins.php', CoinsHandler::class);
+$router->get('/credits.php', CreditsHandler::class);
+$router->get('/friends.php', FriendsHandler::class);
+$router->get('/gift.php', GiftHandler::class);
+$router->get('/invite.php', InviteHandler::class);
+$router->get('/messages.php', MessagesHandler::class);
+$router->get('/reputation.php', ReputationHandler::class);
+$router->get('/admin/namechanger.php', NamechangerHandler::class, ['authz' => 'admin']);
+$router->get('/admin/reports.php', ReportsHandler::class, ['authz' => 'admin']);
+$router->get('/staffpanel.php', IndexHandler::class, ['authz' => ['any' => ['staff', 'admin']]]);
+$router->get('/staffpanel/index.php', IndexHandler::class, ['authz' => ['any' => ['staff', 'admin']]]);
 
-if (in_array('trivia', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::TRIVIA && $BLOCKS['trivia_on']) {
-    include_once $dir . 'trivia.php';
-} else {
-    $remove_columns[] = 'trivia';
-}
+$pipeline->handle($router);
 
-if (in_array('forum_posts', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::FORUMPOSTS && $BLOCKS['forum_posts_on']) {
-    include_once $dir . 'forum_posts.php';
-} else {
-    $remove_columns[] = 'forum_posts';
-}
-
-if (in_array('staffpicks', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::STAFF_PICKS && $BLOCKS['staff_picks_on']) {
-    include_once $dir . 'staff_picks.php';
-} else {
-    $remove_columns[] = 'staffpicks';
-}
-
-if (in_array('latest_user', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_USER && $BLOCKS['latest_user_on']) {
-    include_once $dir . 'latest_user.php';
-} else {
-    $remove_columns[] = 'latest_user';
-}
-
-if (in_array('birthday_users', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::BIRTHDAY_ACTIVE_USERS && $BLOCKS['active_birthday_users_on']) {
-    include_once $dir . 'active_birthday_users.php';
-} else {
-    $remove_columns[] = 'birthday_users';
-}
-
-if (in_array('active_users_irc', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::IRC_ACTIVE_USERS && $BLOCKS['active_irc_users_on']) {
-    include_once $dir . 'active_irc_users.php';
-} else {
-    $remove_columns[] = 'active_users_irc';
-}
-
-if (in_array('active_users', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::ACTIVE_USERS && $BLOCKS['active_users_on']) {
-    include_once $dir . 'active_users.php';
-} else {
-    $remove_columns[] = 'active_users';
-}
-
-if (in_array('cooker', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::COOKER && $BLOCKS['cooker_on']) {
-    include_once $dir . 'cooker.php';
-} else {
-    $remove_columns[] = 'cooker';
-}
-
-if (in_array('requests', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::REQUESTS && $BLOCKS['requests_on']) {
-    include_once $dir . 'requests.php';
-} else {
-    $remove_columns[] = 'requests';
-}
-
-if (in_array('offers', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::OFFERS && $BLOCKS['offers_on']) {
-    include_once $dir . 'offers.php';
-} else {
-    $remove_columns[] = 'offers';
-}
-
-if (in_array('active_users_24', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LAST_24_ACTIVE_USERS && $BLOCKS['active_24h_users_on']) {
-    include_once $dir . 'active_24h_users.php';
-} else {
-    $remove_columns[] = 'active_users_24';
-}
-
-if (in_array('site_poll', $available_columns) && !empty($poll_data) && $user['blocks']['index_page'] & class_blocks_index::ACTIVE_POLL && $BLOCKS['active_poll_on']) {
-    include_once $dir . 'poll.php';
-} else {
-    $remove_columns[] = 'site_poll';
-}
-
-if (in_array('site_stats', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::STATS && $BLOCKS['stats_on']) {
-    include_once $dir . 'stats.php';
-} else {
-    $remove_columns[] = 'site_stats';
-}
-
-if (in_array('christmas_gift', $available_columns) && Christmas() && $user['blocks']['index_page'] & class_blocks_index::CHRISTMAS_GIFT && $BLOCKS['christmas_gift_on']) {
-    include_once $dir . 'gift.php';
-} else {
-    $remove_columns[] = 'christmas_gift';
-}
-
-if (in_array('torrents_scroller', $available_columns) && $torrents_class->get_torrent_count() >= 10 && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS_SCROLL && $BLOCKS['latest_torrents_scroll_on']) {
-    $stdfoot = array_merge_recursive($stdfoot, [
-        'js' => [
-            get_file_name('scroller_js'),
-        ],
-    ]);
-    include_once $dir . 'latest_torrents_scroll.php';
-} else {
-    $remove_columns[] = 'torrents_scroller';
-}
-
-if (in_array('torrents_top', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS && $BLOCKS['latest_torrents_on']) {
-    include_once $dir . 'top_torrents.php';
-} else {
-    $remove_columns[] = 'torrents_top';
-}
-
-if (in_array('latest_torrents', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_TORRENTS && $BLOCKS['latest_torrents_on']) {
-    include_once $dir . 'latest_torrents.php';
-} else {
-    $remove_columns[] = 'latest_torrents';
-}
-
-if (in_array('latest_movies', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_MOVIES && $BLOCKS['latest_movies_on']) {
-    include_once $dir . 'latest_movies.php';
-} else {
-    $remove_columns[] = 'latest_movies';
-}
-
-if (in_array('latest_tv', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATEST_TV && $BLOCKS['latest_tv_on']) {
-    include_once $dir . 'latest_tv.php';
-} else {
-    $remove_columns[] = 'latest_tv';
-}
-
-if (in_array('site_news', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::NEWS && $BLOCKS['news_on']) {
-    include_once $dir . 'news.php';
-} else {
-    $remove_columns[] = 'site_news';
-}
-
-if (in_array('advertise', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::ADVERTISEMENTS && $BLOCKS['ads_on']) {
-    include_once $dir . 'advertise.php';
-} else {
-    $remove_columns[] = 'advertise';
-}
-
-if (in_array('posted_comments', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::LATESTCOMMENTS && $BLOCKS['latest_comments_on']) {
-    include_once $dir . 'comments.php';
-} else {
-    $remove_columns[] = 'posted_comments';
-}
-
-if (in_array('torrents_mow', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::MOVIEOFWEEK && $BLOCKS['movie_ofthe_week_on']) {
-    include_once $dir . 'mow.php';
-} else {
-    $remove_columns[] = 'torrents_mow';
-}
-
-if (in_array('tfreak_feed', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::TORRENTFREAK && $BLOCKS['torrentfreak_on'] && $config->get('newsrss.tfreak')) {
-    include_once $dir . 'torrentfreak.php';
-} else {
-    $remove_columns[] = 'tfreak_feed';
-}
-
-if (in_array('disclaimer', $available_columns) && $user['blocks']['index_page'] & class_blocks_index::DISCLAIMER && $BLOCKS['disclaimer_on']) {
-    include_once $dir . 'disclaimer.php';
-} else {
-    $remove_columns[] = 'disclaimer';
-}
-
-foreach ($remove_columns as $item) {
-    $above_columns = array_values(array_diff($above_columns, [$item]));
-    $left_column = array_values(array_diff($left_column, [$item]));
-    $center_column = array_values(array_diff($center_column, [$item]));
-    $right_column = array_values(array_diff($right_column, [$item]));
-    $below_columns = array_values(array_diff($below_columns, [$item]));
-}
-
-foreach ($above_columns as $item) {
-    $HTMLOUT .= wrap_it($item, ${$item});
-}
-
-$middle = 'is-8-desktop';
-$HTMLOUT .= "
-<div id='parallax' class='columns is-desktop is-variable is-0-mobile is-0-tablet is-1-desktop bottom20'>";
-if (!empty($left_column)) {
-    $middle = 'is-6-desktop';
-    $HTMLOUT .= "
-    <div class='column is-2-desktop fl-3'>
-        <div id='left_column' class='left_column'>";
-
-    foreach ($left_column as $item) {
-        $HTMLOUT .= wrap_it($item, ${$item});
-    }
-
-    $HTMLOUT .= '
-        </div>
-    </div>';
-} else {
-    $HTMLOUT .= "
-    <div class='column is-hidden fl-3'>
-        <div id='left_column' class='left_column'>
-        </div>
-    </div>";
-}
-
-$HTMLOUT .= "
-    <div class='column $middle fl-1'>
-        <div id='center_column'>";
-
-foreach ($center_column as $item) {
-    $HTMLOUT .= wrap_it($item, ${$item});
-}
-
-$HTMLOUT .= "
-        </div>
-    </div>
-    <div class='column is-4-desktop fl-2'>
-        <div id='right_column' class='right_column'>";
-
-foreach ($right_column as $item) {
-    $HTMLOUT .= wrap_it($item, ${$item});
-}
-
-$HTMLOUT .= '
-        </div>
-    </div>
-</div>';
-
-foreach ($below_columns as $item) {
-    $HTMLOUT .= "
-    <div class='top20'>" . wrap_it($item, ${$item}) . '</div>';
-}
-
-/**
- * @param $item
- * @param $data
- *
- * @return string
- */
-function wrap_it(string $item, string $data)
-{
-    $class = $item === 'tfreak_feed' ? '' : "class='portlet'";
-    if (!empty($data)) {
-        return "
-    <div $class id='" . strtolower($item) . "_'>{$data}
-    </div>";
-    }
-
-    return '';
-}
-
-$title = _('Home');
-$breadcrumbs = [];
-echo stdhead($title, $stdhead, 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot($stdfoot);
+// >>>>>> PU239:http-front-1

--- a/public/invite.php
+++ b/public/invite.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/messages.php
+++ b/public/messages.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/reputation.php
+++ b/public/reputation.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 throw new RuntimeException('Stubbed: missing SQL; see tools/rehydrate_v3_manifest.csv');

--- a/public/staffpanel.php
+++ b/public/staffpanel.php
@@ -1,4 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/index.php';
+
+    return;
+}
+
 require_once __DIR__ . '/../staffpanel/index.php';

--- a/staffpanel/index.php
+++ b/staffpanel/index.php
@@ -1,6 +1,12 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('PU239_ROUTED')) {
+    require_once __DIR__ . '/../public/index.php';
+
+    return;
+}
+
 require_once __DIR__ . '/../bootstrap_web.php';
 
 use Monolog\Logger;

--- a/tools/modernize_lint.txt
+++ b/tools/modernize_lint.txt
@@ -1,0 +1,52 @@
+
+Parse error: syntax error, unexpected token "<<" in admin/adduser.php on line 52
+Errors parsing admin/adduser.php
+LINT_FAIL admin/adduser.php
+No syntax errors detected in admin/namechanger.php
+No syntax errors detected in admin/reports.php
+
+Parse error: syntax error, unexpected token "<<" in admin/reset.php on line 44
+Errors parsing admin/reset.php
+LINT_FAIL admin/reset.php
+No syntax errors detected in classes/Security/PasswordHasher.php
+No syntax errors detected in public/coins.php
+No syntax errors detected in public/credits.php
+No syntax errors detected in public/friends.php
+No syntax errors detected in public/gift.php
+No syntax errors detected in public/index.php
+No syntax errors detected in public/invite.php
+No syntax errors detected in public/messages.php
+
+Parse error: syntax error, unexpected token "<<" in public/recover.php on line 76
+Errors parsing public/recover.php
+LINT_FAIL public/recover.php
+No syntax errors detected in public/reputation.php
+
+Parse error: syntax error, unexpected token "<<" in public/signup.php on line 65
+Errors parsing public/signup.php
+LINT_FAIL public/signup.php
+No syntax errors detected in public/staffpanel.php
+
+Parse error: syntax error, unexpected token "<<" in src/User.php on line 265
+Errors parsing src/User.php
+LINT_FAIL src/User.php
+No syntax errors detected in staffpanel/index.php
+No syntax errors detected in classes/Http/Handlers/Admin/NamechangerHandler.php
+No syntax errors detected in classes/Http/Handlers/Admin/ReportsHandler.php
+No syntax errors detected in classes/Http/Handlers/HomeHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/CoinsHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/CreditsHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/FriendsHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/GiftHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/InviteHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/MessagesHandler.php
+No syntax errors detected in classes/Http/Handlers/PublicSite/ReputationHandler.php
+No syntax errors detected in classes/Http/Handlers/Staffpanel/IndexHandler.php
+No syntax errors detected in classes/Http/MiddlewarePipeline.php
+No syntax errors detected in classes/Http/Middlewares/AuthZGate.php
+No syntax errors detected in classes/Http/Middlewares/CsrfGate.php
+No syntax errors detected in classes/Http/Middlewares/JsonOut.php
+No syntax errors detected in classes/Http/Middlewares/RateLimitPost.php
+No syntax errors detected in classes/Http/Middlewares/SecurityHeaders.php
+No syntax errors detected in classes/Http/Router.php
+No syntax errors detected in public/index.legacy.php

--- a/tools/modernize_report.csv
+++ b/tools/modernize_report.csv
@@ -1,0 +1,30 @@
+classes/Http/Router.php,router,introduced minimal GET/POST dispatcher table
+classes/Http/MiddlewarePipeline.php,pipeline,stacked middlewares with per-route authz hook
+classes/Http/Middlewares/SecurityHeaders.php,mw,added default security response headers
+classes/Http/Middlewares/CsrfGate.php,mw,verified POST CSRF tokens
+classes/Http/Middlewares/RateLimitPost.php,mw,rate limited POST endpoints per IP/path
+classes/Http/Middlewares/JsonOut.php,mw,json-encode array responses
+classes/Http/Middlewares/AuthZGate.php,mw,route-aware authorization guard
+classes/Http/Handlers/HomeHandler.php,handler,routed homepage through legacy script
+classes/Http/Handlers/PublicSite/CoinsHandler.php,handler,delegated coins stub via router
+classes/Http/Handlers/PublicSite/CreditsHandler.php,handler,delegated credits stub via router
+classes/Http/Handlers/PublicSite/FriendsHandler.php,handler,delegated friends stub via router
+classes/Http/Handlers/PublicSite/GiftHandler.php,handler,delegated gift stub via router
+classes/Http/Handlers/PublicSite/InviteHandler.php,handler,delegated invite stub via router
+classes/Http/Handlers/PublicSite/MessagesHandler.php,handler,delegated messages stub via router
+classes/Http/Handlers/PublicSite/ReputationHandler.php,handler,delegated reputation stub via router
+classes/Http/Handlers/Admin/NamechangerHandler.php,handler,routed admin namechanger stub
+classes/Http/Handlers/Admin/ReportsHandler.php,handler,routed admin reports stub
+classes/Http/Handlers/Staffpanel/IndexHandler.php,handler,routed staffpanel index through pipeline
+public/index.php,wired_route,front controller registering initial routes
+public/coins.php,wired_route,guarded legacy entry to route dispatcher
+public/credits.php,wired_route,guarded legacy entry to route dispatcher
+public/friends.php,wired_route,guarded legacy entry to route dispatcher
+public/gift.php,wired_route,guarded legacy entry to route dispatcher
+public/invite.php,wired_route,guarded legacy entry to route dispatcher
+public/messages.php,wired_route,guarded legacy entry to route dispatcher
+public/reputation.php,wired_route,guarded legacy entry to route dispatcher
+public/staffpanel.php,wired_route,guarded staffpanel entry to router
+admin/namechanger.php,wired_route,guarded admin stub to router
+admin/reports.php,wired_route,guarded admin stub to router
+staffpanel/index.php,wired_route,guarded staffpanel index to router

--- a/tools/modernize_status.txt
+++ b/tools/modernize_status.txt
@@ -1,0 +1,1 @@
+2025-10-03T21:43:48Z, offset=0, size=10, changed=10, skipped=0, lint_fail=5, markers_used=6

--- a/tools/router_candidates.txt
+++ b/tools/router_candidates.txt
@@ -1,0 +1,12 @@
+public/index.php
+public/coins.php
+public/credits.php
+public/friends.php
+public/gift.php
+public/invite.php
+public/messages.php
+public/reputation.php
+public/staffpanel.php
+admin/namechanger.php
+admin/reports.php
+staffpanel/index.php


### PR DESCRIPTION
## Summary
- add a front controller in `public/index.php` that wires the middleware pipeline and registers the first batch of routed entrypoints
- create lightweight `Router` and middleware classes (security headers, POST CSRF/rate limiting, JSON) plus thin handlers that include the legacy scripts
- guard the legacy entry scripts so direct hits bootstrap the router while routed requests execute through the new handlers

## Testing
- `php -l` *(fails for legacy files with unresolved conflict markers; see tools/modernize_lint.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68e041962c8c83259093b8eb68f76cf4