### PR TITLE
feat: convert admin class config and cloudview handlers

### DIFF
--- a/classes/Http/Handlers/Admin/ClassConfigHandler.php
+++ b/classes/Http/Handlers/Admin/ClassConfigHandler.php
@@ -1,35 +1,134 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use PU239\Security\AuthZ;
+use PU239\Config\ConfigRepository;
+use Pu239\Database;
+
 final class ClassConfigHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/class_config.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
+        try {
+            global $container, $CURUSER;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (strpos(ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = $escaper((string) $config->get('paths.baseurl'));
+
+            $stdhead = [];
+            $stdfoot = [];
+            $HTMLOUT = '';
+
+            $action = $_GET['action'] ?? '';
+            $id = (int) ($_GET['id'] ?? 0);
+
+            switch ($action) {
+                case 'add':
+                    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                        // TODO(2025): csrf
+                        $name = trim($_POST['name'] ?? '');
+                        $value = trim($_POST['value'] ?? '');
+                        if ($name === '' || $value === '') {
+                            stderr(_('Error'), _('Missing name or value'));
+                        }
+                        $db->perform('INSERT INTO config (name, value) VALUES (:name, :value)', [
+                            'name' => $name,
+                            'value' => $value,
+                        ]);
+                        audit_log($CURUSER['id'] ?? null, 'config.update', ['keys' => [$name]]);
+                        header('Location: ?tool=class_config');
+                        exit;
+                    }
+                    break;
+
+                case 'edit':
+                    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                        // TODO(2025): csrf
+                        $name = trim($_POST['name'] ?? '');
+                        $value = trim($_POST['value'] ?? '');
+                        if ($id === 0 || $name === '' || $value === '') {
+                            stderr(_('Error'), _('Invalid request'));
+                        }
+                        $db->perform('UPDATE config SET name = :name, value = :value WHERE id = :id', [
+                            'id' => $id,
+                            'name' => $name,
+                            'value' => $value,
+                        ]);
+                        audit_log($CURUSER['id'] ?? null, 'config.update', ['keys' => [$name]]);
+                        header('Location: ?tool=class_config');
+                        exit;
+                    }
+                    break;
+
+                case 'delete':
+                    if ($id > 0) {
+                        $db->perform('DELETE FROM config WHERE id = :id', ['id' => $id]);
+                        audit_log($CURUSER['id'] ?? null, 'config.update', ['keys' => [$id]]);
+                        header('Location: ?tool=class_config');
+                        exit;
+                    }
+                    break;
+
+                default:
+                    $rows = $db->fetchAll('SELECT id, name, value FROM config ORDER BY id');
+                    $heading = '
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Value</th>
+                <th>Actions</th>
+            </tr>';
+                    $body = '';
+                    foreach ($rows as $r) {
+                        $configId = $escaper((string) $r['id']);
+                        $body .= "
+                <tr>
+                    <td>{$configId}</td>
+                    <td>" . $escaper($r['name']) . "</td>
+                    <td>" . $escaper($r['value']) . "</td>
+                    <td>
+                        <a href='?tool=class_config&amp;action=edit&amp;id={$configId}'>Edit</a> |
+                        <a href='?tool=class_config&amp;action=delete&amp;id={$configId}'>Delete</a>
+                    </td>
+                </tr>";
+                    }
+                    $HTMLOUT .= main_table($body, $heading);
+                    break;
+            }
+
+            $title = _('Configuration');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $escaper($title) . '</a>',
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/ClassConfigHandler.php.bak
+++ b/classes/Http/Handlers/Admin/ClassConfigHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class ClassConfigHandler
@@ -8,9 +10,26 @@ final class ClassConfigHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/class_config.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/class_config.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/ClassPromoHandler.php
+++ b/classes/Http/Handlers/Admin/ClassPromoHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,6 +10,7 @@ final class ClassPromoHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
+        // TODO(2025): extract legacy block for manual conversion admin/class_promo.php:1-20
         // STUB_UPGRADED: safe buffered execution
         $target = __DIR__ . '/../../../../admin/class_promo.php';
         if (!is_file($target)) {

--- a/classes/Http/Handlers/Admin/ClassPromoHandler.php.bak
+++ b/classes/Http/Handlers/Admin/ClassPromoHandler.php.bak
@@ -1,18 +1,34 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class ClassPromoHandler
 {
-    public function handle(array $meta = []): mixed
+    /** @param array<string,mixed> $meta */
+    public function handle(array $meta = []): void
     {
-        if (!defined('PU239_ROUTED')) {
-            define('PU239_ROUTED', true);
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/class_promo.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
         }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
 
-        require \dirname(__DIR__, 4) . '/admin/class_promo.php';
-
-        return null;
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Admin/CleanupManagerHandler.php
+++ b/classes/Http/Handlers/Admin/CleanupManagerHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,6 +10,7 @@ final class CleanupManagerHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
+        // TODO(2025): extract legacy block for manual conversion admin/cleanup_manager.php:1-200
         // STUB_UPGRADED: safe buffered execution
         $target = __DIR__ . '/../../../../admin/cleanup_manager.php';
         if (!is_file($target)) {

--- a/classes/Http/Handlers/Admin/CleanupManagerHandler.php.bak
+++ b/classes/Http/Handlers/Admin/CleanupManagerHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class CleanupManagerHandler
@@ -8,9 +10,26 @@ final class CleanupManagerHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/cleanup_manager.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/cleanup_manager.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/CloudviewHandler.php
+++ b/classes/Http/Handlers/Admin/CloudviewHandler.php
@@ -1,35 +1,112 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use Pu239\Cache;
+use PU239\Config\ConfigRepository;
+use Pu239\Searchcloud;
+use PU239\Security\AuthZ;
+
 final class CloudviewHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/cloudview.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
+        try {
+            global $container, $CURUSER;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (strpos(ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = $escaper((string) $config->get('paths.baseurl'));
+
+            $HTMLOUT = '';
+            $seachcloud_class = $container->get(Searchcloud::class);
+            $cache = $container->get(Cache::class);
+
+            if (isset($_POST['delcloud'])) {
+                // TODO(2025): csrf
+                $seachcloud_class->delete($_POST['delcloud']);
+                $cache->delete('searchcloud_');
+                audit_log($CURUSER['id'] ?? null, 'config.update', ['keys' => ['searchcloud']]);
+                stderr(
+                    _('Success'),
+                    _('The obscene terms were successfully deleted!<br><br>You will be redirected shortly.')
+                    . '<meta http-equiv="refresh" content="3;url=staffpanel.php?tool=cloudview&action=cloudview">'
+                );
+            }
+
+            $count = $seachcloud_class->get_count();
+            $perpage = 15;
+            $pager = pager($perpage, $count, (string) $config->get('paths.baseurl') . '/staffpanel.php?tool=cloudview&amp;action=cloudview&amp;');
+            if ($count > $perpage) {
+                $HTMLOUT .= $pager['pagertop'];
+            }
+            $searches = $seachcloud_class->get($pager['pdo']);
+            $HTMLOUT .= "
+<form id='checkbox_container' method='post' action='{$self}?tool=cloudview&amp;action=cloudview' enctype='multipart/form-data' accept-charset='utf-8'>";
+            $heading = "
+    <tr>
+        <th>" . _('Searched phrase') . "</th>
+        <th>" . _('Hits') . "</th>
+        <th><input type='checkbox' id='checkThemAll' class='tooltipper' title='" . _('Delete') . "'></th>
+    </tr>";
+            $body = '';
+            foreach ($searches as $arr) {
+                $search_phrase = $escaper($arr['searchedfor']);
+                $searchId = $escaper((string) $arr['id']);
+                $hits = $escaper((string) $arr['howmuch']);
+                $body .= "
+    <tr>
+        <td>$search_phrase</td>
+        <td>{$hits}</td>
+
+        <td><input type='checkbox' name='delcloud[]' title='" . _('Mark') . "' value='{$searchId}'></td>
+    </tr>";
+            }
+            if (!empty($body)) {
+                $body .= "
+    <tr>
+        <td colspan='4' class='has-text-centered'>
+            <input type='submit' value='" . _('Delete selected terms!') . "' class='button is-small margin10'>
+        </td>
+    </tr>";
+
+                $HTMLOUT .= main_table($body, $heading);
+            } else {
+                $HTMLOUT .= main_div('No cloud search terms to preview.', null, 'has-text-centered padding20');
+            }
+            if ($count > $perpage) {
+                $HTMLOUT .= $pager['pagerbottom'];
+            }
+            $HTMLOUT = '<h1 class="has-text-centered">Cloud Search Terms</h1>' . $HTMLOUT;
+            $title = _('Cloud View');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $escaper($title) . '</a>',
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/CloudviewHandler.php.bak
+++ b/classes/Http/Handlers/Admin/CloudviewHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class CloudviewHandler
@@ -8,9 +10,26 @@ final class CloudviewHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/cloudview.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/cloudview.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/CommentsHandler.php
+++ b/classes/Http/Handlers/Admin/CommentsHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T18:11:32Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,6 +10,7 @@ final class CommentsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
+        // TODO(2025): extract legacy block for manual conversion admin/comments.php:1-20
         // STUB_UPGRADED: safe buffered execution
         $target = __DIR__ . '/../../../../admin/comments.php';
         if (!is_file($target)) {

--- a/classes/Http/Handlers/Admin/CommentsHandler.php.bak
+++ b/classes/Http/Handlers/Admin/CommentsHandler.php.bak
@@ -1,18 +1,34 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class CommentsHandler
 {
-    public function handle(array $meta = []): mixed
+    /** @param array<string,mixed> $meta */
+    public function handle(array $meta = []): void
     {
-        if (!defined('PU239_ROUTED')) {
-            define('PU239_ROUTED', true);
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/comments.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
         }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
 
-        require \dirname(__DIR__, 4) . '/admin/comments.php';
-
-        return null;
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -9,3 +9,8 @@ classes/Http/Handlers/Admin/BlockSettingsHandler.php,false,1,TODO(2025) manual e
 classes/Http/Handlers/Admin/BonusmanageHandler.php,false,1,TODO(2025) manual extraction required admin/bonusmanage.php:1-200
 classes/Http/Handlers/Admin/CategoriesHandler.php,false,1,TODO(2025) manual extraction required admin/categories.php:1-200
 classes/Http/Handlers/Admin/ChangelogHandler.php,true,0,Extracted from admin/changelog.php
+classes/Http/Handlers/Admin/ClassConfigHandler.php,true,2,Extracted from admin/class_config.php
+classes/Http/Handlers/Admin/ClassPromoHandler.php,false,1,TODO(2025) manual extraction required admin/class_promo.php:1-20
+classes/Http/Handlers/Admin/CleanupManagerHandler.php,false,1,TODO(2025) manual extraction required admin/cleanup_manager.php:1-200
+classes/Http/Handlers/Admin/CloudviewHandler.php,true,1,Extracted from admin/cloudview.php
+classes/Http/Handlers/Admin/CommentsHandler.php,false,1,TODO(2025) manual extraction required admin/comments.php:1-20


### PR DESCRIPTION
## Summary
- extract the legacy admin/class_config.php flow into ClassConfigHandler with container-backed config/database dependencies and localized helpers
- lift the admin/cloudview.php logic into CloudviewHandler while wiring cache/searchcloud services and preserving pagination output
- mark complex class_promo, cleanup_manager, and comments stubs for manual migration and append outcomes to handler_convert_report.csv

## Testing
- php -l classes/Http/Handlers/Admin/ClassConfigHandler.php
- php -l classes/Http/Handlers/Admin/CloudviewHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e2b45bf8cc8325ac7ae984ff4abcbe