### PR TITLE
feat(handler-convert): convert legacy stubs to handlers (batch=5)

### DIFF
--- a/classes/Http/Handlers/Admin/FreeleechHandler.php
+++ b/classes/Http/Handlers/Admin/FreeleechHandler.php
@@ -1,35 +1,230 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use PU239\Security\AuthZ;
+use PU239\Config\ConfigRepository;
+use Pu239\Database;
+
 final class FreeleechHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/freeleech.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
+        try {
+            $container = $GLOBALS['container'] ?? null;
+            if ($container === null) {
+                throw new \RuntimeException('Global container not initialized');
             }
-            return (string) ob_get_clean();
-        })($target);
+            $currentUser = $GLOBALS['CURUSER'] ?? null;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (defined('ADMIN_DIR') && strpos((string) ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = (string) $config->get('paths.baseurl');
+            $baseurlEscaped = $escaper($baseurl);
+
+            $checked1 = $checked2 = $checked3 = $checked4 = '';
+            $HTMLOUT = '';
+            $free = get_event(true);
+            $temp = [];
+
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                // TODO(2025): csrf
+                if (isset($_POST['remove'])) {
+                    $expires = (int) ($_POST['expires'] ?? 0);
+                    update_event($expires, TIME_NOW);
+                    audit_log(
+                        $currentUser['id'] ?? null,
+                        'config.update',
+                        [
+                            'keys' => ['freeleech.event'],
+                            'op' => 'remove',
+                            'expires' => $expires,
+                        ]
+                    );
+                    header('Location: ' . $baseurl . '/staffpanel.php?tool=freeleech');
+                    app_halt('Exit called');
+                }
+
+                $modifier = isset($_POST['modifier']) ? (int) $_POST['modifier'] : false;
+                $expires = isset($_POST['expires']) ? (int) $_POST['expires'] : false;
+                $setby = isset($_POST['setby']) ? htmlsafechars((string) $_POST['setby']) : false;
+                $title = isset($_POST['title']) ? htmlsafechars((string) $_POST['title']) : false;
+
+                if ($modifier === false || $expires === false || $setby === false || $title === false) {
+                    stderr(_('Error'), _('Incomplete form.'));
+                }
+
+                if ($expires === 255) {
+                    $expires = 1;
+                } else {
+                    $expires = $expires * 86400 + TIME_NOW;
+                }
+
+                $fl = [
+                    'modifier' => $modifier,
+                    'expires' => $expires,
+                    'setby' => $setby,
+                    'title' => $title,
+                ];
+
+                $i = 0;
+                foreach ($free as $temp) {
+                    if (($temp['modifier'] ?? null) === $fl['modifier']) {
+                        unset($free[$i]);
+                    }
+                    ++$i;
+                }
+
+                set_event($fl['modifier'], TIME_NOW, $fl['expires'], (int) $fl['setby'], $fl['title']);
+                audit_log(
+                    $currentUser['id'] ?? null,
+                    'config.update',
+                    [
+                        'keys' => ['freeleech.event'],
+                        'op' => 'set',
+                        'modifier' => $fl['modifier'],
+                        'expires' => $fl['expires'],
+                    ]
+                );
+                header('Location: ' . $baseurl . '/staffpanel.php?tool=freeleech');
+                app_halt('Exit called');
+            }
+
+            $HTMLOUT .= '<h1 class="has-text-centered">' . _('Current Freeleech Status') . '</h1>';
+            if (empty($free)) {
+                $HTMLOUT .= stdmsg(_('Nothing found'), '', 'has-text-centered bottom20');
+            } else {
+                $heading = '
+        <tr>
+            <th>' . _('Free All Torrents') . '</th>
+            <th>' . _('Started') . '</th>
+            <th>' . _('Expires') . '</th>
+            <th>' . _('Set By') . '</th>
+            <th>' . _('Title') . '</th>
+            <th>' . _('Remove') . '</th>
+        </tr>';
+                $body = '';
+                foreach ($free as $fl) {
+                    $username = format_username((int) ($fl['setby'] ?? 0));
+                    switch ((int) ($fl['modifier'] ?? 0)) {
+                        case 1:
+                            $checked1 = 'checked';
+                            $mode = _('All Torrents Free');
+                            break;
+                        case 2:
+                            $mode = _('All Torrents Double Upload');
+                            $checked2 = 'checked';
+                            break;
+                        case 3:
+                            $mode = _('All Torrents Free and Double Upload');
+                            $checked3 = 'checked';
+                            break;
+                        case 4:
+                            $mode = _('All Torrents Silver');
+                            $checked4 = 'checked';
+                            break;
+                        default:
+                            $mode = _('Not Enabled');
+                    }
+
+                    $titleText = $escaper((string) ($fl['title'] ?? ''));
+                    $expiresValue = $escaper((string) ($fl['expires'] ?? ''));
+                    $expiresRaw = $fl['expires'] ?? 'Inf.';
+                    $body .= "
+            <tr>
+                <td>{$mode}</td>
+                <td>" . get_date((int) ($fl['begin'] ?? 0), 'LONG') . '</td>';
+                    $body .= '<td>' . ($expiresRaw !== 'Inf.' && $expiresRaw !== 1 ? _('Until ') . get_date((int) $expiresRaw, 'LONG') . ' (' . mkprettytime((int) $expiresRaw - TIME_NOW) . _(' to go') . ')' : _('Unlimited')) . " </td>";
+                    $body .= "
+                <td>{$username}</td>
+                <td>{$titleText}</td>
+                <td class='has-text-centered'>
+                    <form method='post' action='{$self}?tool=freeleech&amp;action=remove' enctype='multipart/form-data' accept-charset='utf-8'>
+                        <input type='hidden' class='w-100' value ='{$expiresValue}' name='expires'>
+                        <input type='" . (((int) $expiresRaw > TIME_NOW) ? 'submit' : 'hidden') . "' name='remove' value='" . _('Remove') . "' class='button is-small'>
+                    </form>
+                </td>
+            </tr>";
+                }
+
+                $HTMLOUT .= main_table($body, $heading);
+            }
+
+            $HTMLOUT .= "
+    <h2 class='has-text-centered'>" . _('Set Freeleech') . "</h2>
+    <form method='post' action='{$self}?tool=freeleech&amp;action=freeleech' enctype='multipart/form-data' accept-charset='utf-8'>
+    <table class='table table-bordered table-striped'>
+    <tr><td class='rowhead'>" . _('Mode') . '</td>
+    <td> <table>
+ <tr>
+ <td>' . _('All Torrents Free') . "</td>
+ <td><input name='modifier' type='radio' {$checked1} value='1'></td>
+ </tr>
+ <tr>
+ <td>" . _('All Torrents Double Upload') . "</td>
+ <td><input name='modifier' type='radio' {$checked2} value='2'></td>
+ </tr>
+ <tr>
+ <td>" . _('All Torrents Free and Double Upload') . "</td>
+ <td><input name='modifier' type='radio' {$checked3} value='3'></td></tr>
+ <tr>
+ <td>" . _('All Torrents Silver') . "</td>
+ <td><input name='modifier' type='radio' {$checked4} value='4'></td></tr>
+ </table>
+    </td></tr>
+    <tr><td class='rowhead'>" . _('Expires in ') . "
+    </td><td>
+    <select name='expires'>
+    <option value='1'>" . _pfe('{0} day', '{0} days', 1) . "</option>
+    <option value='2'>" . _pfe('{0} day', '{0} days', 2) . "</option>
+    <option value='3'>" . _pfe('{0} day', '{0} days', 3) . "</option>
+    <option value='5'>" . _pfe('{0} day', '{0} days', 5) . "</option>
+    <option value='7'>" . _pfe('{0} day', '{0} days', 6) . "</option>
+    <option value='255'>" . _('Unlimited') . "</option>
+    </select></td></tr>
+    <tr><td class='rowhead'>" . _('Title') . "</td>
+    <td><input type='text' class= 'w-100' name='title' placeholder='" . _('Title') . "'>
+    </td></tr>
+    <tr><td class='rowhead'>" . _('Set By') . '</td>
+    <td><span>' . format_username((int) ($currentUser['id'] ?? 0)) . "</span>
+    </td></tr>
+    <tr><td colspan='2' class='has-text-centered'>
+    <input type='hidden' class='w-100' value ='" . $escaper((string) ($currentUser['id'] ?? '')) . "' name='setby'>
+    <input type='submit' name='okay' value='" . _('Do it!') . "' class='button is-small'>
+    </td></tr>
+    </table></form>";
+
+            $title = _('Freeleech Status');
+            $breadcrumbs = [
+                "<a href='{$baseurlEscaped}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $escaper($title) . '</a>',
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/FreeleechHandler.php.bak
+++ b/classes/Http/Handlers/Admin/FreeleechHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class FreeleechHandler
@@ -8,9 +10,26 @@ final class FreeleechHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/freeleech.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/freeleech.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/FreeusersHandler.php
+++ b/classes/Http/Handlers/Admin/FreeusersHandler.php
@@ -1,35 +1,166 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use PU239\Security\AuthZ;
+use Pu239\Cache;
+use PU239\Config\ConfigRepository;
+use Pu239\Database;
+use Pu239\Message;
+
 final class FreeusersHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/freeusers.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
+        try {
+            $container = $GLOBALS['container'] ?? null;
+            if ($container === null) {
+                throw new \RuntimeException('Global container not initialized');
             }
-            return (string) ob_get_clean();
-        })($target);
+            $currentUser = $GLOBALS['CURUSER'] ?? null;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (defined('ADMIN_DIR') && strpos((string) ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = (string) $config->get('paths.baseurl');
+            $baseurlEscaped = $escaper($baseurl);
+
+            $dt = TIME_NOW;
+            $HTMLOUT = '';
+
+            $remove = isset($_GET['remove']) ? (int) $_GET['remove'] : 0;
+            if ($remove > 0) {
+                $user = $db->fetch(
+                    'SELECT id, username, class FROM users WHERE personal_freeleech > NOW() AND id = :id',
+                    [':id' => $remove]
+                );
+                if ($user === null) {
+                    stderr(_('Error'), _('Invalid user or Freeleech already expired.'));
+                }
+
+                $modline = get_date((int) $dt, 'DATE', 1) . ' - ' . _fe('Freeleech On All Torrents removed by {0}', $currentUser['username'] ?? '') . " \n";
+
+                $db->run(
+                    'UPDATE users
+                     SET personal_freeleech = NULL,
+                         modcomment = CONCAT(:mod, modcomment)
+                     WHERE id = :id',
+                    [
+                        ':mod' => $modline,
+                        ':id'  => (int) $user['id'],
+                    ]
+                );
+                audit_log(
+                    $currentUser['id'] ?? null,
+                    'config.update',
+                    [
+                        'keys' => ['freeleech.user'],
+                        'target' => (int) $user['id'],
+                        'op' => 'remove',
+                    ]
+                );
+
+                /** @var Message $messages_class */
+                $messages_class = $container->get(Message::class);
+                $msg = _fe('Freeleech On All Torrents have been removed by {0}', $currentUser['username'] ?? '');
+                $messages_class->insert([
+                    [
+                        'receiver' => (int) $user['id'],
+                        'added'    => $dt,
+                        'msg'      => $msg,
+                        'subject'  => _('Freeleech Notice!'),
+                    ],
+                ]);
+
+                /** @var Cache $cache */
+                $cache = $container->get(Cache::class);
+                $cache->delete('inbox_' . (int) $user['id']);
+            }
+
+            $countRow = $db->fetch('SELECT COUNT(id) AS count FROM users WHERE personal_freeleech > NOW()');
+            $count = (int) ($countRow['count'] ?? 0);
+
+            $perpage = 25;
+            $pager = pager($perpage, $count, $baseurl . '/staffpanel.php?tool=freeusers&amp;');
+
+            $rows = [];
+            if ($count > 0) {
+                $rows = $db->fetchAll(
+                    'SELECT id, username, class, personal_freeleech
+                     FROM users
+                     WHERE personal_freeleech > NOW()
+                     ORDER BY username ' . $pager['limit']
+                );
+            }
+
+            $HTMLOUT .= "<h1 class='has-text-centered'>" . _fe('Freeleech Users ({0})', $count) . '</h1>';
+
+            if ($count === 0) {
+                $HTMLOUT .= main_div(_('Nothing here'), null, 'padding20 has-text-centered');
+            } else {
+                $heading = '
+        <tr>
+            <th>' . _('UserName') . '</th>
+            <th>' . _('Class') . '</th>
+            <th>' . _('Expires') . '</th>
+            <th>' . _('Remove Freeleech') . '</th>
+        </tr>';
+
+                $body = '';
+                foreach ($rows as $arr2) {
+                    $personal_freeleech = strtotime((string) $arr2['personal_freeleech']);
+                    $body .= '
+        <tr>
+            <td>' . format_username((int) $arr2['id']) . '</td>
+            <td>' . get_user_class_name((int) $arr2['class']);
+
+                    if (!has_access((int) $arr2['class'], UC_ADMINISTRATOR, 'coder') && (int) $arr2['id'] !== (int) ($currentUser['id'] ?? 0)) {
+                        $body .= '</td>
+            <td>' . _fe('Until {0} ({1}) to go.', get_date($personal_freeleech, 'DATE'), mkprettytime($personal_freeleech - $dt)) . "</td>
+            <td><span class='has-text-danger'>" . _('Not Allowed') . '</span></td>
+        </tr>';
+                    } else {
+                        $body .= '</td>
+            <td>' . _fe('Until {0} ({1}) to go.', get_date($personal_freeleech, 'DATE'), mkprettytime($personal_freeleech - $dt)) . "</td>
+            <td><a href='" . $baseurl . "/staffpanel.php?tool=freeusers&amp;remove=" . (int) $arr2['id'] . "' onclick=\"return confirm('" . _('Are you sure you want to remove this users Freeleech Status?') . "')\">" . _('Remove') . '</a></td>
+        </tr>';
+                    }
+                }
+
+                $HTMLOUT .= ($count > $perpage ? $pager['pagertop'] : '') . main_table($body, $heading) . ($count > $perpage ? $pager['pagerbottom'] : '');
+            }
+
+            $title = _('Freeleech Manager');
+            $breadcrumbs = [
+                "<a href='{$baseurlEscaped}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>$title</a>",
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/FreeusersHandler.php.bak
+++ b/classes/Http/Handlers/Admin/FreeusersHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class FreeusersHandler
@@ -8,9 +10,26 @@ final class FreeusersHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/freeusers.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/freeusers.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/GrouppmHandler.php
+++ b/classes/Http/Handlers/Admin/GrouppmHandler.php
@@ -1,35 +1,260 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use PU239\Security\AuthZ;
+use PU239\Config\ConfigRepository;
+use Pu239\Database;
+use Pu239\Message;
+use Pu239\Session;
+
 final class GrouppmHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/grouppm.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
+        try {
+            $container = $GLOBALS['container'] ?? null;
+            if ($container === null) {
+                throw new \RuntimeException('Global container not initialized');
             }
-            return (string) ob_get_clean();
-        })($target);
+            $currentUser = $GLOBALS['CURUSER'] ?? null;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (defined('ADMIN_DIR') && strpos((string) ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            /** @var Session $session */
+            $session = $container->get(Session::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = $escaper($config->get('paths.baseurl'));
+
+            $stdhead = [
+                'css' => [get_file_name('sceditor_css')],
+            ];
+            $stdfoot = [
+                'js' => [get_file_name('sceditor_js')],
+            ];
+
+            $HTMLOUT = '';
+            $errors = [];
+            $last_user_class = UC_STAFF - 1;
+            $dt = TIME_NOW;
+            $sentToClasses = [];
+
+            $classesToName = static function (int $min, int $max) use (&$sentToClasses): void {
+                for ($i = $min; $i <= $max; ++$i) {
+                    $sentToClasses[] = get_user_class_name($i);
+                }
+            };
+
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                // TODO(2025): csrf
+                $groups = isset($_POST['groups']) && is_array($_POST['groups']) ? $_POST['groups'] : [];
+                $subject = isset($_POST['subject']) ? trim((string) $_POST['subject']) : '';
+                $msg_raw = isset($_POST['body']) ? (string) $_POST['body'] : '';
+                $msg = str_replace('&amp', '&', $msg_raw);
+
+                $sender = (isset($_POST['system']) && $_POST['system'] === 'yes') ? 2 : (int) ($currentUser['id'] ?? 0);
+
+                if ($subject === '') {
+                    $errors[] = _("Your message doesn't have a subject");
+                }
+                if ($msg === '') {
+                    $errors[] = _('There is not any text in your message!');
+                }
+                if (empty($groups)) {
+                    $errors[] = _('You have to select a group to send your message');
+                }
+
+                if (empty($errors)) {
+                    $where = [];
+                    $params = [];
+                    $recipient_ids = [];
+
+                    foreach ($groups as $g) {
+                        if (is_string($g)) {
+                            switch ($g) {
+                                case 'all_staff':
+                                    $where[] = '(u.class BETWEEN :staff_min AND :staff_max)';
+                                    $params[':staff_min'] = (int) UC_STAFF;
+                                    $params[':staff_max'] = (int) UC_MAX;
+                                    $classesToName(UC_STAFF, UC_MAX);
+                                    break;
+                                case 'all_users':
+                                    $where[] = '(u.class BETWEEN :user_min AND :user_max)';
+                                    $params[':user_min'] = (int) UC_MIN;
+                                    $params[':user_max'] = (int) UC_MAX;
+                                    $classesToName(UC_MIN, UC_MAX);
+                                    break;
+                                case 'fls':
+                                    $where[] = "(u.support = 'yes')";
+                                    $sentToClasses[] = _('First line support');
+                                    break;
+                                case 'donor':
+                                    $where[] = "(u.donor = 'yes')";
+                                    $sentToClasses[] = _('Donors');
+                                    break;
+                                case 'all_friends':
+                                    $friendRows = $db->fetchAll(
+                                        "SELECT f.friendid AS id
+                                           FROM friends AS f
+                                          WHERE f.userid = :uid AND f.confirmed = 'yes'",
+                                        [':uid' => (int) ($currentUser['id'] ?? 0)]
+                                    );
+                                    foreach ($friendRows as $fr) {
+                                        $recipient_ids[] = (int) $fr['id'];
+                                    }
+                                    break;
+                            }
+                        }
+
+                        if (is_numeric($g)) {
+                            $key = ':c' . (int) $g;
+                            $where[] = "(u.class = $key)";
+                            $params[$key] = (int) $g;
+                            $sentToClasses[] = get_user_class_name((int) $g);
+                        }
+                    }
+
+                    if (!empty($where)) {
+                        $ids = $db->fetchAll('SELECT u.id FROM users AS u WHERE ' . implode(' OR ', $where), $params);
+                        foreach ($ids as $r) {
+                            $recipient_ids[] = (int) $r['id'];
+                        }
+                    }
+
+                    $recipient_ids = array_values(array_unique(array_diff($recipient_ids, [$sender])));
+
+                    if (empty($recipient_ids)) {
+                        $errors[] = _('There are not any users in the groups you selected!');
+                    } else {
+                        /** @var Message $messages_class */
+                        $messages_class = $container->get(Message::class);
+                        $buffer = [];
+                        foreach ($recipient_ids as $rid) {
+                            $buffer[] = [
+                                'receiver' => (int) $rid,
+                                'added'    => $dt,
+                                'msg'      => $msg,
+                                'subject'  => $subject,
+                            ];
+                        }
+
+                        if (!empty($buffer)) {
+                            $messages_class->insert($buffer);
+                        }
+
+                        $session->set('is-success', _fe('Message sent to {0} recipient(s)!', count($recipient_ids)));
+                    }
+                }
+            }
+
+            $groups = [];
+            $groups['staff'] = [
+                'opname'   => _('Site Staff'),
+                'minclass' => UC_MIN,
+                'ops'      => [],
+            ];
+            for ($i = UC_STAFF; $i <= UC_MAX; ++$i) {
+                $groups['staff']['ops'][$i] = get_user_class_name((int) $i);
+            }
+            $groups['staff']['ops']['fls'] = _('First line support');
+            $groups['staff']['ops']['all_staff'] = _('All staff');
+
+            $groups['members'] = [
+                'opname'   => _('Members Groups'),
+                'minclass' => UC_STAFF,
+                'ops'      => [],
+            ];
+            for ($i = UC_MIN; $i <= $last_user_class; ++$i) {
+                $groups['members']['ops'][$i] = get_user_class_name((int) $i);
+            }
+            $groups['members']['ops']['donor'] = _('Donors');
+            $groups['members']['ops']['all_users'] = _('All users');
+
+            $groups['friends'] = [
+                'opname'   => _('Related to you'),
+                'minclass' => UC_MIN,
+                'ops'      => ['all_friends' => _('Your friends')],
+            ];
+
+            $dropdown = static function (array $groupsDef, array $currentUserData): string {
+                $currentClass = (int) ($currentUserData['class'] ?? 0);
+                $r = '<select multiple="multiple" name="groups[]" size="16">';
+                foreach ($groupsDef as $group) {
+                    if (($group['minclass'] ?? 0) >= $currentClass) {
+                        continue;
+                    }
+                    $r .= '<optgroup label="' . (string) $group['opname'] . '">';
+                    foreach ($group['ops'] as $k => $v) {
+                        $r .= '<option value="' . (string) $k . '">' . (string) $v . '</option>';
+                    }
+                    $r .= '</optgroup>';
+                }
+                $r .= '</select>';
+
+                return $r;
+            };
+
+            if (!empty($errors)) {
+                foreach ($errors as $error) {
+                    $session->set('is-warning', $error);
+                }
+            }
+
+            $HTMLOUT .= "
+    <h1 class='has-text-centered'>" . _('Group message') . "</h1>
+    <form action='{$self}?tool=grouppm&amp;action=grouppm' method='post' enctype='multipart/form-data' accept-charset='utf-8'>
+      <table class='table table-bordered table-striped'>
+        <tr>
+          <td colspan='2'>" . _('Subject') . "
+            <input type='text' name='subject' class='w-100'></td>
+        </tr>
+        <tr>
+          <td>" . _('Body') . "</td>
+          <td>" . _('Groups') . "</td>
+        </tr>
+        <tr>
+          <td class='is-paddingless'>" . BBcode() . "</td>
+          <td>" . $dropdown($groups, $currentUser ?? []) . "</td>
+        </tr>
+      </table>
+        <div class='has-text-centered margin20'>
+            <label for='sys'>" . _('Send as System') . "</label>
+            <input id='sys' type='checkbox' name='system' value='yes' class=''>
+            <input type='submit' value='" . _('Send!') . "' class='button is-small left20'>
+        </div>
+    </form>";
+
+            $title = _('Group PM');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $escaper($title) . '</a>',
+            ];
+
+            echo stdhead($title, $stdhead, 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot($stdfoot);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/GrouppmHandler.php.bak
+++ b/classes/Http/Handlers/Admin/GrouppmHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class GrouppmHandler
@@ -8,9 +10,26 @@ final class GrouppmHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/grouppm.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/grouppm.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/HitAndRunHandler.php
+++ b/classes/Http/Handlers/Admin/HitAndRunHandler.php
@@ -1,35 +1,281 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use PU239\Security\AuthZ;
+use PU239\Config\ConfigRepository;
+use Pu239\Database;
+
 final class HitAndRunHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/hit_and_run.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
+        try {
+            $container = $GLOBALS['container'] ?? null;
+            if ($container === null) {
+                throw new \RuntimeException('Global container not initialized');
             }
-            return (string) ob_get_clean();
-        })($target);
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (defined('ADMIN_DIR') && strpos((string) ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = (string) $config->get('paths.baseurl');
+            $baseurlEscaped = $escaper($baseurl);
+
+            $reallyBad = isset($_GET['really_bad']);
+
+            if ($reallyBad) {
+                $countRow = $db->fetch(
+                    "SELECT COUNT(s.id) AS count
+                       FROM snatched AS s
+                       LEFT JOIN users AS u ON u.id = s.userid
+                      WHERE s.finished = 'yes' AND s.hit_and_run > 0 AND u.hit_and_run_total > 2"
+                );
+            } else {
+                $countRow = $db->fetch(
+                    "SELECT COUNT(id) AS count
+                       FROM snatched
+                      WHERE finished = 'yes' AND hit_and_run > 0"
+                );
+            }
+
+            $count = (int) ($countRow['count'] ?? 0);
+            $perpage = isset($_GET['perpage']) ? (int) $_GET['perpage'] : 15;
+            $link = $baseurl . '/staffpanel.php?tool=hit_and_run';
+            $pager = pager($perpage, $count, $link);
+            $menu_top = $pager['pagertop'];
+            $menu_bottom = $pager['pagerbottom'];
+            $limitClause = $pager['limit'];
+
+            if ($reallyBad) {
+                $rows = $db->fetchAll(
+                    "SELECT s.torrentid,
+                            s.userid,
+                            s.hit_and_run,
+                            s.downloaded AS dload,
+                            s.uploaded AS uload,
+                            s.seedtime,
+                            s.start_date,
+                            s.complete_date,
+                            p.id AS peer_id,
+                            p.torrent,
+                            p.seeder,
+                            u.id AS user_id,
+                            u.avatar,
+                            u.offensive_avatar,
+                            u.username,
+                            u.uploaded AS up,
+                            u.downloaded AS down,
+                            u.class,
+                            u.hit_and_run_total,
+                            u.donor,
+                            u.warned,
+                            u.status,
+                            u.leechwarn,
+                            u.chatpost,
+                            u.pirate,
+                            u.king,
+                            t.owner,
+                            t.name,
+                            t.added AS torrent_added,
+                            t.seeders AS numseeding,
+                            t.leechers AS numleeching
+                       FROM snatched AS s
+                       LEFT JOIN users AS u ON u.id = s.userid
+                       LEFT JOIN peers AS p ON p.torrent = s.torrentid AND p.userid = s.userid
+                       LEFT JOIN torrents AS t ON t.id = s.torrentid
+                      WHERE s.finished = 'yes' AND s.hit_and_run > 0 AND u.hit_and_run_total > 2
+                      ORDER BY s.userid $limitClause"
+                );
+            } else {
+                $rows = $db->fetchAll(
+                    "SELECT s.torrentid,
+                            s.userid,
+                            s.hit_and_run,
+                            s.downloaded AS dload,
+                            s.uploaded AS uload,
+                            s.seedtime,
+                            s.start_date,
+                            s.complete_date,
+                            p.id AS peer_id,
+                            p.torrent,
+                            p.seeder,
+                            u.id AS user_id,
+                            u.avatar,
+                            u.username,
+                            u.uploaded AS up,
+                            u.downloaded AS down,
+                            u.class,
+                            u.hit_and_run_total,
+                            u.donor,
+                            u.warned,
+                            u.status,
+                            u.leechwarn,
+                            u.chatpost,
+                            u.pirate,
+                            u.king,
+                            t.owner,
+                            t.name,
+                            t.added AS torrent_added,
+                            t.seeders AS numseeding,
+                            t.leechers AS numleeching
+                       FROM snatched AS s
+                       LEFT JOIN users AS u ON u.id = s.userid
+                       LEFT JOIN peers AS p ON p.torrent = s.torrentid AND p.userid = s.userid
+                       LEFT JOIN torrents AS t ON t.id = s.torrentid
+                      WHERE s.finished = 'yes' AND s.hit_and_run > 0
+                      ORDER BY s.userid $limitClause"
+                );
+            }
+
+            $HTMLOUT = "
+            <ul class='level-center bg-06'>
+                <li class='is-link margin10'>
+                    <a href='{$baseurlEscaped}/staffpanel.php?tool=hit_and_run'>" . _('show all current hit and runs') . "</a>
+                </li>
+                <li class='is-link margin10'>
+                    <a href='{$baseurlEscaped}/staffpanel.php?tool=hit_and_run&amp;really_bad=show_them'>" . _('show disabled hit and runs') . "</a>
+                </li>
+            </ul>
+            <h1 class='has-text-centered'>" . ($reallyBad ? _('Hit and Runs with no chance') : _('Current Hit and Runs who still have a chance')) . '</h1>';
+
+            if ($count > $perpage) {
+                $HTMLOUT .= '<p>' . $menu_top . '</p>';
+            }
+
+            $HTMLOUT .= "
+        <table class=\"table table-bordered table-striped\">";
+
+            if (count($rows) === 0) {
+                $HTMLOUT .= "<tr><td><div class='padding20'>" . _('no hit and runners at the moment...') . '</div></td></tr>';
+            } else {
+                $HTMLOUT .= "<tr><td class=\"colhead\">" . _('Avatar') . "</td>
+        <td class=\"colhead\"><b>" . _('Member') . "</b></td>
+        <td class=\"colhead\"><b>" . _('Torrent') . "</b></td>
+        <td class=\"colhead\"><b>" . _('Times') . "</b></td>
+        <td class=\"colhead\"><b>" . _('Stats') . "</b></td>
+        <td class=\"colhead\">" . _('Actions') . '</td></tr>';
+
+                foreach ($rows as $row) {
+                    $isSeeder = ($row['seeder'] ?? 'no') !== 'yes';
+                    $userId = (int) ($row['userid'] ?? 0);
+                    $startDate = (int) ($row['start_date'] ?? 0);
+                    $torrentId = (int) ($row['torrentid'] ?? 0);
+                    $completeDate = (int) ($row['complete_date'] ?? 0);
+
+                    if (!$isSeeder) {
+                        continue;
+                    }
+
+                    if ($userId === (int) ($row['owner'] ?? 0)) {
+                        continue;
+                    }
+
+                    $siteRatioDivisor = (bool) $config->get('site.ratio_free') ? 1 : max(1, (int) ($row['down'] ?? 0));
+                    $torrentRatioDivisor = (bool) $config->get('site.ratio_free') ? 1 : max(1, (int) ($row['dload'] ?? 0));
+                    $site_ratio = (float) ($row['up'] ?? 0) / $siteRatioDivisor;
+                    $torrent_ratio = (float) ($row['uload'] ?? 0) / $torrentRatioDivisor;
+                    $ratio_site = member_ratio((float) ($row['up'] ?? 0), (float) ($row['down'] ?? 0));
+                    $ratio_torrent = member_ratio((float) ($row['uload'] ?? 0), (float) ($row['dload'] ?? 0));
+                    $avatar = get_avatar($row);
+                    $torrent_needed_seed_time = (int) ($row['seedtime'] ?? 0);
+
+                    switch (true) {
+                        case ((int) ($row['class'] ?? 0)) <= (int) $config->get('hnr_config.firstclass'):
+                            $days_3 = (int) $config->get('hnr_config._3day_first') * 3600;
+                            $days_14 = (int) $config->get('hnr_config._14day_first') * 3600;
+                            $days_over_14 = (int) $config->get('hnr_config._14day_over_first') * 3600;
+                            break;
+                        case ((int) ($row['class'] ?? 0)) < (int) $config->get('hnr_config.secondclass'):
+                            $days_3 = (int) $config->get('hnr_config._3day_second') * 3600;
+                            $days_14 = (int) $config->get('hnr_config._14day_second') * 3600;
+                            $days_over_14 = (int) $config->get('hnr_config._14day_over_second') * 3600;
+                            break;
+                        case ((int) ($row['class'] ?? 0)) >= (int) $config->get('hnr_config.thirdclass'):
+                            $days_3 = (int) $config->get('hnr_config._3day_third') * 3600;
+                            $days_14 = (int) $config->get('hnr_config._14day_third') * 3600;
+                            $days_over_14 = (int) $config->get('hnr_config._14day_over_third') * 3600;
+                            break;
+                        default:
+                            $days_3 = (int) $config->get('hnr_config._3day_first') * 3600;
+                            $days_14 = (int) $config->get('hnr_config._14day_first') * 3600;
+                            $days_over_14 = (int) $config->get('hnr_config._14day_over_first') * 3600;
+                            break;
+                    }
+
+                    switch (true) {
+                        case ($startDate - (int) ($row['torrent_added'] ?? 0)) < (int) $config->get('hnr_config.torrentage1') * 86400:
+                            $minus_ratio = $days_3 - $torrent_needed_seed_time;
+                            break;
+                        case ($startDate - (int) ($row['torrent_added'] ?? 0)) < (int) $config->get('hnr_config.torrentage2') * 86400:
+                            $minus_ratio = $days_14 - $torrent_needed_seed_time;
+                            break;
+                        case ($startDate - (int) ($row['torrent_added'] ?? 0)) >= (int) $config->get('hnr_config.torrentage3') * 86400:
+                            $minus_ratio = $days_over_14 - $torrent_needed_seed_time;
+                            break;
+                        default:
+                            $minus_ratio = $days_over_14 - $torrent_needed_seed_time;
+                            break;
+                    }
+
+                    $minus_ratio = $minus_ratio < 0 ? 0 : $minus_ratio;
+                    $HTMLOUT .= '<tr><td class="has-text-centered w-15 mw-150">' . $avatar . '</td>
+            <td><a class="is-link" href="' . $baseurl . '/userdetails.php?id=' . $userId . '&amp;completed=1#completed">' . htmlsafechars((string) ($row['username'] ?? '')) . '</a>  [ ' . get_user_class_name((int) ($row['class'] ?? 0)) . ' ]
+</td>
+            <td><a class="is-link" href="details.php?id=' . $torrentId . '&amp;hit=1">' . htmlsafechars((string) ($row['name'] ?? '')) . '</a><br>
+            ' . _('Leechers:') . ' ' . (int) ($row['numleeching'] ?? 0) . '<br>
+            ' . _('Seeders:') . ' ' . (int) ($row['numseeding'] ?? 0) . '
+         </td>
+            <td>' . _('Finished DL at:') . ' ' . get_date($completeDate, 'LONG') . '<br>
+            ' . _('Stopped seeding at:') . ' ' . get_date((int) ($row['hit_and_run'] ?? 0), '') . '<br>
+            ' . _('Seeded for:') . ' ' . mkprettytime((int) ($row['seedtime'] ?? 0)) . '<br>
+            **' . _('Should still seed for') . ': ' . mkprettytime($minus_ratio) . '</td>
+            <td>' . _('Uploaded') . ': ' . mksize((int) ($row['uload'] ?? 0)) . '<br>
+            ' . ((bool) $config->get('site.ratio_free') ? ' ' : _('Downloaded') . mksize((int) ($row['dload'] ?? 0)) . '<br>') . '
+            ' . _('Torrent ratio') . ': <span style="color: " ' . get_ratio_color($torrent_ratio) . '">' . $ratio_torrent . '</span><br>
+            ' . _('Site ratio') . ': <span style="color: "' . get_ratio_color($site_ratio) . '" title="' . _('includes all bonus and karma stuff') . '">' . $ratio_site . '</font></td>
+            <td><a href="messages.php?action=send_message&amp;receiver=' . $userId . '"><img src="' . (string) $config->get('paths.images_baseurl') . 'pm.gif" alt="PM" title="' . _('Send this user a PM') . '"></a><br>
+            <a class="is-link" href="' . $baseurl . '/staffpanel.php?tool=shit_list&amp;action2=new&amp;shit_list_id=' . $userId . '&amp;return_to=staffpanel.php?tool=hit_and_run"><img src="' . (string) $config->get('paths.images_baseurl') . 'smilies/shit.gif" alt="Shit" title="' . _('Shit') . '"></a></td></tr>';
+                }
+            }
+
+            $HTMLOUT .= '</table>';
+
+            if ($count > $perpage) {
+                $HTMLOUT .= '<p>' . $menu_bottom . '</p>';
+            }
+
+            $title = _('Hit and Runs');
+            $breadcrumbs = [
+                "<a href='{$baseurlEscaped}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>$title</a>",
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/HitAndRunHandler.php.bak
+++ b/classes/Http/Handlers/Admin/HitAndRunHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class HitAndRunHandler
@@ -8,9 +10,26 @@ final class HitAndRunHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/hit_and_run.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/hit_and_run.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/HitAndRunSettingsHandler.php
+++ b/classes/Http/Handlers/Admin/HitAndRunSettingsHandler.php
@@ -1,35 +1,138 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
 
 namespace PU239\Http\Handlers\Admin;
 
+use PU239\Config\ConfigRepository;
+use PU239\Security\AuthZ;
+use Pu239\Cache;
+use Pu239\Database;
+use Pu239\Session;
+
 final class HitAndRunSettingsHandler
 {
-    /** @param array<string,mixed> $meta */
+    /**
+     * @param array<string, mixed> $meta
+     */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/hit_and_run_settings.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-05T19:32:40Z via codex handler conversion
+        try {
+            $container = $GLOBALS['container'] ?? null;
+            if ($container === null) {
+                throw new \RuntimeException('Global container not initialized');
             }
-            return (string) ob_get_clean();
-        })($target);
+            $currentUser = $GLOBALS['CURUSER'] ?? null;
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            if (defined('ADMIN_DIR') && strpos((string) ADMIN_DIR, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $escaper = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $escaper($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = $escaper($config->get('paths.baseurl'));
+
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                // TODO(2025): csrf
+                /** @var Session $session */
+                $session = $container->get(Session::class);
+                $updated = false;
+                $changedKeys = [];
+
+                $hnrConfig = (array) $config->get('hnr_config');
+                foreach ($hnrConfig as $name => $currentValue) {
+                    if (!array_key_exists($name, $_POST)) {
+                        continue;
+                    }
+
+                    $newValue = $_POST[$name];
+                    if ((string) $newValue === (string) $currentValue) {
+                        continue;
+                    }
+
+                    $db->run(
+                        'UPDATE hit_and_run_settings SET value = :value WHERE name = :name',
+                        [
+                            ':value' => (string) $newValue,
+                            ':name' => (string) $name,
+                        ]
+                    );
+                    $updated = true;
+                    $changedKeys[] = $name;
+                }
+
+                if (!$updated) {
+                    $session->set('is-warning', _('There was an error while executing the update query or nothing was updated.'));
+                } else {
+                    /** @var Cache $cache */
+                    $cache = $container->get(Cache::class);
+                    $cache->delete('hnr_settings_');
+                    audit_log($currentUser['id'] ?? null, 'config.update', ['keys' => $changedKeys]);
+                    $session->set('is-success', 'Update Successful');
+                }
+            }
+
+            $HTMLOUT = "
+<h1 class='has-text-centered'>" . _('Hit And Run Settings') . "</h1>
+<form action='{$self}?tool=hit_and_run_settings' method='post' enctype='multipart/form-data' accept-charset='utf-8'>";
+
+            $rows = [];
+            $rows[] = "    <tr><td class='w-50'>" . _('Hit And Run Online:') . "</td><td>" . _('Yes') . "<input type='radio' name='hnr_online' value='1' " . ($config->get('hnr_config.hnr_online') ? 'checked' : '') . "> " . _('No') . "<input type='radio' name='hnr_online' value='0' " . (!$config->get('hnr_config.hnr_online') ? 'checked' : '') . "></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('First Class (Under and Equal)') . "</td><td><input type='text' name='firstclass' size='20' value='" . htmlsafechars($config->get('hnr_config.firstclass')) . "'></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Second Class (Under)') . "</td><td><input type='text' name='secondclass' size='20' value='" . htmlsafechars($config->get('hnr_config.secondclass')) . "'></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Third Class (Above and Equal)') . "</td><td><input type='text' name='thirdclass' size='20' value='" . htmlsafechars($config->get('hnr_config.thirdclass')) . "'></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Torrent Age Group 1 Under') . "</td><td><input type='number' name='torrentage1' min='0' max='31' step='1' value='" . $config->get('hnr_config.torrentage1') . "'> " . _('Days') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Torrent Age Group 2 Under') . "</td><td><input type='number' name='torrentage2' min='0' max='31' step='1' value='" . $config->get('hnr_config.torrentage2') . "'> " . _('Days') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Torrent Age Group 3 Over') . "</td><td><input type='number' name='torrentage3' min='0' max='31' step='1' value='" . $config->get('hnr_config.torrentage3') . "'> " . _('Days') . "</td></tr>";
+            $rows[] = "    <tr><td colspan='2'><div class='has-text-centered size_6'>" . _('Group 1') . "</div></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 1 First Class') . "</td><td><input type='number' name='_3day_first' min='0' max='4320' step='1' value='" . $config->get('hnr_config._3day_first') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 1 Second Class') . "</td><td><input type='number' name='_3day_second' min='0' max='4320' step='1' value='" . $config->get('hnr_config._3day_second') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 1 Third Class') . "</td><td><input type='number' name='_3day_third' min='0' max='4320' step='1' value='" . $config->get('hnr_config._3day_third') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td colspan='2'><div class='has-text-centered size_6'>" . _('Group 3') . "</div></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 2 First Class') . "</td><td><input type='number' name='_14day_first' min='0' max='4320' step='1' value='" . $config->get('hnr_config._14day_first') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 2 Second Class') . "</td><td><input type='number' name='_14day_second' min='0' max='4320' step='1' value='" . $config->get('hnr_config._14day_second') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 2 Third Class') . "</td><td><input type='number' name='_14day_third' min='0' max='4320' step='1' value='" . $config->get('hnr_config._14day_third') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td colspan='2'><div class='has-text-centered size_6'>" . _('Group 2') . "</div></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 3 First Class') . "</td><td><input type='number' name='_14day_over_first' min='0' max='4320' step='1' value='" . $config->get('hnr_config._14day_over_first') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 3 Second Class') . "</td><td><input type='number' name='_14day_over_second' min='0' max='4320' step='1' value='" . $config->get('hnr_config._14day_over_second') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Seed Time For Torrent Age Group 3 Third Class') . "</td><td><input type='number' name='_14day_over_third' min='0' max='4320' step='1' value='" . $config->get('hnr_config._14day_over_third') . "'>" . _(' Hours') . "</td></tr>";
+            $rows[] = "    <tr><td colspan='2'></td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Time Allowed Before Mark Of Cain') . "</td><td><input type='number' name='caindays' min='0' max='31' step='0.1' value='" . $config->get('hnr_config.caindays') . "'>" . _(' Days') . "</td></tr>";
+            $rows[] = "    <tr><td class='w-50'>" . _('Allowed Mark Of Cains') . "</td><td><input type='number' name='cainallowed' min='0' max='500' step='1' value='" . $config->get('hnr_config.cainallowed') . "'></td></tr>";
+            $rows[] = "    <tr><td colspan='2'></td></tr>";
+            $rows[] = "    <tr>";
+            $rows[] = "        <td class='w-50'>" . _('Are all downloads subject to HnR, including incomplete downloads?') . "</td>";
+            $rows[] = "        <td>";
+            $rows[] = "            <input type='radio' name='all_torrents' value='1' " . ($config->get('hnr_config.all_torrents') ? 'checked' : '') . '>' . _('Yes');
+            $rows[] = "            <input type='radio' name='all_torrents' value='0' " . (!$config->get('hnr_config.all_torrents') ? 'checked' : '') . '>' . _(' No');
+            $rows[] = "        </td>";
+            $rows[] = "    </tr>";
+            $rows[] = "    <tr><td colspan='2' class='has-text-centered'><input type='submit' value='" . _('Apply changes') . "' class='button is-small'></td></tr>";
+
+            $HTMLOUT .= main_table(implode("\n", $rows)) . '</form>';
+
+            $title = _('HnR Settings');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $escaper($title) . '</a>',
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/HitAndRunSettingsHandler.php.bak
+++ b/classes/Http/Handlers/Admin/HitAndRunSettingsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class HitAndRunSettingsHandler
@@ -8,9 +10,26 @@ final class HitAndRunSettingsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/hit_and_run_settings.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/hit_and_run_settings.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -19,3 +19,8 @@ classes/Http/Handlers/Admin/DonationsHandler.php,true,0,Extracted from admin/don
 classes/Http/Handlers/Admin/DoubleusersHandler.php,true,0,Extracted from admin/doubleusers.php
 classes/Http/Handlers/Admin/EditMoodsHandler.php,true,0,Extracted from admin/edit_moods.php
 classes/Http/Handlers/Admin/EditlogHandler.php,true,1,Extracted from admin/editlog.php
+classes/Http/Handlers/Admin/FreeleechHandler.php,true,1,Extracted from admin/freeleech.php
+classes/Http/Handlers/Admin/FreeusersHandler.php,true,0,Extracted from admin/freeusers.php
+classes/Http/Handlers/Admin/GrouppmHandler.php,true,1,Extracted from admin/grouppm.php
+classes/Http/Handlers/Admin/HitAndRunHandler.php,true,0,Extracted from admin/hit_and_run.php
+classes/Http/Handlers/Admin/HitAndRunSettingsHandler.php,true,1,Extracted from admin/hit_and_run_settings.php


### PR DESCRIPTION
## Summary
- migrate the admin freeleech handler from the legacy script and preserve event management with container-driven config access
- inline the freeusers and grouppm legacy logic, wiring database/cache/message services and local helpers for rendering
- lift hit-and-run display and settings scripts into handlers, swapping raw SQL calls for the shared Database wrapper and structured HTML assembly
- record the conversions in tools/handler_convert_report.csv and refresh .bak snapshots for rollback

## Testing
- php -l classes/Http/Handlers/Admin/FreeleechHandler.php
- php -l classes/Http/Handlers/Admin/FreeusersHandler.php
- php -l classes/Http/Handlers/Admin/GrouppmHandler.php
- php -l classes/Http/Handlers/Admin/HitAndRunHandler.php
- php -l classes/Http/Handlers/Admin/HitAndRunSettingsHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e2c73e64788325868b6cee64c4efe9