### PR TITLE
feat: add view helper and escaping bootstrap

### DIFF
--- a/classes/View/View.php
+++ b/classes/View/View.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace PU239\View;
+
+final class View
+{
+    /** @param array<string,mixed> $data */
+    public function render(callable $template, array $data = []): void
+    {
+        // Provide $s helper in scope
+        $s = static fn($v) => htmlspecialchars((string)$v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $template($data, $s);
+    }
+}

--- a/public/allsmiles.php
+++ b/public/allsmiles.php
@@ -17,6 +17,8 @@ global $container;
 $config = $container->get(ConfigRepository::class);
 $db = $container->get(Database::class);
 
+$s = $s ?? static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
 
 
 

--- a/public/download.php
+++ b/public/download.php
@@ -22,6 +22,8 @@ require_once CLASS_DIR . 'class.bencdec.php';
 global $container, $site_config;
 $db = $container->get(Database::class);
 
+$s = $s ?? static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
 $users_class = $container->get(User::class);
 // $fluent removed — use $this->db (ExtendedPdo)
 $torrent_class = $container->get(Torrent::class);

--- a/public/rss.php
+++ b/public/rss.php
@@ -34,6 +34,8 @@ $validation = $validator->validate($_GET, [
     'cats' => 'regex:/^(\d+,?)*$/',
 ]);
 
+$s = $s ?? static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
 if ($validation->fails()) {
     if (!isset($_GET['torrent_pass'])) {
         format_rss(_("Your link doesn't have a torrent pass"), null);

--- a/tools/_review_markers.php
+++ b/tools/_review_markers.php
@@ -1,7 +1,7 @@
 <?php
-// >>>>>> PU239:stabilize-1
-// >>>>>> PU239:stabilize-2
-// >>>>>> PU239:stabilize-3
-// >>>>>> PU239:stabilize-4
-// >>>>>> PU239:stabilize-5
-// >>>>>> PU239:stabilize-6
+// >>>>>> PU239:view-escapes-1
+// >>>>>> PU239:view-escapes-2
+// >>>>>> PU239:view-escapes-3
+// >>>>>> PU239:view-escapes-4
+// >>>>>> PU239:view-escapes-5
+// >>>>>> PU239:view-escapes-6

--- a/tools/modernize_lint.txt
+++ b/tools/modernize_lint.txt
@@ -333,3 +333,8 @@ No syntax errors detected in classes/Http/Handlers/PublicSite/PollsTakeVoteHandl
 No syntax errors detected in classes/Http/Handlers/PublicSite/StaffboxHandler.php
 No syntax errors detected in classes/Http/Handlers/PublicSite/TakeThemeHandler.php
 No syntax errors detected in classes/Http/Handlers/PublicSite/UserUnlocksHandler.php
+No syntax errors detected in classes/View/View.php
+No syntax errors detected in public/allsmiles.php
+No syntax errors detected in public/download.php
+No syntax errors detected in public/rss.php
+No syntax errors detected in tools/_review_markers.php

--- a/tools/modernize_report.csv
+++ b/tools/modernize_report.csv
@@ -258,3 +258,6 @@ classes/Http/Handlers/PublicSite/PollsTakeVoteHandler.php,handler,scrubbed revie
 classes/Http/Handlers/PublicSite/StaffboxHandler.php,handler,scrubbed review marker while keeping legacy require
 classes/Http/Handlers/PublicSite/TakeThemeHandler.php,handler,scrubbed review marker while keeping legacy require
 classes/Http/Handlers/PublicSite/UserUnlocksHandler.php,handler,scrubbed review marker while keeping legacy require
+public/allsmiles.php,true,0,0,helper injected
+public/download.php,true,0,0,helper injected
+public/rss.php,true,0,0,helper injected

--- a/tools/modernize_status.txt
+++ b/tools/modernize_status.txt
@@ -17,3 +17,4 @@
 2025-10-05T08:09:24Z - Inserted ForceHttps/Hsts imports and pipeline entries in public/index.php.
 2025-10-05T08:44:22Z - Adjusted ForceHttps/Hsts middleware process methods to return downstream responses.
 2025-10-05T09:30:00Z - Verified HTTP middleware imports/pipeline already included; no additions required.
+2025-10-05T09:27:09Z, offset=0, size=6, changed=3, skipped=3, lint_fail=0, markers_used=6

--- a/tools/view_candidates.txt
+++ b/tools/view_candidates.txt
@@ -1,0 +1,6 @@
+admin/reputation_settings.php
+public/ajax/autocomplete.php
+public/ajax/thanks.php
+public/allsmiles.php
+public/download.php
+public/rss.php


### PR DESCRIPTION
## Summary
- create `PU239\View\View` to render templates with an `$s` escaping helper
- seed the `$s` helper into `allsmiles.php`, `download.php`, and `rss.php`
- refresh modernization tracking artifacts and PU239 review markers

## Testing
- php -l classes/View/View.php
- php -l public/allsmiles.php
- php -l public/download.php
- php -l public/rss.php
- php -l tools/_review_markers.php

------
https://chatgpt.com/codex/tasks/task_e_68e23949f9f88325944d7a0f1dadc443