### PR TITLE
Convert ajax offer & request handlers to containerized logic

### DIFF
--- a/classes/Http/Handlers/Public/Ajax/OfferStatusHandler.php
+++ b/classes/Http/Handlers/Public/Ajax/OfferStatusHandler.php
@@ -1,34 +1,74 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
 
 namespace PU239\Http\Handlers\Public\Ajax;
+
+use Pu239\Database;
 
 final class OfferStatusHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../../public/ajax/offer_status.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
+        try {
+            require_once \dirname(__DIR__, 5) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 5) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 5) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+            if ($user === false || !has_access($user['class'], UC_STAFF, '')) {
+                json_out(['status' => 'invalid']);
+
+                return;
+            }
+
+            // TODO(2025): csrf on POST where missing
+            $offerId = (int) ($_POST['id'] ?? 0);
+            $currentStatus = (string) ($_POST['status'] ?? '');
+
+            if ($offerId <= 0 || $currentStatus === '') {
+                json_out(['status' => 'invalid']);
+
+                return;
+            }
+
+            $nextStatus = match ($currentStatus) {
+                'pending' => 'approved',
+                'approved' => 'denied',
+                default => 'pending',
+            };
+
+            $db->run(
+                'UPDATE offers SET status = :status WHERE id = :id',
+                [
+                    'status' => $nextStatus,
+                    'id' => $offerId,
+                ],
+            );
+
+            audit_log(
+                $user['id'] ?? null,
+                'torrent.moderate',
+                [
+                    'id' => $offerId,
+                    'op' => 'offer.status',
+                    'from' => $currentStatus,
+                    'to' => $nextStatus,
+                ],
+            );
+
+            json_out(['status' => $nextStatus]);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/Ajax/OfferVoteHandler.php
+++ b/classes/Http/Handlers/Public/Ajax/OfferVoteHandler.php
@@ -1,34 +1,84 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
 
 namespace PU239\Http\Handlers\Public\Ajax;
+
+use Pu239\Database;
 
 final class OfferVoteHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../../public/ajax/offer_vote.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
+        try {
+            require_once \dirname(__DIR__, 5) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 5) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 5) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+            if ($user === false) {
+                json_out(['voted' => 'invalid']);
+
+                return;
+            }
+
+            // TODO(2025): csrf on POST where missing
+            $offerId = (int) ($_POST['id'] ?? 0);
+            $currentVote = (string) ($_POST['voted'] ?? '');
+
+            if ($offerId <= 0 || $currentVote === '') {
+                json_out(['voted' => 'invalid']);
+
+                return;
+            }
+
+            $params = [
+                'offer_id' => $offerId,
+                'user_id' => (int) $user['id'],
+            ];
+
+            if ($currentVote === 'yes') {
+                $db->run(
+                    'UPDATE offer_votes SET vote = :vote WHERE offer_id = :offer_id AND user_id = :user_id',
+                    $params + ['vote' => 'no'],
+                );
+
+                json_out(['voted' => 'no']);
+
+                return;
+            }
+
+            if ($currentVote === 'no') {
+                $db->run(
+                    'DELETE FROM offer_votes WHERE offer_id = :offer_id AND user_id = :user_id',
+                    $params,
+                );
+
+                json_out(['voted' => 0]);
+
+                return;
+            }
+
+            $db->run(
+                'INSERT INTO offer_votes (vote, user_id, offer_id, added) VALUES (:vote, :user_id, :offer_id, :added)',
+                $params + [
+                    'vote' => 'yes',
+                    'added' => [TIME_NOW, \PDO::PARAM_INT],
+                ],
+            );
+
+            json_out(['voted' => 'yes']);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/Ajax/RatingHandler.php
+++ b/classes/Http/Handlers/Public/Ajax/RatingHandler.php
@@ -1,34 +1,180 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
 
 namespace PU239\Http\Handlers\Public\Ajax;
+
+use PU239\Config\ConfigRepository;
+use Pu239\Cache;
+use Pu239\Database;
 
 final class RatingHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../../public/ajax/rating.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
