### PR TITLE
Convert admin handler stubs (batch 5)

### DIFF
--- a/classes/Http/Handlers/Admin/BannedemailsHandler.php
+++ b/classes/Http/Handlers/Admin/BannedemailsHandler.php
@@ -1,35 +1,152 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
-
 namespace PU239\Http\Handlers\Admin;
+
+use PU239\Config\ConfigRepository;
+use PU239\Security\AuthZ;
+use PU239\Support\Audit;
+use Pu239\Database;
 
 final class BannedemailsHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/bannedemails.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T17:02:40Z via codex handler conversion
+        try {
+            global $container, $CURUSER;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (strpos(ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            $fluent = $db;
+            $s = static fn(mixed $v): string => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $s($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = $s((string) $config->get('paths.baseurl'));
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $HTMLOUT = '';
+            $remove = isset($_GET['remove']) ? (int) $_GET['remove'] : 0;
+            if (is_valid_id($remove)) {
+                $db->run('DELETE FROM bannedemails WHERE id = :id', [':id' => $remove]);
+                write_log(_fe('Email ban {0} was removed by {1}', $remove, $CURUSER['username']));
+                Audit::log($CURUSER['id'] ?? null, 'user.unban', ['target' => $remove, 'type' => 'email']);
+            }
+
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                // TODO(2025): csrf
+                $email = htmlsafechars($_POST['email'] ?? '');
+                $comment = htmlsafechars($_POST['comment'] ?? '');
+                if ($email === '' || $comment === '') {
+                    stderr(_('Error'), _('Missing Form Data.'));
+                }
+
+                $db->run(
+                    'INSERT INTO bannedemails (added, addedby, comment, email) VALUES (:added, :addedby, :comment, :email)',
+                    [
+                        ':added' => TIME_NOW,
+                        ':addedby' => $CURUSER['id'],
+                        ':comment' => $comment,
+                        ':email' => $email,
+                    ],
+                );
+                Audit::log($CURUSER['id'] ?? null, 'user.ban', ['target' => $email, 'type' => 'email']);
+                header('Location: ' . ($_SERVER['PHP_SELF'] ?? '') . '?tool=bannedemails');
+                app_halt('Exit called');
+            }
+
+            $HTMLOUT .= "
+                <h1 class='has-text-centered'>" . _('Add Ban') . "</h1>
+                <form method='post' action='staffpanel.php?tool=bannedemails' enctype='multipart/form-data' accept-charset='utf-8'>";
+            $body = "
+                    <tr>
+                        <td class='rowhead'>" . _('Email') . "</td>
+                        <td><input type='text' name='email' size='40'></td></tr>
+                        <tr><td class='rowhead has-text-left'>" . _('Comment') . "</td>
+                        <td><input type='text' name='comment' size='40'></td>
+                    </tr>
+                    <tr>
+                        <td colspan='2'>" . _('Use *@email.com as wildcard for domain.') . "</td>
+                    </tr>
+                    <tr>
+                        <td colspan='2' class='has-text-centered'>
+                            <input type='submit' value='" . _('Ok') . "' class='button is-small'>
+                        </td>
+                    </tr>";
+            $HTMLOUT .= main_table($body) . '
+                </form>';
+
+            $count1 = $fluent->from('bannedemails')
+                             ->select(null)
+                             ->select('COUNT(id) AS count')
+                             ->fetch('count');
+            $perpage = 15;
+            $pager = pager($perpage, $count1, 'staffpanel.php?tool=bannedemails&amp;');
+            $rows = $db->fetchAll(
+                'SELECT b.id, b.added, b.addedby, b.comment, b.email, u.username FROM bannedemails AS b LEFT JOIN users AS u ON b.addedby = u.id ORDER BY added DESC ' . $pager['limit'],
+            );
+
+            $HTMLOUT .= "<h1 class='has-text-centered'>" . _('Current Banned Emails') . '</h1>';
+            if ($count1 > $perpage) {
+                $HTMLOUT .= $pager['pagertop'];
+            }
+
+            if (empty($rows)) {
+                $HTMLOUT .= stdmsg('Sorry', '<p><b>' . _('Nothing Found!') . '</b></p>');
+            } else {
+                $heading = '
+                        <tr>
+                            <th>' . _('Added') . '</th>
+                            <th>' . _('Email') . '</th>
+                            <th>' . _('By') . '</th>
+                            <th>' . _('Comment') . '</th>
+                            <th>' . _('Remove?') . '</th>
+                        </tr>';
+                $body = '';
+                foreach ($rows as $arr) {
+                    $addedOn = $s(get_date((int) $arr['added'], ''));
+                    $emailText = $s($arr['email']);
+                    $commentText = $s($arr['comment']);
+                    $idText = $s((string) $arr['id']);
+                    $body .= "
+                        <tr>
+                            <td>{$addedOn}</td>
+                            <td>{$emailText}</td>
+                            <td>" . format_username((int) $arr['addedby']) . "</td>
+                            <td>{$commentText}</td>
+                            <td><a href='staffpanel.php?tool=bannedemails&amp;remove={$idText}'>" . _('Remove it') . "</a></td>
+                        </tr>";
+                }
+                $HTMLOUT .= main_table($body, $heading);
+            }
+
+            if ($count1 > $perpage) {
+                $HTMLOUT .= $pager['pagerbottom'];
+            }
+
+            $title = _('Banned Emails');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $s($title) . '</a>',
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/BannedemailsHandler.php.bak
+++ b/classes/Http/Handlers/Admin/BannedemailsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class BannedemailsHandler
@@ -8,9 +10,26 @@ final class BannedemailsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/bannedemails.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/bannedemails.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/GoaccessHandler.php
+++ b/classes/Http/Handlers/Admin/GoaccessHandler.php
@@ -1,35 +1,57 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
-
 namespace PU239\Http\Handlers\Admin;
+
+use PU239\Config\ConfigRepository;
+use PU239\Security\AuthZ;
+use Pu239\Database;
 
 final class GoaccessHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/goaccess.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T17:02:40Z via codex handler conversion
+        try {
+            global $container;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (strpos(ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $HTMLOUT = '';
+            if (file_exists(CACHE_DIR . 'goaccess.html')) {
+                require_once CACHE_DIR . 'goaccess.html';
+                app_halt('Exit called');
+            }
+
+            stderr(_('Error'), 'Is goaccess installed?');
+
+            $title = _('GoAccess');
+            $breadcrumbs = [
+                "<a href='" . (string) $config->get('paths.baseurl') . "/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='" . ($_SERVER['PHP_SELF'] ?? '') . "'>$title</a>",
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/GoaccessHandler.php.bak
+++ b/classes/Http/Handlers/Admin/GoaccessHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class GoaccessHandler
@@ -8,9 +10,26 @@ final class GoaccessHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/goaccess.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/goaccess.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/OpHandler.php
+++ b/classes/Http/Handlers/Admin/OpHandler.php
@@ -1,35 +1,40 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
-
 namespace PU239\Http\Handlers\Admin;
+
+use PU239\Config\ConfigRepository;
+use PU239\Security\AuthZ;
+use Pu239\Database;
 
 final class OpHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/op.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T17:02:40Z via codex handler conversion
+        try {
+            global $container;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            AuthZ::requireRole('admin');
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            unset($config);
+
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db);
+
+            class_check(UC_MAX);
+
+            require_once VENDOR_DIR . 'amnuts/opcache-gui/index.php';
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/OpHandler.php.bak
+++ b/classes/Http/Handlers/Admin/OpHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class OpHandler
@@ -8,9 +10,26 @@ final class OpHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/op.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/op.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/TracerouteHandler.php
+++ b/classes/Http/Handlers/Admin/TracerouteHandler.php
@@ -1,35 +1,95 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
-
 namespace PU239\Http\Handlers\Admin;
+
+use PU239\Config\ConfigRepository;
+use PU239\Security\AuthZ;
+use Pu239\Database;
 
 final class TracerouteHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/traceroute.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T17:02:40Z via codex handler conversion
+        try {
+            global $container;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (strpos(ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $user = check_user_status();
+
+            $HTMLOUT = '';
+            $windows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? 1 : 0;
+            $unix = $windows === 1 ? 0 : 1;
+            $register_globals = (bool) ini_get('register_gobals');
+            $action = '';
+            $host = '';
+            $system = ini_get('system');
+            $unix = (bool) $unix;
+            $win = (bool) $windows;
+            unset($win);
+
+            if ($register_globals) {
+                $ip = getenv($_SERVER['REMOTE_ADDR'] ?? '');
+                $self = $_SERVER['PHP_SELF'] ?? '';
+            } else {
+                $action = $_POST['action'] ?? '';
+                $host = $_POST['host'] ?? '';
+                $ip = getip($user['id']);
+                $self = $_SERVER['SCRIPT_NAME'] ?? '';
+            }
+
+            if (($action ?? '') === 'do') {
+                $host = preg_replace('/[^A-Za-z0-9.]/', '', (string) ($host ?? ''));
+                $HTMLOUT .= '<div class="error">';
+                $HTMLOUT .= '' . _('Trace Output:') . '<br>';
+                $HTMLOUT .= '<pre>';
+                if ($unix) {
+                    system('' . 'traceroute ' . $host);
+                    system('killall -q traceroute');
+                } else {
+                    system('' . 'tracert ' . $host);
+                }
+                $HTMLOUT .= '</pre>';
+                $HTMLOUT .= '' . _('done...') . '</div>';
+            } else {
+                $HTMLOUT .= '
+    <p><span class="size_3">' . _fe('Your IP is: {0}', $ip) . '</span></p>
+    <form method="post" action="' . ($_SERVER['PHP_SELF'] ?? '') . '" accept-charset="utf-8">' . _('Enter IP or Host ') . '<input type="text" id=specialboxn name="host" value="' . $ip . '">
+    <input type="hidden" name="action" value="do"><input type="submit" value="' . _('Traceroute!') . '" class="button is-small">
+   </form>';
+                $HTMLOUT .= '<br><b>' . $system . '</b>';
+                $HTMLOUT .= '</body></html>';
+            }
+
+            $title = _('Traceroute');
+            $breadcrumbs = [
+                "<a href='{$config->get('paths.baseurl')}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='" . ($_SERVER['PHP_SELF'] ?? '') . "'>$title</a>",
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/TracerouteHandler.php.bak
+++ b/classes/Http/Handlers/Admin/TracerouteHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class TracerouteHandler
@@ -8,9 +10,26 @@ final class TracerouteHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/traceroute.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/traceroute.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/UserHitsHandler.php
+++ b/classes/Http/Handlers/Admin/UserHitsHandler.php
@@ -1,35 +1,102 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
-
 namespace PU239\Http\Handlers\Admin;
+
+use PU239\Config\ConfigRepository;
+use PU239\Security\AuthZ;
+use Pu239\Database;
+use Pu239\User;
 
 final class UserHitsHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/user_hits.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T17:02:40Z via codex handler conversion
+        try {
+            global $container, $CURUSER;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (strpos(ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            stderr(_('Error'), 'This page is not in use atm');
+
+            $HTMLOUT = '';
+            $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+            if (!is_valid_id($id) || ($CURUSER['id'] ?? 0) !== $id && ($CURUSER['class'] ?? 0) < UC_STAFF) {
+                $id = (int) ($CURUSER['id'] ?? 0);
+            }
+
+            $count = (int) ($db->fetch(
+                'SELECT COUNT(id) AS count FROM userhits WHERE hitid = :id',
+                [':id' => $id],
+            )['count'] ?? 0);
+            $perpage = 15;
+            $pager = pager($perpage, $count, "staffpanel.php?tool=user_hits&amp;id={$id}&amp;");
+            if ($count === 0) {
+                stderr(_('No views'), _('This user has had no profile views yet.'));
+            }
+
+            /** @var User $users */
+            $users = $container->get(User::class);
+            unset($users);
+
+            $db->fetch('SELECT username FROM users WHERE id = :id', [':id' => $id]);
+            $HTMLOUT .= '<h1>' . _('Profile views of ') . '' . format_username((int) $id) . '</h1>
+<h2>' . _('In total ') . '' . htmlsafechars($count) . '' . _(' views') . '</h2>';
+            if ($count > $perpage) {
+                $HTMLOUT .= $pager['pagertop'];
+            }
+
+            $HTMLOUT .= "
+<table>
+<tr>
+<td class='colhead'>" . _('Nr.') . "</td>
+<td class='colhead'>" . _('Username') . "</td>
+<td class='colhead'>" . _('Viewed at') . "</td>
+</tr>\n";
+            $rows = $db->fetchAll(
+                'SELECT uh.*, username, users.id AS uid FROM userhits AS uh LEFT JOIN users ON uh.userid = users.id WHERE hitid = :id ORDER BY uh.id DESC ' . $pager['limit'],
+                [':id' => $id],
+            );
+            foreach ($rows as $arr) {
+                $HTMLOUT .= '
+<tr><td>' . number_format((int) $arr['number']) . '</td>
+<td>' . format_username((int) $arr['uid']) . '</td>
+<td>' . get_date((int) $arr['added'], 'DATE', 0, 1) . "</td>
+</tr>\n";
+            }
+            $HTMLOUT .= '</table>';
+            if ($count > $perpage) {
+                $HTMLOUT .= $pager['pagerbottom'];
+            }
+
+            $title = _('Profile Views');
+            $baseurl = (string) $config->get('paths.baseurl');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='" . ($_SERVER['PHP_SELF'] ?? '') . "'>$title</a>",
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/UserHitsHandler.php.bak
+++ b/classes/Http/Handlers/Admin/UserHitsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class UserHitsHandler
@@ -8,9 +10,26 @@ final class UserHitsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/user_hits.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/user_hits.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -1,0 +1,6 @@
+file,converted,todos,notes
+classes/Http/Handlers/Admin/OpHandler.php,true,0,Extracted from admin/op.php
+classes/Http/Handlers/Admin/BannedemailsHandler.php,true,1,Extracted from admin/bannedemails.php
+classes/Http/Handlers/Admin/UserHitsHandler.php,true,0,Extracted from admin/user_hits.php
+classes/Http/Handlers/Admin/GoaccessHandler.php,true,0,Extracted from admin/goaccess.php
+classes/Http/Handlers/Admin/TracerouteHandler.php,true,0,Extracted from admin/traceroute.php


### PR DESCRIPTION
## Summary
- inline the legacy admin op, bannedemails, user_hits, goaccess, and traceroute scripts into their handlers
- wire each handler to resolve config and database services from the container and preserve legacy side effects inside try/catch guards
- add a handler conversion report entry for this batch

## Testing
- php -l classes/Http/Handlers/Admin/OpHandler.php
- php -l classes/Http/Handlers/Admin/BannedemailsHandler.php
- php -l classes/Http/Handlers/Admin/UserHitsHandler.php
- php -l classes/Http/Handlers/Admin/GoaccessHandler.php
- php -l classes/Http/Handlers/Admin/TracerouteHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e2a400b1788325871307ab96d0db28