### PR TITLE
feat: convert handler stubs batch 80-5

### DIFF
--- a/classes/Http/Handlers/Public/AjaxchatHandler.php
+++ b/classes/Http/Handlers/Public/AjaxchatHandler.php
@@ -1,34 +1,44 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Database;
 
 final class AjaxchatHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/ajaxchat.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db); // Legacy script expected database bootstrap side-effects.
+
+            if (!\defined('AJAX_CHAT_PATH')) {
+                error_log('AJAX_CHAT_PATH is not defined');
+                http_response_code(500);
+                echo 'Internal error';
+
+                return;
+            }
+
+            require_once AJAX_CHAT_PATH . 'lib' . DIRECTORY_SEPARATOR . 'custom.php';
+            require_once AJAX_CHAT_PATH . 'lib' . DIRECTORY_SEPARATOR . 'classes.php';
+
+            check_user_status();
+            new \CustomAJAXChat();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/AjaxchatHandler.php.bak
+++ b/classes/Http/Handlers/Public/AjaxchatHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class AjaxchatHandler
@@ -8,9 +10,25 @@ final class AjaxchatHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/ajaxchat.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/ajaxchat.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/AnnouncementHandler.php
+++ b/classes/Http/Handlers/Public/AnnouncementHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class AnnouncementHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        // TODO(2025): extract legacy block from public/announcement.php:1-220; dynamic sql_query/sqlesc chains need manual review.
         $target = __DIR__ . '/../../../../public/announcement.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class AnnouncementHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/AnnouncementHandler.php.bak
+++ b/classes/Http/Handlers/Public/AnnouncementHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class AnnouncementHandler
@@ -8,9 +10,25 @@ final class AnnouncementHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/announcement.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/announcement.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/CategoryidsHandler.php
+++ b/classes/Http/Handlers/Public/CategoryidsHandler.php
@@ -1,34 +1,90 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 
 final class CategoryidsHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/categoryids.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+            $parents = genrelist(true);
+            $baseUrl = (string) $config->get('paths.baseurl');
+
+            $countRows = $db->fetchAll('SELECT category, COUNT(id) AS count FROM torrents GROUP BY category');
+            $counts = [];
+            foreach ($countRows as $row) {
+                if (!isset($row['category'])) {
+                    continue;
+                }
+                $categoryId = (int) $row['category'];
+                $counts[$categoryId] = (int) ($row['count'] ?? 0);
+            }
+
+            $heading = "
+        <tr>
+            <th class='has-text-centered w-25'>" . _('Cat ID') . "</th>
+            <th class='has-text-centered'>" . _('Cat Name') . "</th>
+            <th class='has-text-centered w-25'>" . _('Torrents Uploaded') . '</th>
+        </tr>';
+            $body = '';
+
+            foreach ($parents as $parent) {
+                if (!$user['hidden'] && (int) ($parent['hidden'] ?? 0) === 1) {
+                    continue;
+                }
+
+                $children = $parent['children'] ?? [];
+                if (!\is_array($children)) {
+                    continue;
+                }
+
+                foreach ($children as $child) {
+                    if (!$user['hidden'] && (int) ($child['hidden'] ?? 0) === 1) {
+                        continue;
+                    }
+
+                    $childId = (int) ($child['id'] ?? 0);
+                    $count = $counts[$childId] ?? 0;
+                    $body .= "
+        <tr>
+            <td class='has-text-centered'>{$childId}</td>
+            <td><a href='{$baseUrl}/browse.php?cats[]={$childId}'>{$parent['name']}::{$child['name']}</a></td>
+            <td class='has-text-centered'>{$count}</td>
+        </tr>";
+                }
+            }
+
+            $HTMLOUT = "
+    <h1 class='has-text-centered'>" . _("Category ID's") . '</h1>';
+            $HTMLOUT .= main_table($body, $heading, 'w-50 has-text-centered');
+            $title = _("Category ID's");
+            $breadcrumbs = [
+                sprintf("<a href='%s'>%s</a>", $_SERVER['PHP_SELF'] ?? '', $title),
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/CategoryidsHandler.php.bak
+++ b/classes/Http/Handlers/Public/CategoryidsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class CategoryidsHandler
@@ -8,9 +10,25 @@ final class CategoryidsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/categoryids.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/categoryids.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/RssPdoDemoHandler.php
+++ b/classes/Http/Handlers/Public/RssPdoDemoHandler.php
@@ -1,34 +1,53 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Database;
 
 final class RssPdoDemoHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/rss_pdo_demo.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db); // Intentional: demo handler retains bootstrap side-effects.