+        try {
+            require_once \dirname(__DIR__, 5) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 5) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 5) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            /** @var Cache $cache */
+            $cache = $container->get(Cache::class);
+
+            $s = static fn(mixed $value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+            $user = check_user_status();
+
+            // TODO(2025): csrf
+            if (empty($_POST)) {
+                return;
+            }
+
+            $id = (int) ($_POST['id'] ?? 0);
+            $rate = (int) ($_POST['rate'] ?? 0);
+            $uid = (int) ($user['id'] ?? 0);
+            $ajax = isset($_POST['ajax']) && (int) $_POST['ajax'] === 1;
+            $what = ($_POST['what'] ?? '') === 'torrent' ? 'torrent' : 'topic';
+            $ref = $_POST['ref'] ?? ($what === 'torrent' ? 'details.php' : 'forums/view_topic.php');
+            $table = $what === 'torrent' ? 'torrents' : 'topics';
+
+            if ($uid === 0 || $id <= 0) {
+                return;
+            }
+
+            $exists = $db->fetch(
+                "SELECT id FROM rating WHERE user = :uid AND {$what} = :id",
+                [
+                    ':uid' => $uid,
+                    ':id' => $id,
+                ],
+            );
+            if ($exists !== false) {
+                return;
+            }
+
+            try {
+                $db->beginTransaction();
+                $db->run(
+                    "INSERT INTO rating (user, {$what}, rating, added) VALUES (:uid, :id, :rate, NOW())",
+                    [
+                        ':uid' => $uid,
+                        ':id' => $id,
+                        ':rate' => $rate,
+                    ],
+                );
+                $db->run(
+                    "UPDATE {$table} SET num_ratings = num_ratings + 1, rating_sum = rating_sum + :rate WHERE id = :id",
+                    [
+                        ':rate' => $rate,
+                        ':id' => $id,
+                    ],
+                );
+                $db->commit();
+            } catch (\Throwable $e) {
+                $db->rollBack();
+
+                return;
+            }
+
+            $cache->delete('rating_' . $what . '_' . $id . '_' . $uid);
+            if ($what === 'torrent') {
+                $torrentRating = $db->fetch(
+                    'SELECT num_ratings, rating_sum FROM torrents WHERE id = :id',
+                    [':id' => $id],
+                );
+                if ($torrentRating !== false) {
+                    $cache->update_row(
+                        'torrent_details_' . $id,
+                        [
+                            'num_ratings' => (int) ($torrentRating['num_ratings'] ?? 0),
+                            'rating_sum' => (int) ($torrentRating['rating_sum'] ?? 0),
+                        ],
+                        (int) $config->get('expires.torrent_details'),
+                    );
+                }
+            }
+
+            if ((bool) $config->get('bonus.on')) {
+                $amount = $what === 'torrent' ? (float) $config->get('bonus.per_rating') : (float) $config->get('bonus.per_topic');
+                $db->run(
+                    'UPDATE users SET seedbonus = seedbonus + :amount WHERE id = :id',
+                    [
+                        ':amount' => $amount,
+                        ':id' => $uid,
+                    ],
+                );
+                $cache->update_row(
+                    'user_' . $uid,
+                    [
+                        'seedbonus' => ($user['seedbonus'] ?? 0.0) + $amount,
+                    ],
+                    (int) $config->get('expires.user_cache'),
+                );
+            }
+
+            $keys = 'rating_' . $what . '_' . $id . '_' . $uid;
+            $summary = $db->fetch(
+                "SELECT SUM(rating) AS sum, COUNT(id) AS count FROM rating WHERE {$what} = :id",
+                [':id' => $id],
+            ) ?: [];
+            $userRating = $db->fetch(
+                "SELECT id AS rated, rating FROM rating WHERE {$what} = :id AND user = :uid",
+                [
+                    ':id' => $id,
+                    ':uid' => $uid,
+                ],
+            ) ?: [];
+
+            $ratingCache = array_merge($summary, $userRating);
+            $ratings = $cache->get('ratings_' . $id);
+            if (!empty($ratings)) {
+                foreach ($ratings as $rater) {
+                    $cache->delete('rating_' . $what . '_' . $id . '_' . $rater);
+                }
+                $cache->delete('ratings_' . $id);
+            }
+            $cache->set($keys, $ratingCache, 86400);
+
+            if (!empty($ratingCache['count']) && (int) $ratingCache['count'] > 0) {
+                $rated = number_format(((float) ($ratingCache['sum'] ?? 0)) / (int) $ratingCache['count'] / 5 * 100, 0) . '%';
+                $ratingText = _pfe(
+                    'Rating: {0}. You rate this {1} {2, number} star',
+                    'Rating: {0}. You rate this {1} {2, number} stars',
+                    $rated,
+                    $what,
+                    $ratingCache['rating'] ?? 0,
+                );
+                $title = $s($ratingText);
+                $width = $s($rated);
+
+                echo "
+            <div class='star-ratings-css-top tooltipper' title='{$title}' style='width: {$width};'>
+                <span>&#9733;</span>
+                <span>&#9733;</span>
+                <span>&#9733;</span>
+                <span>&#9733;</span>
+                <span>&#9733;</span>
+            </div>
+            <div class='star-ratings-css-bottom'>
+                <span>&#9734;</span>
+                <span>&#9734;</span>
+                <span>&#9734;</span>
+                <span>&#9734;</span>
+                <span>&#9734;</span>
+            </div>";
+            }
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.php
+++ b/classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.php
@@ -1,34 +1,70 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
 
 namespace PU239\Http\Handlers\Public\Ajax;
+
+use Pu239\Database;
 
 final class RequestNotifyHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../../public/ajax/request_notify.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
+        try {
+            require_once \dirname(__DIR__, 5) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 5) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 5) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+            if ($user === false) {
+                json_out(['notify' => 'invalid']);
+
+                return;
+            }
+
+            // TODO(2025): csrf
+            $requestId = (int) ($_POST['id'] ?? 0);
+            $notified = filter_var($_POST['notified'] ?? null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            if ($requestId <= 0 || $notified === null) {
+                json_out(['notify' => 'invalid']);
+
+                return;
+            }
+
+            $params = [
+                'userid' => (int) $user['id'],
+                'requestid' => $requestId,
+            ];
+
+            if ($notified) {
+                $db->run(
+                    'DELETE FROM request_notify WHERE userid = :userid AND requestid = :requestid',
+                    $params,
+                );
+
+                json_out(['notify' => 0]);
+
+                return;
+            }
+
+            $insertId = (int) $db->insert(
+                'INSERT INTO request_notify (userid, requestid, added) VALUES (:userid, :requestid, :added)',
+                $params + ['added' => [TIME_NOW, \PDO::PARAM_INT]],
+            );
+
+            json_out(['notify' => $insertId]);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/Ajax/RequestVoteHandler.php
+++ b/classes/Http/Handlers/Public/Ajax/RequestVoteHandler.php
@@ -1,34 +1,81 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
 
 namespace PU239\Http\Handlers\Public\Ajax;
+
+use Pu239\Database;
 
 final class RequestVoteHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../../public/ajax/request_vote.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-06 via handler-convert batch=60-5
+        try {
+            require_once \dirname(__DIR__, 5) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 5) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 5) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+            if ($user === false) {
+                json_out(['voted' => 'invalid']);
+
+                return;
+            }
+
+            // TODO(2025): csrf
+            $requestId = (int) ($_POST['id'] ?? 0);
+            $voted = $_POST['voted'] ?? null;
+
+            if ($requestId <= 0 || $voted === null) {
+                json_out(['voted' => 'invalid']);
+
+                return;
+            }
+
+            $params = [
+                'user_id' => (int) $user['id'],
+                'request_id' => $requestId,
+            ];
+
+            if ($voted === 'yes') {
+                $db->run(
+                    'UPDATE request_votes SET vote = :vote WHERE user_id = :user_id AND request_id = :request_id',
+                    $params + ['vote' => 'no'],
+                );
+
+                json_out(['voted' => 'no']);
+
+                return;
+            }
+
+            if ($voted === 'no') {
+                $db->run(
+                    'DELETE FROM request_votes WHERE user_id = :user_id AND request_id = :request_id',
+                    $params,
+                );
+
+                json_out(['voted' => 0]);
+
+                return;
+            }
+
+            $db->run(
+                'INSERT INTO request_votes (user_id, request_id, vote) VALUES (:user_id, :request_id, :vote)',
+                $params + ['vote' => 'yes'],
+            );
+
+            json_out(['voted' => 'yes']);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/OfferStatusHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/OfferStatusHandler.conversion_report.md
@@ -1,0 +1,12 @@
+# Conversion Report: classes/Http/Handlers/Public/Ajax/OfferStatusHandler.php
+
+- **Date**: 2025-10-06
+- **Batch**: offset=60 size=5
+- **Source legacy script**: public/ajax/offer_status.php
+- **Summary**:
+  - Replaced legacy stub wrapper with inline logic executing offer status transitions.
+  - Retrieved `Database` service from the container and re-used `audit_log` helper.
+  - Preserved staff authorization check and JSON responses.
+- **Todos**:
+  - TODO(2025): csrf on POST where missing.
+- **Error handling**: Wrapped execution in try/catch with HTTP 500 fallback as per handler guidelines.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/OfferVoteHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/OfferVoteHandler.conversion_report.md
@@ -1,0 +1,12 @@
+# Conversion Report: classes/Http/Handlers/Public/Ajax/OfferVoteHandler.php
+
+- **Date**: 2025-10-06
+- **Batch**: offset=60 size=5
+- **Source legacy script**: public/ajax/offer_vote.php
+- **Summary**:
+  - Embedded vote toggle logic for offers with container-provided `Database` instance.
+  - Preserved legacy branching for yes/no/current vote states and JSON payloads.
+  - Maintained audit helper availability (no direct usage) to mirror legacy bootstrap stack.
+- **Todos**:
+  - TODO(2025): csrf on POST where missing.
+- **Error handling**: Added try/catch guard logging unexpected errors and emitting HTTP 500 fallback.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/RatingHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/RatingHandler.conversion_report.md
@@ -1,0 +1,12 @@
+# Conversion Report: classes/Http/Handlers/Public/Ajax/RatingHandler.php
+
+- **Date**: 2025-10-06
+- **Batch**: offset=60 size=5
+- **Source legacy script**: public/ajax/rating.php
+- **Summary**:
+  - Migrated full rating flow including transaction, cache updates, and bonus adjustments into handler.
+  - Retrieved `ConfigRepository`, `Database`, and `Cache` services from the container and preserved helper bootstrap.
+  - Normalized HTML sanitization closure and JSON response parity with legacy script.
+- **Todos**:
+  - TODO(2025): csrf.
+- **Error handling**: Protected execution with try/catch; rating transaction keeps rollback semantics on failure.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.conversion_report.md
@@ -1,0 +1,12 @@
+# Conversion Report: classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.php
+
+- **Date**: 2025-10-06
+- **Batch**: offset=60 size=5
+- **Source legacy script**: public/ajax/request_notify.php
+- **Summary**:
+  - Ported notification toggle logic for requests, sourcing `Database` from the container.
+  - Preserved boolean validation semantics and JSON payload structure.
+  - Ensured helper bootstrap remains to provide global functions and constants.
+- **Todos**:
+  - TODO(2025): csrf.
+- **Error handling**: Surrounds execution with try/catch to surface 500 response on unexpected failures.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/RequestVoteHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/Ajax/RequestVoteHandler.conversion_report.md
@@ -1,0 +1,12 @@
+# Conversion Report: classes/Http/Handlers/Public/Ajax/RequestVoteHandler.php
+
+- **Date**: 2025-10-06
+- **Batch**: offset=60 size=5
+- **Source legacy script**: public/ajax/request_vote.php
+- **Summary**:
+  - Inlined vote management logic for requests with container-backed `Database` instance.
+  - Preserved legacy branching for vote toggling and JSON responses.
+  - Maintained helper bootstrap stack compatibility.
+- **Todos**:
+  - TODO(2025): csrf.
+- **Error handling**: Added try/catch wrapper to emit HTTP 500 and log on unexpected issues.

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -59,3 +59,8 @@ classes/Http/Handlers/Public/Ajax/CookerNotifyHandler.php,true,1,Converted from 
 classes/Http/Handlers/Public/Ajax/DescrFormatHandler.php,true,1,Converted from public/ajax/descr_format.php; Torrent formatting inline
 classes/Http/Handlers/Public/Ajax/EbookLookupHandler.php,true,1,Converted from public/ajax/ebook_lookup.php; validator rules preserved
 classes/Http/Handlers/Public/Ajax/EmailcheckHandler.php,true,0,Converted from public/ajax/emailcheck.php; echoes availability messages
