### PR TITLE
feat(handler-convert): convert legacy stubs to handlers (batch=75-5)

### DIFF
--- a/classes/Http/Handlers/Public/ArcadeTopScoresHandler.php
+++ b/classes/Http/Handlers/Public/ArcadeTopScoresHandler.php
@@ -1,34 +1,180 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 
 final class ArcadeTopScoresHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/arcade_top_scores.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $siteName = (string) $config->get('site.name');
+            $topScorePoints = (int) $config->get('arcade.top_score_points');
+            $baseUrl = (string) $config->get('paths.baseurl');
+            $imagesBase = (string) $config->get('paths.images_baseurl');
+            $gameNames = (array) $config->get('arcade.game_names');
+            $games = (array) $config->get('arcade.games');
+
+            $user = check_user_status();
+
+            $scores = $db->fetchAll(
+                'SELECT game, user_id, level, score FROM flashscores ORDER BY game, level DESC, score DESC',
+            );
+            $highscores = $db->fetchAll(
+                'SELECT game, user_id, level, score FROM highscores ORDER BY game',
+            );
+
+            $htmlOut = "
+                <h1 class='has-text-centered'>" . _fe('{0} Arcade Top Scores!', $siteName) . "</h1>
+                <div class='bottom10 has-text-centered'>
+                    <div>" . _fe('Top Scores Earn {0} Karma Points', $topScorePoints) . "</div>
+                    <div class='level-center top10'>
+                        <a class='is-link' href='{$baseUrl}/arcade.php'>" . _('Back to the Arcade') . '</a>
+                    </div>
+                </div>';
+
+            $list = $gameNames;
+            sort($list);
+
+            $heading = '
+                            <tr>
+                                <th>' . _('Rank') . '</th>
+                                <th>' . _('Name') . '</th>
+                                <th>' . _('Level') . '</th>
+                                <th>' . _('Score') . '</th>
+                            </tr>';
+
+            foreach ($list as $gameName) {
+                $gameId = array_search($gameName, $gameNames, true);
+                if ($gameId === false) {
+                    continue;
+                }
+
+                $game = (string) ($games[$gameId] ?? '');
+                if ($game === '') {
+                    continue;
+                }
+
+                $gameScores = $this->filterScores($game, $scores);
+                if ($gameScores === []) {
+                    continue;
+                }
+
+                $body = '';
+                $highscore = $this->findHighscore($game, $highscores);
+                if ($highscore !== null) {
+                    $body .= '
+                                <tr>
+                                    <td>0</td>
+                                    <td>' . format_username($highscore['user_id']) . '</td>
+                                    <td>' . $highscore['level'] . '</td>
+                                    <td>' . number_format((float) $highscore['score']) . '</td>
+                                </tr>
+                                <tr>
+                                    <td colspan="4"></td>
+                                </tr>';
+                }
+
+                $i = 0;
+                $userHigh = 0.0;
+                $userRank = 0;
+
+                foreach ($gameScores as $scoreRow) {
+                    $body .= '
+                                <tr>
+                                    <td>' . ++$i . '</td>
+                                    <td>' . format_username($scoreRow['user_id']) . '</td>
+                                    <td>' . $scoreRow['level'] . '</td>
+                                    <td>' . number_format((float) $scoreRow['score']) . '</td>
+                                </tr>';
+
+                    if ($scoreRow['user_id'] === ($user['id'] ?? null) && $userHigh === 0.0) {
+                        $userHigh = (float) $scoreRow['score'];
+                        $userRank = $i;
+                    }
+
+                    if ($i >= 10) {
+                        break;
+                    }
+                }
+
+                if ($userHigh !== 0.0) {
+                    $body .= '
+                                <tr>
+                                    <td colspan="4">
+                                        <div class="top10 bottom10 has-text-centered">' . _fe('Your high score was {0} and you ranked #{1}.', number_format($userHigh), number_format((float) $userRank)) . '</div>
+                                    </td>
+                                </tr>';
+                }
+
+                $table = main_table($body, $heading, 'top20');
+                $htmlOut .= "
+                <div class='bg-00 round10 has-text-centered top20'>
+                    <a id='{$game}'></a>
+                    <a href='{$baseUrl}/flash.php?gameURI={$game}.swf&amp;gamename={$game}&amp;game_id={$gameId}'>
+                        <img src='{$imagesBase}games/{$game}.png' alt='{$gameName}' class='round10 top20 w-50 min-250'>
+                    </a>{$table}
+                </div>";
+            }
+
+            $title = _('Top Scores');
+            $breadcrumbs = [
+                "<a href='{$baseUrl}/games.php'>" . _('Games') . '</a>',
+                "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($htmlOut) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $scores
+     * @return array<int,array<string,mixed>>
+     */
+    private function filterScores(string $game, array $scores): array
+    {
+        $gameScores = [];
+        foreach ($scores as $score) {
+            if (($score['game'] ?? null) === $game) {
+                $gameScores[] = $score;
+            }
+        }
+
+        return $gameScores;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $highscores
+     * @return array<string,mixed>|null
+     */
+    private function findHighscore(string $game, array $highscores): ?array
+    {
+        foreach ($highscores as $score) {
+            if (($score['game'] ?? null) === $game) {
+                return $score;
+            }
+        }
+
+        return null;
     }
 }

--- a/classes/Http/Handlers/Public/ArcadeTopScoresHandler.php.bak
+++ b/classes/Http/Handlers/Public/ArcadeTopScoresHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class ArcadeTopScoresHandler
@@ -8,9 +10,25 @@ final class ArcadeTopScoresHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/arcade_top_scores.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/arcade_top_scores.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/BitbucketHandler.php
+++ b/classes/Http/Handlers/Public/BitbucketHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,16 @@ final class BitbucketHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // TODO(2025): extract legacy block from public/bitbucket.php:1-400 (complex file operations, bookmarking state, and CSRF review)
         $target = __DIR__ . '/../../../../public/bitbucket.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +27,10 @@ final class BitbucketHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/BitbucketHandler.php.bak
+++ b/classes/Http/Handlers/Public/BitbucketHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class BitbucketHandler
@@ -8,9 +10,25 @@ final class BitbucketHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/bitbucket.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/bitbucket.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/BjstatsHandler.php
+++ b/classes/Http/Handlers/Public/BjstatsHandler.php
@@ -1,34 +1,173 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 
 final class BjstatsHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/bjstats.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            if (!defined('PU239_ROUTED')) {
+                require_once \dirname(__DIR__, 4) . '/public/index.php';
+
+                return;
+            }
+
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $allowedPlay = (int) $config->get('allowed.play');
+            $classNames = (array) $config->get('class_names');
+
+            $user = check_user_status();
+
+            if (!has_access($user['class'], $allowedPlay, '')) {
+                $requiredClassName = $classNames[$allowedPlay] ?? '';
+                stderr(_('Error'), _fe('Sorry, you must be a {0} to play blackjack!', $requiredClassName), 'bottom20');
+            } elseif (($user['game_access'] ?? 0) !== 1 || ($user['status'] ?? 0) !== 0) {
+                stderr(_('Error'), _('Your gaming rights have been disabled.'), 'bottom20');
+            }
+
+            $minGames = 10;
+
+            $mostGames = $db->fetchAll(
+                'SELECT id,
+                        username,
+                        bjwins AS wins,
+                        bjlosses AS losses,
+                        (bjwins + bjlosses) AS games
+                 FROM users
+                 WHERE (bjwins + bjlosses) > :minGames
+                 ORDER BY games DESC, wins DESC
+                 LIMIT 10',
+                ['minGames' => $minGames],
+            );
+            $htmlOut = $this->renderTable($mostGames, _('Most Games Played'));
+
+            $highestWinPercent = $db->fetchAll(
+                'SELECT id,
+                        username,
+                        bjwins AS wins,
+                        bjlosses AS losses,
+                        (bjwins + bjlosses) AS games,
+                        (bjwins / NULLIF(bjwins + bjlosses, 0)) AS winperc
+                 FROM users
+                 WHERE (bjwins + bjlosses) > :minGames
+                 ORDER BY winperc DESC, wins DESC
+                 LIMIT 10',
+                ['minGames' => $minGames],
+            );
+            $htmlOut .= $this->renderTable($highestWinPercent, _('Highest Win Percentage'));
+
+            $mostCreditWon = $db->fetchAll(
+                'SELECT id,
+                        username,
+                        bjwins AS wins,
+                        bjlosses AS losses,
+                        (bjwins - bjlosses) AS winnings
+                 FROM users
+                 WHERE (bjwins + bjlosses) > :minGames
+                 ORDER BY winnings DESC, wins DESC
+                 LIMIT 10',
+                ['minGames' => $minGames],
+            );
+            $htmlOut .= $this->renderTable($mostCreditWon, _('Most Credit Won'));
+
+            $mostCreditLost = $db->fetchAll(
+                'SELECT id,
+                        username,
+                        bjwins AS wins,
+                        bjlosses AS losses,
+                        (bjlosses - bjwins) AS losings,
+                        (bjwins / NULLIF(bjwins + bjlosses, 0)) AS winperc
+                 FROM users
+                 WHERE (bjwins + bjlosses) > :minGames
+                 ORDER BY losings DESC, losses DESC
+                 LIMIT 10',
+                ['minGames' => $minGames],
+            );
+            $htmlOut .= $this->renderTable($mostCreditLost, _('Most Credit Lost'));
+
+            $title = _('Blackjack Stats');
+            $breadcrumbs = [
+                "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($htmlOut) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $rows
+     */
+    private function renderTable(array $rows, string $caption): string
+    {
+        $html = "<h1 class='has-text-centered'>$caption</h1>";
+        $heading = '
+                <tr>
+                    <th>' . _('Rank') . '</th>
+                    <th>' . _('User') . "</th>
+                    <th class='colhead has-text-right'>" . _('Wins') . "</th>
+                    <th class='colhead has-text-right'>" . _('Losses') . "</th>
+                    <th class='colhead has-text-right'>" . _('Games') . "</th>
+                    <th class='colhead has-text-right'>" . _('Percentage') . "</th>
+                    <th class='colhead has-text-right'>" . _('Win/Loss') . '</th>
+                </tr>';
+
+        $rank = 0;
+        $body = '';
+        foreach ($rows as $row) {
+            $wins = (int) ($row['wins'] ?? 0);
+            $losses = (int) ($row['losses'] ?? 0);
+            $games = (int) ($row['games'] ?? ($wins + $losses));
+            $winPercentage = $games > 0 ? number_format(($wins / $games) * 100, 1) : '0.0';
+            $diff = $wins - $losses;
+            if ($diff >= 0) {
+                $winLoss = mksize($diff * 100 * 1024 * 1024);
+            } else {
+                $winLoss = '-' . mksize(abs($diff) * 100 * 1024 * 1024);
+            }
+
+            ++$rank;
+            $body .= sprintf(
+                "\n                <tr>\n                    <td>%d</td>\n                    <td>%s</td>\n                    <td class='has-text-right'>%s</td>\n                    <td class='has-text-right'>%s</td>\n                    <td class='has-text-right'>%s</td>\n                    <td class='has-text-right'>%s</td>\n                    <td class='has-text-right'>%s</td>\n                </tr>",
+                $rank,
+                format_username((int) ($row['id'] ?? 0)),
+                number_format($wins, 0),
+                number_format($losses, 0),
+                number_format($games, 0),
+                $winPercentage,
+                $winLoss,
+            );
+        }
+
+        if ($body === '') {
+            $body .= "
+                <tr>
+                    <td colspan='7' class='has-text-centered'>" . _('No Game Stats') . '</td>
+                </tr>';
+        }
+
+        $html .= main_table($body, $heading);
+
+        return $html;
     }
 }

--- a/classes/Http/Handlers/Public/BjstatsHandler.php.bak
+++ b/classes/Http/Handlers/Public/BjstatsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class BjstatsHandler
@@ -8,9 +10,25 @@ final class BjstatsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/bjstats.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/bjstats.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/BlackjackHandler.php
+++ b/classes/Http/Handlers/Public/BlackjackHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,16 @@ final class BlackjackHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // TODO(2025): extract legacy block from public/blackjack.php:1-420 (stateful gameplay, SQL migrations, CSRF hardening)
         $target = __DIR__ . '/../../../../public/blackjack.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +27,10 @@ final class BlackjackHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/BlackjackHandler.php.bak
+++ b/classes/Http/Handlers/Public/BlackjackHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class BlackjackHandler
@@ -8,9 +10,25 @@ final class BlackjackHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/blackjack.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/blackjack.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/BookmarksHandler.php
+++ b/classes/Http/Handlers/Public/BookmarksHandler.php
@@ -1,34 +1,336 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 
 final class BookmarksHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/bookmarks.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=70-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/helpers/audit.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            if (!defined('PU239_ROUTED')) {
+                require_once \dirname(__DIR__, 4) . '/public/index.php';
+
+                return;
+            }
+
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+
+            $stdfoot = [
+                'js' => [
+                    get_file_name('bookmarks_js'),
+                ],
+            ];
+
+            $htmlOut = '';
+
+            $userId = isset($_GET['id']) ? (int) $_GET['id'] : (int) $user['id'];
+            if (!is_valid_id($userId)) {
+                stderr(_('Error'), _('Invalid ID'));
+            }
+
+            if ($userId !== (int) $user['id']) {
+                stderr(
+                    _('Error'),
+                    _('Access denied. Try ') . "<a href='{$config->get('paths.baseurl')}/sharemarks.php?id={$userId}'>" . _('Here') . '</a>'
+                );
+            }
+
+            $htmlOut .= '
+    <div class="has-text-centered bottom20">
+        <h1>' . _('My Bookmarks') . '</h1>
+        <div class="tabs is-centered">
+            <ul>
+                <li><a href="' . $config->get('paths.baseurl') . '/sharemarks.php?id=' . $userId . '" class="is-link">' . _('My Sharemarks') . '</a></li>
+            </ul>
+        </div>
+    </div>';
+
+            $count = (int) ($db->fetchValue(
+                'SELECT COUNT(id) FROM bookmarks WHERE userid = :userid',
+                ['userid' => $userId],
+            ) ?? 0);
+
+            $torrentsPerPage = (int) ($user['torrentsperpage'] ?? 25);
+            if ($torrentsPerPage <= 0) {
+                $torrentsPerPage = 25;
+            }
+
+            if ($count > 0) {
+                $pager = pager($torrentsPerPage, $count, 'bookmarks.php?&amp;');
+
+                $bookmarks = $db->fetchAll(
+                    'SELECT b.id AS bookmarkid,
+                            b.private,
+                            t.owner,
+                            t.id,
+                            t.name,
+                            t.comments,
+                            t.leechers,
+                            t.seeders,
+                            t.save_as,
+                            t.numfiles,
+                            t.added,
+                            t.filename,
+                            t.size,
+                            t.views,
+                            t.visible,
+                            t.hits,
+                            t.times_completed,
+                            t.category
+                     FROM bookmarks AS b
+                     INNER JOIN torrents AS t ON b.torrentid = t.id
+                     WHERE b.userid = :userid
+                     ORDER BY t.id DESC
+                     LIMIT :limit OFFSET :offset',
+                    [
+                        'userid' => $userId,
+                        'limit' => [$pager['pdo']['limit'], \PDO::PARAM_INT],
+                        'offset' => [$pager['pdo']['offset'], \PDO::PARAM_INT],
+                    ],
+                );
+
+                if ($count > $torrentsPerPage) {
+                    $htmlOut .= $pager['pagertop'];
+                }
+
+                $htmlOut .= $this->renderBookmarks($bookmarks, $userId, 'index', $config);
+
+                if ($count > $torrentsPerPage) {
+                    $htmlOut .= $pager['pagerbottom'];
+                }
+            }
+
+            $title = _('Bookmarks');
+            $breadcrumbs = [
+                "<a href='{$_SERVER['PHP_SELF']}'>$title</a>",
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($htmlOut) . stdfoot($stdfoot);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $rows
+     */
+    private function renderBookmarks(array $rows, int $userId, string $variant, ConfigRepository $config): string
+    {
+        $html = "
+    <div class='has-text-centered bottom20'>
+        " . _('Icon Legend :') . "
+        <i class='icon-bookmark-empty icon has-text-danger'></i> = " . _('Delete Bookmark') . " |
+        <i class='icon-download icon'></i> = " . _('Download Torrent') . " |
+        <i class='icon-key icon has-text-success'></i> = " . _('Bookmark is Private') . " |
+        <i class='icon-users icon has-text-danger'></i> = " . _('Bookmark is Public') . '
+    </div>';
+
+        $heading = '
+                        <tr>
+                            <th>' . _('Type') . "</th>
+                            <th class='has-text-left'>" . _('Name') . '</th>';
+        $heading .= ($variant === 'index' ? '
+                            <th>' . _('Delete') . '</th>
+                            <th>' : '') . _('Download') . '</th>
+                            <th>' . _('Share') . '</th>';
+        if ($variant === 'mytorrents') {
+            $heading .= '
+                            <th>' . _('Edit') . '</th>
+                            <th>' . _('Yes') . '</th>';
+        }
+        $heading .= '
+                            <th>' . _('Files') . '</th>
+                            <th>' . _('Comments') . '</th>
+                            <th>' . _('Added') . '</th>
+                            <th>' . _('Torrent Size') . '</th>
+                            <th>' . _('Times Completed') . '</th>
+                            <th>' . _('Seeders') . '</th>
+                            <th>' . _('Leechers') . '</th>';
+        if ($variant === 'index') {
+            $heading .= '
+                            <th>' . _('Upped by') . '</th>';
+        }
+        $heading .= '
+                        </tr>';
+
+        $body = '';
+        $categories = genrelist(false);
+        $categoryIndex = [];
+        foreach ($categories as $category) {
+            $categoryIndex[$category['id']] = [
+                'name' => $category['name'],
+                'image' => $category['image'],
+            ];
+        }
+
+        foreach ($rows as $row) {
+            $categoryId = (int) ($row['category'] ?? 0);
+            $categoryName = $categoryIndex[$categoryId]['name'] ?? '';
+            $categoryImage = $categoryIndex[$categoryId]['image'] ?? '';
+            $torrentId = (int) ($row['id'] ?? 0);
+
+            $body .= "
+                        <tr>
+                            <td class='has-text-centered'>";
+            if ($categoryName !== '') {
+                $body .= '<a href="' . $config->get('paths.baseurl') . '/browse.php?cat=' . $categoryId . '">';
+                if ($categoryImage !== '') {
+                    $body .= "<img src='{$config->get('paths.images_baseurl')}caticons/" . get_category_icons() . '/' . htmlsafechars((string) $categoryImage) . "' alt='" . htmlsafechars((string) $categoryName) . "' class='tooltipper' title='" . htmlsafechars((string) $categoryName) . "'>";
+                } else {
+                    $body .= htmlsafechars((string) $categoryName);
+                }
+                $body .= '</a>';
+            } else {
+                $body .= '-';
+            }
+            $body .= '
+                            </td>';
+
+            $displayName = htmlsafechars((string) ($row['name'] ?? ''));
+            $body .= "
+                            <td class='has-text-left'>
+                                <a href='{$config->get('paths.baseurl')}/details.php?";
+            if ($variant === 'mytorrents') {
+                $body .= 'returnto=' . urlencode($_SERVER['REQUEST_URI'] ?? '') . '&amp;';
+            }
+            $body .= "id=$torrentId";
+            if ($variant === 'index') {
+                $body .= '&amp;hit=1';
+            }
+            $body .= "'><b>$displayName</b></a>&#160;
+                            </td>";
+
+            if ($variant === 'index') {
+                $body .= "
+                            <td class='has-text-centered'>
+                                <span data-tid='{$torrentId}' data-remove='true' data-private='false' class='bookmarks tooltipper' title='" . _('Delete Bookmark!') . "'>
+                                    <i class='icon-bookmark-empty icon has-text-danger'></i>
+                                </span>
+                            </td>";
+                $body .= "
+                            <td class='has-text-centered'>
+                                <a href='{$config->get('paths.baseurl')}/download.php?torrent={$torrentId}' class='tooltipper' title='" . _('Download Bookmark!') . "'>
+                                    <i class='icon-download icon'></i>
+                                </a>
+                            </td>";
+
+                $isPrivate = ($row['private'] ?? 'no') === 'yes';
+                if ($isPrivate) {
+                    $body .= "
+                            <td class='has-text-centered'>
+                                <span data-tid='{$torrentId}' data-remove='false' data-private='true' class='bookmarks tooltipper' title='" . _('Mark Bookmark Public!') . "'>
+                                    <i class='icon-key icon has-text-success'></i>
+                                </span>
+                            </td>";
+                } else {
+                    $body .= "
+                            <td class='has-text-centered'>
+                                <span data-tid='{$torrentId}' data-remove='false' data-private='true' class='bookmarks tooltipper' title='" . _('Mark Bookmark Private!') . "'>
+                                    <i class='icon-users icon has-text-danger'></i>
+                                </span>
+                            </td>";
+                }
+            }
+
+            if ($variant === 'mytorrents') {
+                $body .= "
+                            <td class='has-text-centered'>
+                                <a href='{$config->get('paths.baseurl')}/edit.php?returnto=" . urlencode($_SERVER['REQUEST_URI'] ?? '') . "&amp;id={$torrentId}'>" . _('Edit') . '</a>';
+                $body .= "
+                            </td>
+                            <td class='has-text-right'>";
+                $body .= ($row['visible'] ?? 'yes') === 'no' ? _('No') : _('Yes');
+                $body .= '
+                            </td>';
+            }
+
+            $body .= "
+                            <td class='has-text-right'><b><a href='{$config->get('paths.baseurl')}/filelist.php?id={$torrentId}'>" . (int) ($row['numfiles'] ?? 0) . '</a></b></td>';
+
+            $commentCount = (int) ($row['comments'] ?? 0);
+            if ($commentCount === 0) {
+                $body .= "
+                            <td class='has-text-right'>0</td>";
+            } else {
+                if ($variant === 'index') {
+                    $body .= "
+                            <td class='has-text-right'><b><a href='{$config->get('paths.baseurl')}/details.php?id={$torrentId}&amp;hit=1&amp;tocomm=1'>" . $commentCount . '</a></b></td>';
+                } else {
+                    $body .= "
+                            <td class='has-text-right'><b><a href='{$config->get('paths.baseurl')}/details.php?id={$torrentId}&amp;page=0#startcomments'>" . $commentCount . '</a></b></td>';
+                }
+            }
+
+            $added = (int) ($row['added'] ?? 0);
+            $body .= "
+                            <td class='has-text-centered'><span>" . str_replace(',', '<br>', get_date($added, '')) . "</span></td>
+                            <td class='has-text-centered'>" . str_replace(' ', '<br>', mksize((int) ($row['size'] ?? 0))) . '</td>';
+
+            $completed = (int) ($row['times_completed'] ?? 0);
+            $body .= "
+                            <td class='has-text-centered'><a href='{$config->get('paths.baseurl')}/snatches.php?id={$torrentId}'>" . _pfe('{0} time', '{0} times', $completed) . '</a></td>';
+
+            $seeders = (int) ($row['seeders'] ?? 0);
+            $leechers = (int) ($row['leechers'] ?? 0);
+            if ($seeders > 0) {
+                if ($variant === 'index') {
+                    $ratio = $leechers > 0 ? $seeders / max($leechers, 1) : 1;
+                    $body .= "
+                            <td class='has-text-right'><b><a href='{$config->get('paths.baseurl')}/peerlist.php?id={$torrentId}#seeders'><span style='color: " . get_slr_color($ratio) . ";'>" . $seeders . '</span></a></b></td>';
+                } else {
+                    $body .= "
+                            <td class='has-text-right'><b><a class='" . linkcolor($seeders) . "' href='{$config->get('paths.baseurl')}/peerlist.php?id={$torrentId}#seeders'>" . $seeders . '</a></b></td>';
+                }
+            } else {
+                $body .= "
+                            <td class='has-text-right'><span class='" . linkcolor($seeders) . "'>" . $seeders . '</span></td>';
+            }
+
+            if ($leechers > 0) {
+                if ($variant === 'index') {
+                    $body .= "
+                            <td class='has-text-right'><b><a href='{$config->get('paths.baseurl')}/peerlist.php?id={$torrentId}#leechers'>" . number_format($leechers) . '</a></b></td>';
+                } else {
+                    $body .= "
+                            <td class='has-text-right'><b><a class='" . linkcolor($leechers) . "' href='{$config->get('paths.baseurl')}/peerlist.php?id={$torrentId}#leechers'>" . $leechers . '</a></b></td>';
+                }
+            } else {
+                $body .= "
+                            <td class='has-text-right'>0</td>";
+            }
+
+            if ($variant === 'index') {
+                $ownerId = (int) ($row['owner'] ?? 0);
+                $body .= "
+                            <td class='has-text-centered'>" . ($ownerId > 0 ? format_username($ownerId) : '<i>(' . _('Unknown') . ')</i>') . '</td>';
+            }
+
+            $body .= '
+                        </tr>';
+        }
+
+        $html .= main_table($body, $heading);
+
+        return $html;
     }
 }

--- a/classes/Http/Handlers/Public/BookmarksHandler.php.bak
+++ b/classes/Http/Handlers/Public/BookmarksHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class BookmarksHandler
@@ -8,9 +10,25 @@ final class BookmarksHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/bookmarks.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/bookmarks.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/LotteryHandler.php
+++ b/classes/Http/Handlers/Public/LotteryHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class LotteryHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
+        // TODO(2025): extract legacy block from public/lottery.php:1-140 (nested lottery includes and legacy sql_query usage)
         $target = __DIR__ . '/../../../../public/lottery.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class LotteryHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/LotteryHandler.php.bak
+++ b/classes/Http/Handlers/Public/LotteryHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class LotteryHandler
@@ -8,9 +10,25 @@ final class LotteryHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/lottery.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/lottery.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/MoviesHandler.php
+++ b/classes/Http/Handlers/Public/MoviesHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class MoviesHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
+        // TODO(2025): extract legacy block from public/movies.php:1-360 (multi-source cache hydration and helper functions)
         $target = __DIR__ . '/../../../../public/movies.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class MoviesHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/MoviesHandler.php.bak
+++ b/classes/Http/Handlers/Public/MoviesHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class MoviesHandler
@@ -8,9 +10,25 @@ final class MoviesHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/movies.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/movies.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/MybonusHandler.php
+++ b/classes/Http/Handlers/Public/MybonusHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class MybonusHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
+        // TODO(2025): extract legacy block from public/mybonus.php:1-320 (complex bonus catalogue flow with $fluent chains)
         $target = __DIR__ . '/../../../../public/mybonus.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class MybonusHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/MybonusHandler.php.bak
+++ b/classes/Http/Handlers/Public/MybonusHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class MybonusHandler
@@ -8,9 +10,25 @@ final class MybonusHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/mybonus.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/mybonus.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/MytorrentsHandler.php
+++ b/classes/Http/Handlers/Public/MytorrentsHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class MytorrentsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
+        // TODO(2025): extract legacy block from public/mytorrents.php:1-160 (heavy $fluent pagination and sorting logic)
         $target = __DIR__ . '/../../../../public/mytorrents.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class MytorrentsHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/MytorrentsHandler.php.bak
+++ b/classes/Http/Handlers/Public/MytorrentsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class MytorrentsHandler
@@ -8,9 +10,25 @@ final class MytorrentsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/mytorrents.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/mytorrents.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/NeedseedHandler.php
+++ b/classes/Http/Handlers/Public/NeedseedHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class NeedseedHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=75-5
+        // TODO(2025): extract legacy block from public/needseed.php:1-200 (dual-mode $fluent queries and genre hydration)
         $target = __DIR__ . '/../../../../public/needseed.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class NeedseedHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/NeedseedHandler.php.bak
+++ b/classes/Http/Handlers/Public/NeedseedHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class NeedseedHandler
@@ -8,9 +10,25 @@ final class NeedseedHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/needseed.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/needseed.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/tools/conversion_reports/classes/Http/Handlers/Public/ArcadeTopScoresHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/ArcadeTopScoresHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/ArcadeTopScoresHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=70 size=5
+- **Source legacy script**: public/arcade_top_scores.php
+- **Summary**:
+  - Embedded the arcade top score listing directly into the handler with container-backed config access.
+  - Replaced legacy `$fluent` usages with `Database::fetchAll` queries and localized helpers for filtering results.
+  - Preserved score tables, breadcrumbs, and layout rendering identical to the legacy script.
+- **Todos**: _None_
+- **Error handling**: Wrapped execution in try/catch with HTTP 500 fallback and legacy `stdhead/stdfoot` rendering.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/BitbucketHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/BitbucketHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/BitbucketHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=70 size=5
+- **Source legacy script**: public/bitbucket.php
+- **Summary**:
+  - Conversion deferred; retained upgraded stub that continues to buffer output from the legacy script.
+  - Marked the handler with an explicit TODO referencing the legacy implementation for manual extraction.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/bitbucket.php:1-400 (complex file operations, bookmarking state, CSRF review).
+- **Error handling**: Existing stub wrapper continues to capture legacy output and logs failures.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/BjstatsHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/BjstatsHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/BjstatsHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=70 size=5
+- **Source legacy script**: public/bjstats.php
+- **Summary**:
+  - Ported blackjack statistics rendering into the handler with container-managed config and database services.
+  - Replaced legacy `$fluent` chains with parameterised `Database::fetchAll` queries, including helper rendering for ranking tables.
+  - Preserved permission checks, breadcrumbs, and table layout consistent with the original script.
+- **Todos**: _None_
+- **Error handling**: Retains handler-level try/catch with HTTP 500 fallback.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/BlackjackHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/BlackjackHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/BlackjackHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=70 size=5
+- **Source legacy script**: public/blackjack.php
+- **Summary**:
+  - Conversion deferred due to complex, stateful blackjack gameplay engine with extensive SQL and messaging side-effects.
+  - Added explicit TODO referencing the legacy script for manual extraction and auditing.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/blackjack.php:1-420 (stateful gameplay, SQL migrations, CSRF hardening).
+- **Error handling**: Existing stub wrapper still buffers output and logs thrown errors.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/BookmarksHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/BookmarksHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/BookmarksHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=70 size=5
+- **Source legacy script**: public/bookmarks.php
+- **Summary**:
+  - Inlined the bookmarks listing logic into the handler with container-managed config and database services.
+  - Replaced legacy `$fluent` queries with parameterised `Database::fetchValue`/`fetchAll` calls and reused pager helpers.
+  - Consolidated table rendering into a private method while preserving icon legend, columns, and share toggles.
+- **Todos**: _None_
+- **Error handling**: Protected handler body with try/catch mirroring other converted handlers.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/LotteryHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/LotteryHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/LotteryHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=75 size=5
+- **Source legacy script**: public/lottery.php
+- **Summary**:
+  - Conversion deferred because the legacy entry dispatches into nested `lottery/*.php` scripts and mixes direct SQL helpers (`sql_query`, `mysqli_fetch_assoc`) that require manual PDO mapping.
+  - Handler retains legacy inclusion path with TODO marker for manual extraction.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/lottery.php:1-140 (nested includes and sql_query usage).
+- **Notes**: Ensure supporting lottery sub-scripts are reviewed together to avoid partial migrations.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/MoviesHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/MoviesHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/MoviesHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=75 size=5
+- **Source legacy script**: public/movies.php
+- **Summary**:
+  - Conversion deferred; the legacy script orchestrates multiple cached data feeds (TMDB, TVMaze, IMDB) with large helper blocks requiring careful extraction.
+  - Handler keeps legacy require path and records TODO for manual follow-up.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/movies.php:1-360 (cache hydration, helper generation, and proxy usage).
+- **Notes**: Coordinate with caching subsystem maintainers before attempting a full port.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/MybonusHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/MybonusHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/MybonusHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=75 size=5
+- **Source legacy script**: public/mybonus.php
+- **Summary**:
+  - Conversion deferred due to extensive `$fluent` query chains, bonus catalogue branching, and cross-service interactions (Auth, Bonuslog, Message).
+  - Handler preserves legacy bootstrap and adds TODO marker for manual porting.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/mybonus.php:1-320 (bonus purchase flows and dependent service updates).
+- **Notes**: Plan migration alongside karma bonus feature rewrite to avoid regressions.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/MytorrentsHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/MytorrentsHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/MytorrentsHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=75 size=5
+- **Source legacy script**: public/mytorrents.php
+- **Summary**:
+  - Conversion deferred; script relies on chained `$fluent` queries for pagination, sorting, and table rendering helpers.
+  - Handler still routes to legacy page and marks TODO for future refactor.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/mytorrents.php:1-160 (pager integration and torrent table generation).
+- **Notes**: Align refactor with torrent browsing module to share pagination utilities.

--- a/tools/conversion_reports/classes/Http/Handlers/Public/NeedseedHandler.conversion_report.md
+++ b/tools/conversion_reports/classes/Http/Handlers/Public/NeedseedHandler.conversion_report.md
@@ -1,0 +1,11 @@
+# Conversion Report: classes/Http/Handlers/Public/NeedseedHandler.php
+
+- **Date**: 2025-10-07
+- **Batch**: offset=75 size=5
+- **Source legacy script**: public/needseed.php
+- **Summary**:
+  - Conversion deferred because the legacy page drives two distinct `$fluent` query modes and category hydration that require coordinated repository work.
+  - Handler preserves legacy inclusion with TODO marker for targeted rewrite.
+- **Todos**:
+  - TODO(2025): extract legacy block from public/needseed.php:1-200 (dual-mode query logic and genre table composition).
+- **Notes**: Schedule refactor alongside browse/needseed consolidation to avoid duplication.

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -64,3 +64,13 @@ classes/Http/Handlers/Public/Ajax/OfferVoteHandler.php,true,1,Converted from pub
 classes/Http/Handlers/Public/Ajax/RatingHandler.php,true,1,Converted from public/ajax/rating.php
 classes/Http/Handlers/Public/Ajax/RequestNotifyHandler.php,true,1,Converted from public/ajax/request_notify.php
 classes/Http/Handlers/Public/Ajax/RequestVoteHandler.php,true,1,Converted from public/ajax/request_vote.php
+classes/Http/Handlers/Public/ArcadeTopScoresHandler.php,true,0,Extracted from public/arcade_top_scores.php
+classes/Http/Handlers/Public/BitbucketHandler.php,false,1,TODO(2025) legacy script complex public/bitbucket.php:1-400
+classes/Http/Handlers/Public/BjstatsHandler.php,true,0,Extracted from public/bjstats.php
+classes/Http/Handlers/Public/BlackjackHandler.php,false,1,TODO(2025) legacy script complex public/blackjack.php:1-420
+classes/Http/Handlers/Public/BookmarksHandler.php,true,0,Extracted from public/bookmarks.php
+classes/Http/Handlers/Public/LotteryHandler.php,false,1,TODO(2025) legacy script dispatch and sql_query usage require manual extraction
+classes/Http/Handlers/Public/MoviesHandler.php,false,1,TODO(2025) multi-source cache workflow requires curated port
+classes/Http/Handlers/Public/MybonusHandler.php,false,1,TODO(2025) complex bonus catalogue with fluent chains
+classes/Http/Handlers/Public/MytorrentsHandler.php,false,1,TODO(2025) torrent pager relies on fluent sorting helpers
+classes/Http/Handlers/Public/NeedseedHandler.php,false,1,TODO(2025) dual-mode needseed queries pending repository rewrite


### PR DESCRIPTION
## Summary
- mark the lottery, movies, mybonus, mytorrents, and needseed public handlers with AUTO_CONVERT_ATTEMPTED headers and TODO markers for manual extraction
- add per-handler conversion reports documenting why each legacy script was deferred for manual work
- extend the handler conversion report registry with batch offset 75 metadata

## Testing
- php -l classes/Http/Handlers/Public/LotteryHandler.php
- php -l classes/Http/Handlers/Public/MoviesHandler.php
- php -l classes/Http/Handlers/Public/MybonusHandler.php
- php -l classes/Http/Handlers/Public/MytorrentsHandler.php
- php -l classes/Http/Handlers/Public/NeedseedHandler.php


------
https://chatgpt.com/codex/tasks/task_e_68e48dfc60148325b412f8d9f1668f0f