### PR TITLE
feat: convert public handler stubs (batch 50)

### DIFF
--- a/classes/Http/Handlers/Public/ClearAnnouncementHandler.php
+++ b/classes/Http/Handlers/Public/ClearAnnouncementHandler.php
@@ -1,34 +1,59 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 
 final class ClearAnnouncementHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/clear_announcement.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+
+            $db->run(
+                'UPDATE users SET curr_ann_id = :curr_ann_id, curr_ann_last_check = :curr_ann_last_check WHERE id = :id AND curr_ann_id != 0',
+                [
+                    ':curr_ann_id' => 0,
+                    ':curr_ann_last_check' => 0,
+                    ':id' => $user['id'],
+                ],
+            );
+            audit_log($user['id'] ?? null, 'announcement.clear', []);
+
+            /** @var Cache $cache */
+            $cache = $container->get(Cache::class);
+            $cache->update_row(
+                'user_' . $user['id'],
+                [
+                    'curr_ann_id' => 0,
+                    'curr_ann_last_check' => 0,
+                ],
+                $config->get('expires.user_cache'),
+            );
+
+            header('Location: ' . (string) $config->get('paths.baseurl'));
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/ClearAnnouncementHandler.php.bak
+++ b/classes/Http/Handlers/Public/ClearAnnouncementHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class ClearAnnouncementHandler
@@ -8,9 +10,25 @@ final class ClearAnnouncementHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/clear_announcement.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/clear_announcement.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/HappylogHandler.php
+++ b/classes/Http/Handlers/Public/HappylogHandler.php
@@ -1,34 +1,74 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\HappyLog;
 
 final class HappylogHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/happylog.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+