+classes/Http/Handlers/Public/Ajax/OfferStatusHandler.php,true,1,Converted from public/ajax/offer_status.php
+classes/Http/Handlers/Public/Ajax/OfferVoteHandler.php,true,1,Converted from public/ajax/offer_vote.php
+classes/Http/Handlers/Public/Ajax/RatingHandler.php,true,1,Converted from public/ajax/rating.php
+classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.php,true,1,Converted from public/ajax/request_notify.php
+classes/Http/Handlers/Public/Ajax/RequestVoteHandler.php,true,1,Converted from public/ajax/request_vote.php


### PR DESCRIPTION
## Summary
- inline the legacy offer status and vote ajax flows directly inside their handlers using container services
- migrate the ajax rating handler to execute the full database, cache, and bonus update workflow without requiring the legacy script
- convert the request notification and vote handlers and record conversion notes for all touched files

## Testing
- php -l classes/Http/Handlers/Public/Ajax/OfferStatusHandler.php
- php -l classes/Http/Handlers/Public/Ajax/OfferVoteHandler.php
- php -l classes/Http/Handlers/Public/Ajax/RatingHandler.php
- php -l classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.php
- php -l classes/Http/Handlers/Public/Ajax/RequestVoteHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e3e8e0d1908325b1af040768ddf123