+
+            header('Content-Type: application/rss+xml; charset=UTF-8');
+
+            $channelTitle = 'Pu-239 RSS Demo';
+            $channelLink = 'https://example.com/';
+            $channelDesc = 'Demo feed without short open tags';
+
+            $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+            echo '<' . '?xml version="1.0" encoding="UTF-8"?' . '>' . "\n";
+            echo "<rss version=\"2.0\">\n";
+            echo "  <channel>\n";
+            echo '    <title>' . $escape($channelTitle) . "</title>\n";
+            echo '    <link>' . $escape($channelLink) . "</link>\n";
+            echo '    <description>' . $escape($channelDesc) . "</description>\n";
+            echo "    <item>\n";
+            echo "      <title>Demo item</title>\n";
+            echo "      <link>https://example.com/demo</link>\n";
+            echo "      <guid isPermaLink=\"false\">demo-1</guid>\n";
+            echo '      <pubDate>' . gmdate('D, d M Y H:i:s') . " GMT</pubDate>\n";
+            echo "      <description>Minimal RSS item for Static Guard compliance.</description>\n";
+            echo "    </item>\n";
+            echo "  </channel>\n";
+            echo "</rss>\n";
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/RssPdoDemoHandler.php.bak
+++ b/classes/Http/Handlers/Public/RssPdoDemoHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class RssPdoDemoHandler
@@ -8,9 +10,25 @@ final class RssPdoDemoHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/rss_pdo_demo.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/rss_pdo_demo.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UsercommentHandler.php
+++ b/classes/Http/Handlers/Public/UsercommentHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class UsercommentHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        // TODO(2025): extract legacy block from public/usercomment.php:1-260; includes CSRF + ExtendedPDO rewrite stubs.
         $target = __DIR__ . '/../../../../public/usercomment.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class UsercommentHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UsercommentHandler.php.bak
+++ b/classes/Http/Handlers/Public/UsercommentHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class UsercommentHandler
@@ -8,9 +10,25 @@ final class UsercommentHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/usercomment.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/usercomment.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/tools/handler_conversion_reports/AjaxchatHandler.md
+++ b/tools/handler_conversion_reports/AjaxchatHandler.md
@@ -1,0 +1,8 @@
+# AjaxchatHandler Conversion Report
+- Source: `public/ajaxchat.php`
+- Converted: ✅ Yes
+- Todos: 0
+- Notes:
+  - Embedded bootstrap + bittorrent includes inside handler and resolved container dependencies.
+  - Added guard to ensure `AJAX_CHAT_PATH` is defined before loading chat classes.
+  - Instantiates `CustomAJAXChat` to preserve previous side-effects.

--- a/tools/handler_conversion_reports/AnnouncementHandler.md
+++ b/tools/handler_conversion_reports/AnnouncementHandler.md
@@ -1,0 +1,8 @@
+# AnnouncementHandler Conversion Report
+- Source: `public/announcement.php`
+- Converted: ❌ No
+- Todos: 1
+- Notes:
+  - Legacy script includes complex `sql_query` + `sqlesc` patterns with dynamic SQL fragments.
+  - Marked handler with TODO for manual extraction referencing `public/announcement.php:1-220`.
+  - Stub still proxies to legacy file until manual rewrite can safely replace dynamic workflows.