+            $user = check_user_status();
+            $HTMLOUT = '';
+            $baseUrl = (string) $config->get('paths.baseurl');
+
+            if (empty($user)) {
+                stderr(_('Error'), 'User not found');
+            }
+            $id = $user['id'];
+            /** @var HappyLog $happylog */
+            $happylog = $container->get(HappyLog::class);
+            $count = $happylog->get_count($id);
+            $perpage = 30;
+            $pager = pager($perpage, $count, sprintf('%s/happylog.php?id=%d&amp;', $baseUrl, $id));
+            $res = $happylog->get_by_userid($id, $pager['pdo']);
+            $HTMLOUT .= "
+                <h1 class='has-text-centered'>" . _fe('Happy hour log for {0}', format_username((int) $id)) . '</h1>';
+            if ($count > 0) {
+                $HTMLOUT .= $count > $perpage ? $pager['pagertop'] : '';
+                $heading = "
+                    <tr>
+                        <td class='colhead w-50'>" . _('Name') . "</td>
+                        <td class='colhead'>" . _('Multiplier') . "</td>
+                        <td class='colhead' nowrap='nowrap'>" . _('Date Started') . '</td>
+                    </tr>';
+                $body = '';
+                foreach ($res as $arr) {
+                    $body .= "
+                    <tr>
+                        <td><a href='{$baseUrl}/details.php?id={$arr['torrentid']}'>" . htmlsafechars($arr['name']) . "</a></td>
+                        <td>{$arr['multi']}</td>
+                        <td nowrap='nowrap'>" . get_date((int) $arr['date'], 'LONG', 1, 0) . '</td>
+                    </tr>';
+                }
+                $HTMLOUT .= main_table($body, $heading);
+                $HTMLOUT .= $count > $perpage ? $pager['pagerbottom'] : '';
+            } else {
+                $HTMLOUT .= main_div(_('No torrents downloaded during happy hour!'), '', 'has-text-centered padding20');
+            }
+            $title = _('Happy Log');
+            $breadcrumbs = [
+                sprintf("<a href='%s'>%s</a>", $_SERVER['PHP_SELF'] ?? '', $title),
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/HappylogHandler.php.bak
+++ b/classes/Http/Handlers/Public/HappylogHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class HappylogHandler
@@ -8,9 +10,25 @@ final class HappylogHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/happylog.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/happylog.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/LogoutHandler.php
+++ b/classes/Http/Handlers/Public/LogoutHandler.php
@@ -1,34 +1,45 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Delight\Auth\Auth;
+use Pu239\Config\ConfigRepository;
+use Pu239\User;
 
 final class LogoutHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/logout.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            $baseUrl = (string) $config->get('paths.baseurl');
+
+            /** @var Auth $auth */
+            $auth = $container->get(Auth::class);
+            if ($auth->isLoggedIn()) {
+                $userId = $auth->getUserId();
+                if (!empty($userId)) {
+                    /** @var User $user */
+                    $user = $container->get(User::class);
+                    $user->logout((int) $userId, true);
+                }
+            }
+
+            header(sprintf('Location: %s/login.php', $baseUrl));
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/LogoutHandler.php.bak
+++ b/classes/Http/Handlers/Public/LogoutHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class LogoutHandler
@@ -8,9 +10,25 @@ final class LogoutHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/logout.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/logout.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/VerifyEmailHandler.php
+++ b/classes/Http/Handlers/Public/VerifyEmailHandler.php
@@ -1,34 +1,70 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Delight\Auth\Auth;
+use Delight\Auth\InvalidSelectorTokenPairException;
+use Delight\Auth\TokenExpiredException;
+use Delight\Auth\TooManyRequestsException;
+use Delight\Auth\UserAlreadyExistsException;
+use PU239\Support\Audit;
+use Pu239\Config\ConfigRepository;
+use Pu239\Session;
 
 final class VerifyEmailHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/verify_email.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Session $session */
+            $session = $container->get(Session::class);
+            /** @var Auth $auth */
+            $auth = $container->get(Auth::class);
+            if ($auth->isLoggedIn()) {
+                $auth->logOutEverywhere();
+                $auth->destroySession();
+            }
+            $selector = $_GET['selector'] ?? '';
+            $token = $_GET['token'] ?? '';
+            if ($selector === '' || $token === '') {
+                stderr(_('Error'), _('Invalid verification link'));
+            }
+            $emails = [];
+            try {
+                $emails = $auth->confirmEmail($selector, $token);
+            } catch (InvalidSelectorTokenPairException $e) {
+                stderr(_('Error'), _('Invalid token'));
+            } catch (TokenExpiredException $e) {
+                stderr(_('Error'), _('Token expired'));
+            } catch (UserAlreadyExistsException $e) {
+                stderr(_('Error'), _('Email address already exists'));
+            } catch (TooManyRequestsException $e) {
+                stderr(_('Error'), _('Too many requests from your IP'));
+            }
+            if (empty($emails[0])) {
+                $session->set('is-success', _('Your email has been confirmed'));
+            } else {
+                $session->set('is-success', _fe('Your email has been changed to {0}', $emails[1] ?? ''));
+            }
+            $userid = $auth->getUserId();
+            Audit::log($userid, 'config.update', ['target' => $userid, 'keys' => ['email']]);
+            $baseUrl = (string) $config->get('paths.baseurl');
+            header(sprintf('Location: %s/usercp.php?action=security', $baseUrl));
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/VerifyEmailHandler.php.bak
+++ b/classes/Http/Handlers/Public/VerifyEmailHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class VerifyEmailHandler
@@ -8,9 +10,25 @@ final class VerifyEmailHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/verify_email.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/verify_email.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/VerifyHandler.php
+++ b/classes/Http/Handlers/Public/VerifyHandler.php
@@ -1,34 +1,107 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Delight\Auth\Auth;
+use Delight\Auth\NotLoggedInException;
+use Delight\Auth\TooManyRequestsException;
+use Pu239\Config\ConfigRepository;
+use Pu239\Session;
 
 final class VerifyHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/verify.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=50-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            $s = $s ?? static fn($v): string => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+            $user = check_user_status();
+            $baseUrl = (string) $config->get('paths.baseurl');
+
+            $page = $_GET['page'] ?? '';
+
+            get_template();
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                // TODO(2025): add CSRF verification
+                /** @var Session $session */
+                $session = $container->get(Session::class);
+                /** @var Auth $auth */
+                $auth = $container->get(Auth::class);
+                $url = get_return_to($_POST['page'] ?? '');
+                if (empty($url)) {
+                    $session->set('is-warning', _('Invalid Page Requested.'));
+                    header(sprintf('Location: %s/index.php', $baseUrl));
+                    app_halt('Exit called');
+
+                    return;
+                }
+                try {
+                    if ($auth->reconfirmPassword($_POST['password'] ?? '')) {
+                        $session->set('is-success', _('Your identity has been confirmed.'));
+                        $session->set('auth_remembered', false, false);
+                        header(sprintf('Location: %s', $url));
+                        app_halt('Exit called');
+
+                        return;
+                    }
+                    $auth->logOutEverywhere();
+                    $session->set('is-danger', _('Password verification failed.'));
+                    header(sprintf('Location: %s/login.php', $baseUrl));
+                    app_halt('Exit called');
+
+                    return;
+                } catch (NotLoggedInException $e) {
+                    $session->set('is-danger', _('The user is not signed in.'));
+                    header(sprintf('Location: %s/login.php', $baseUrl));
+                    app_halt('Exit called');
+
+                    return;
+                } catch (TooManyRequestsException $e) {
+                    $session->set('is-danger', _('Too many requests from your IP..'));
+                    header(sprintf('Location: %s/index.php', $baseUrl));
+                    app_halt('Exit called');
+
+                    return;
+                }
+            }
+            $HTMLOUT = "
+                        <form id='site_login' class='form-inline table-wrapper' method='post' action='{$baseUrl}/verify.php' enctype='multipart/form-data' accept-charset='utf-8'>";
+            $body = "
+                            <h1 class='has-text-centered'>" . _('Verify Your Identity') . "</h1>
+                            <div class='columns'>
+                                <div class='column is-one-quarter'>" . _('Password') . "</div>
+                                <div class='column'>
+                                    <input type='password' class='w-100' name='password' autocomplete='on' placeholder='" . _('Password') . "' required>
+                                    <input type='hidden' name='page' value='" . $s($page) . "'>
+                                </div>
+                            </div>
+                            <div class='has-text-centered'>
+                                <input id='login' type='submit' value='" . ('Verify') . "' class='button is-small'>
+                            </div>";
+
+            $HTMLOUT .= main_div($body, '', 'padding20') . '
+                        </div>
+                    </form>';
+            $title = _('Verify Identity');
+            $breadcrumbs = [
+                sprintf("<a href='%s'>%s</a>", $s($_SERVER['PHP_SELF'] ?? ''), $s($title)),
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/VerifyHandler.php.bak
+++ b/classes/Http/Handlers/Public/VerifyHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class VerifyHandler
@@ -8,9 +10,25 @@ final class VerifyHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/verify.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/verify.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/tools/conversion_report/classes_Http_Handlers_Public_ClearAnnouncementHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_ClearAnnouncementHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/ClearAnnouncementHandler.php
+
+- Legacy source: public/clear_announcement.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/helpers/audit.php, include/bittorrent.php
+- Config mappings: `$site_config['paths']['baseurl']` → `$config->get('paths.baseurl')`
+- Database usage: Converted inline `UPDATE` to `$db->run(...)` with bound params
+- TODOs introduced: 0
+- Notes: Preserved cache row update with config-driven expiry duration.

--- a/tools/conversion_report/classes_Http_Handlers_Public_HappylogHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_HappylogHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/HappylogHandler.php
+
+- Legacy source: public/happylog.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/bittorrent.php
+- Config mappings: `$site_config['paths']['baseurl']` → `$config->get('paths.baseurl')`
+- Database usage: Delegated to `HappyLog` service via container
+- TODOs introduced: 0
+- Notes: Preserved pager/table rendering and error handling via `stderr`.

--- a/tools/conversion_report/classes_Http_Handlers_Public_LogoutHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_LogoutHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/LogoutHandler.php
+
+- Legacy source: public/logout.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/bittorrent.php
+- Config mappings: `$site_config['paths']['baseurl']` → `$config->get('paths.baseurl')`
+- Database usage: none
+- TODOs introduced: 0
+- Notes: Handler now resolves Auth and User services via the container before redirecting.

--- a/tools/conversion_report/classes_Http_Handlers_Public_VerifyEmailHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_VerifyEmailHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/VerifyEmailHandler.php
+
+- Legacy source: public/verify_email.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/bittorrent.php
+- Config mappings: `$site_config['paths']['baseurl']` → `$config->get('paths.baseurl')`
+- Database usage: none (handled via Delight Auth services)
+- TODOs introduced: 0
+- Notes: Preserved Delight Auth exception handling and success messaging; Audit logging retained.

--- a/tools/conversion_report/classes_Http_Handlers_Public_VerifyHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_VerifyHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/VerifyHandler.php
+
+- Legacy source: public/verify.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/bittorrent.php
+- Config mappings: `$site_config['paths']['baseurl']` → `$config->get('paths.baseurl')`
+- Database usage: none (legacy script instantiated DB but performed no queries)
+- TODOs carried forward: 1 (`TODO(2025): add CSRF verification`)
+- Notes: Maintained password reconfirmation flow with Delight Auth exceptions and retained legacy helper calls (`get_template`, `app_halt`).

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -49,3 +49,8 @@ classes/Http/Handlers/Admin/AllagentsHandler.php,false,1,TODO(2025) merge marker
 classes/Http/Handlers/Admin/BanclientHandler.php,false,1,TODO(2025) merge markers require manual extraction admin/banclient.php:1-80
 classes/Http/Handlers/Admin/BackupHandler.php,false,1,TODO(2025) merge markers require manual extraction admin/backup.php:1-320
 classes/Http/Handlers/Admin/ManageImagesHandler.php,false,1,TODO(2025) merge markers require manual extraction admin/manage_images.php:1-200
+classes/Http/Handlers/Public/LogoutHandler.php,true,0,Converted from public/logout.php
+classes/Http/Handlers/Public/ClearAnnouncementHandler.php,true,0,Converted from public/clear_announcement.php
+classes/Http/Handlers/Public/VerifyHandler.php,true,1,Converted from public/verify.php; TODO(2025) CSRF verification pending
+classes/Http/Handlers/Public/HappylogHandler.php,true,0,Converted from public/happylog.php
+classes/Http/Handlers/Public/VerifyEmailHandler.php,true,0,Converted from public/verify_email.php


### PR DESCRIPTION
## Summary
- inline the legacy public logout, clear announcement, verify, happylog, and verify email scripts directly into their handlers with container-aware dependencies and error handling
- add AUTO_CONVERT metadata, container bootstrapping, and config lookups for each handler conversion
- append conversion notes for the batch to the handler conversion report and record per-file conversion details under tools/conversion_report

## Testing
- php -l classes/Http/Handlers/Public/LogoutHandler.php classes/Http/Handlers/Public/ClearAnnouncementHandler.php classes/Http/Handlers/Public/VerifyHandler.php classes/Http/Handlers/Public/HappylogHandler.php classes/Http/Handlers/Public/VerifyEmailHandler.php


------
https://chatgpt.com/codex/tasks/task_e_68e340d54080832599aedaf75e22cc30