--- a/tools/handler_conversion_reports/CategoryidsHandler.md
+++ b/tools/handler_conversion_reports/CategoryidsHandler.md
@@ -1,0 +1,9 @@
+# CategoryidsHandler Conversion Report
+- Source: `public/categoryids.php`
+- Converted: ✅ Yes
+- Todos: 0
+- Notes:
+  - Wrapped legacy procedural body inside handler `handle()` with error handling.
+  - Introduced `ConfigRepository` and `Database` retrievals from the container.
+  - Replaced FluentPDO count aggregation with `Database::fetchAll` + local map.
+  - Preserved existing HTML layout and breadcrumb construction.

--- a/tools/handler_conversion_reports/RssPdoDemoHandler.md
+++ b/tools/handler_conversion_reports/RssPdoDemoHandler.md
@@ -1,0 +1,8 @@
+# RssPdoDemoHandler Conversion Report
+- Source: `public/rss_pdo_demo.php`
+- Converted: ✅ Yes
+- Todos: 0
+- Notes:
+  - Migrated static RSS demo output into handler context with bootstrap + container access.
+  - Retained database retrieval side-effect (unused) for parity with legacy script startup.
+  - Added local HTML escaping closure to mirror inline helper.

--- a/tools/handler_conversion_reports/UsercommentHandler.md
+++ b/tools/handler_conversion_reports/UsercommentHandler.md
@@ -1,0 +1,7 @@
+# UsercommentHandler Conversion Report
+- Source: `public/usercomment.php`
+- Converted: ❌ No
+- Todos: 1
+- Notes:
+  - Handler remains a legacy proxy because the source script still mixes placeholder ExtendedPDO calls and TODO blocks.
+  - Flagged manual follow-up referencing `public/usercomment.php:1-260` for CSRF + Database migration cleanup.

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -78,3 +78,8 @@ classes/Http/Handlers/Public/MoviesHandler.php,false,1,TODO(2025) multi-source c
 classes/Http/Handlers/Public/MybonusHandler.php,false,1,TODO(2025) complex bonus catalogue with fluent chains
 classes/Http/Handlers/Public/MytorrentsHandler.php,false,1,TODO(2025) torrent pager relies on fluent sorting helpers
 classes/Http/Handlers/Public/NeedseedHandler.php,false,1,TODO(2025) dual-mode needseed queries pending repository rewrite
+classes/Http/Handlers/Public/CategoryidsHandler.php,true,0,Extracted from public/categoryids.php; replaced FluentPDO usage with Database::fetchAll
+classes/Http/Handlers/Public/AnnouncementHandler.php,false,1,TODO(2025) dynamic announcement workflow requires manual Database migration
+classes/Http/Handlers/Public/RssPdoDemoHandler.php,true,0,Converted from public/rss_pdo_demo.php
+classes/Http/Handlers/Public/AjaxchatHandler.php,true,0,Extracted from public/ajaxchat.php; ensures AJAX_CHAT_PATH guard
+classes/Http/Handlers/Public/UsercommentHandler.php,false,1,TODO(2025) multi-branch comment controller retains legacy require


### PR DESCRIPTION
## Summary
- inline the legacy `public/categoryids.php` logic into `CategoryidsHandler` with container-backed config/db access
- convert `RssPdoDemoHandler` and `AjaxchatHandler` to execute their legacy workflows directly inside the handler layer
- flag `AnnouncementHandler` and `UsercommentHandler` as TODO with references for manual extraction and add per-file conversion reports

## Testing
- php -l classes/Http/Handlers/Public/CategoryidsHandler.php
- php -l classes/Http/Handlers/Public/AnnouncementHandler.php
- php -l classes/Http/Handlers/Public/RssPdoDemoHandler.php
- php -l classes/Http/Handlers/Public/AjaxchatHandler.php
- php -l classes/Http/Handlers/Public/UsercommentHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e495919bcc8325b7f308f31fdbeaff