### PR TITLE
feat: convert handler stubs batch 85-5

### DIFF
--- a/classes/Http/Handlers/Admin/AdduserHandler.php
+++ b/classes/Http/Handlers/Admin/AdduserHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,7 +10,8 @@ final class AdduserHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
+        // TODO(2025): extract legacy block from admin/adduser.php:1-200 (merge conflicts and inconsistent helpers)
         $target = __DIR__ . '/../../../../admin/adduser.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));

--- a/classes/Http/Handlers/Admin/AdduserHandler.php.bak
+++ b/classes/Http/Handlers/Admin/AdduserHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class AdduserHandler
@@ -8,9 +10,26 @@ final class AdduserHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/adduser.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/adduser.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/CheatersHandler.php
+++ b/classes/Http/Handlers/Admin/CheatersHandler.php
@@ -1,35 +1,191 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
 
 namespace PU239\Http\Handlers\Admin;
+
+use Pu239\Cache;
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
+use PU239\Security\AuthZ;
 
 final class CheatersHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../admin/cheaters.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
-    
+            $handlerPath = __FILE__;
+            if (stripos($handlerPath, '/admin/') !== false) {
+                AuthZ::requireRole('admin');
+            } else {
+                AuthZ::requireAnyRole(['staff', 'admin']);
+            }
+
+            global $container, $CURUSER;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            /** @var Cache $cache */
+            $cache = $container->get(Cache::class);
+
+            $class = get_access(basename($_SERVER['REQUEST_URI'] ?? ''));
+            class_check($class);
+
+            $s = static fn($v) => htmlspecialchars((string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $self = $s($_SERVER['PHP_SELF'] ?? '');
+            $baseurl = $s((string) $config->get('paths.baseurl'));
+
+            $stdfoot = [
+                'js' => [
+                    get_file_name('cheaters_js'),
+                ],
+            ];
+
+            $dt = TIME_NOW;
+
+            if (isset($_POST['nowarned']) && $_POST['nowarned'] === 'nowarned') {
+                // TODO(2025): csrf hardening for admin cheater actions
+                $idsRemove = !empty($_POST['remove']) ? array_map('intval', (array) $_POST['remove']) : [];
+                $idsDisable = !empty($_POST['desact']) ? array_map('intval', (array) $_POST['desact']) : [];
+
+                if ($idsRemove === [] && $idsDisable === []) {
+                    stderr(_('Error'), _('You must select a user.'));
+                }
+
+                if ($idsRemove !== []) {
+                    [$inClause, $bindings] = $db->inClause('remove_id', $idsRemove);
+                    $db->run("DELETE FROM cheaters WHERE id IN ($inClause)", $bindings);
+                }
+
+                if ($idsDisable !== []) {
+                    [$inClause, $bindings] = $db->inClause('disable_id', $idsDisable);
+                    $modline = get_date((int) $dt, 'DATE', 1) . ' - ' . _fe('Disabled by {0} (cheater panel)', $CURUSER['username']) . "\n";
+                    $bindings['modline'] = $modline;
+                    $db->run(
+                        "UPDATE users
+                            SET status = 2,
+                                modcomment = CONCAT(:modline, modcomment)
+                          WHERE id IN ($inClause)",
+                        $bindings
+                    );
+
+                    foreach ($idsDisable as $uid) {
+                        $cache->delete('user_' . (int) $uid);
+                    }
+                }
+
+                $refreshTarget = htmlsafechars($_SERVER['REQUEST_URI'] ?? '');
+                header('Refresh: 2; url=' . $refreshTarget);
+                $changed = count($idsRemove) + count($idsDisable);
+                stderr(_('Success'), _pfe('{0} change applied.', '{0} changes applied.', $changed));
+                app_halt('Exit called');
+            }
+
+            $count = (int) $db->fetchValue('SELECT COUNT(id) FROM cheaters');
+            $perpage = 15;
+
+            $HTMLOUT = "<h1 class='has-text-centered'>" . _('Possible Cheaters') . '</h1>';
+
+            if ($count > 0) {
+                $pager = pager($perpage, $count, (string) $config->get('paths.baseurl') . '/staffpanel.php?tool=cheaters&amp;action=cheaters&amp;');
+
+                $HTMLOUT .= "
+    <form action='{$self}?tool=cheaters&amp;action=cheaters' method='post' enctype='multipart/form-data' accept-charset='utf-8'>";
+
+                if ($count > $perpage) {
+                    $HTMLOUT .= $pager['pagertop'];
+                }
+
+                $heading = "
+        <tr>
+            <th class='w-1 has-text-centered'>#</th>
+            <th>" . _('Username') . "</th>
+            <th class='w-1 has-text-centered'>" . _('Disable') . "</th>
+            <th class='w-1 has-text-centered'>" . _('Remove') . '</th>
+        </tr>';
+
+                $rows = $db->fetchAll(
+                    'SELECT c.id AS cid, c.added, c.userid, c.torrentid, c.client, c.rate, c.beforeup, c.upthis, c.timediff, c.userip,
+                            t.id AS tid, t.name AS tname
+                       FROM cheaters AS c
+                  LEFT JOIN torrents AS t ON t.id = c.torrentid
+                   ORDER BY c.added DESC ' . ($pager['limit'] ?? '')
+                );
+
+                $body = '';
+                foreach ($rows as $arr) {
+                    $id = (int) ($arr['cid'] ?? 0);
+                    $userid = (int) ($arr['userid'] ?? 0);
+                    $idDisplay = $s((string) $id);
+                    $userIdDisplay = $s((string) $userid);
+                    $torrentName = $s(CutName((string) ($arr['tname'] ?? ''), 80));
+                    $client = $s((string) ($arr['client'] ?? ''));
+                    $userIp = $s((string) ($arr['userip'] ?? ''));
+                    $uploaded = $s(mksize((int) ($arr['upthis'] ?? 0)));
+                    $speed = $s(mksize((int) ($arr['rate'] ?? 0)));
+                    $timeDiff = $s((string) ($arr['timediff'] ?? ''));
+                    $tid = $s((string) (int) ($arr['tid'] ?? 0));
+                    $detailsLink = "{$baseurl}/details.php?id={$tid}";
+
+                    $cheater = format_username($userid) . ' ' . _(' has been flagged with an abnormally high upload speed!') . '<br>'
+                        . _('On torrent') . " <a href='{$detailsLink}' title='{$torrentName}'>{$torrentName}</a><br>"
+                        . _('Uploaded') . ' ' . $uploaded . '<br>'
+                        . _('Speed') . ' ' . $speed . '/s<br>'
+                        . _('Within') . ' ' . $timeDiff . ' ' . _('Seconds') . '<br>'
+                        . _('Using Client:') . ' ' . $client . '<br>'
+                        . _('Ip Address') . ' ' . $userIp;
+
+                    $cheaters = "
+        <div class='dt-tooltipper-large' data-tooltip-content='#cheater_{$idDisplay}_tooltip'>" . format_username($userid, true, false) . "
+            <div class='tooltip_templates'>
+                <div id='cheater_{$idDisplay}_tooltip'>$cheater</div>
+            </div>
+        </div>";
+
+                    $body .= "
+        <tr>
+            <td class='has-text-centered'>{$idDisplay}</td>
+            <td>{$cheaters}</td>
+            <td class='has-text-centered'><input type='checkbox' name='desact[]' value='{$userIdDisplay}'></td>
+            <td class='has-text-centered'><input type='checkbox' name='remove[]' value='{$idDisplay}'></td>
+        </tr>";
+                }
+
+                $HTMLOUT .= main_table($body, $heading);
+
+                $HTMLOUT .= "
+        <div class='has-text-centered margin20'>
+            <input type='button' value='" . _('Check All Disable') . "' onclick=\"this.value=check1(this.form.elements['desact[]'])\" class='button is-small'>
+            <input type='button' value='" . _('Check All Remove') . "' onclick=\"this.value=check2(this.form.elements['remove[]'])\" class='button is-small'>
+            <input type='hidden' name='nowarned' value='nowarned'>
+            <input type='submit' name='submit' value='" . _('Apply Changes') . "' class='button is-small'>
+        </div>
+    </form>";
+
+                if ($count > $perpage) {
+                    $HTMLOUT .= $pager['pagerbottom'];
+                }
+            } else {
+                $HTMLOUT .= stdmsg(_('Error'), _('Nothing found.'));
+            }
+
+            $title = _('Possible Cheaters');
+            $breadcrumbs = [
+                "<a href='{$baseurl}/staffpanel.php'>" . _('Staff Panel') . '</a>',
+                "<a href='{$self}'>" . $s($title) . '</a>',
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot($stdfoot);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Admin/CheatersHandler.php.bak
+++ b/classes/Http/Handlers/Admin/CheatersHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class CheatersHandler
@@ -8,9 +10,26 @@ final class CheatersHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/cheaters.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/cheaters.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/DataresetHandler.php
+++ b/classes/Http/Handlers/Admin/DataresetHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,7 +10,8 @@ final class DataresetHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
+        // TODO(2025): extract legacy block from admin/datareset.php:1-200 (requires fluent query rewrite and service wiring)
         $target = __DIR__ . '/../../../../admin/datareset.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));

--- a/classes/Http/Handlers/Admin/DataresetHandler.php.bak
+++ b/classes/Http/Handlers/Admin/DataresetHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class DataresetHandler
@@ -8,9 +10,26 @@ final class DataresetHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/datareset.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/datareset.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/DeathrowHandler.php
+++ b/classes/Http/Handlers/Admin/DeathrowHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,7 +10,8 @@ final class DeathrowHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
+        // TODO(2025): extract legacy block from admin/deathrow.php:1-240 (custom helpers, $fluent usage, nested functions)
         $target = __DIR__ . '/../../../../admin/deathrow.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));

--- a/classes/Http/Handlers/Admin/DeathrowHandler.php.bak
+++ b/classes/Http/Handlers/Admin/DeathrowHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class DeathrowHandler
@@ -8,9 +10,26 @@ final class DeathrowHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/deathrow.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/deathrow.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Admin/FindnotconnectableHandler.php
+++ b/classes/Http/Handlers/Admin/FindnotconnectableHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
 
 namespace PU239\Http\Handlers\Admin;
 
@@ -10,7 +10,8 @@ final class FindnotconnectableHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=85-5
+        // TODO(2025): extract legacy block from admin/findnotconnectable.php:1-220 (legacy mysqli/sql_query flow)
         $target = __DIR__ . '/../../../../admin/findnotconnectable.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));

--- a/classes/Http/Handlers/Admin/FindnotconnectableHandler.php.bak
+++ b/classes/Http/Handlers/Admin/FindnotconnectableHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Admin;
 
 final class FindnotconnectableHandler
@@ -8,9 +10,26 @@ final class FindnotconnectableHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../admin/findnotconnectable.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../admin/findnotconnectable.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
+    
     }
 }

--- a/classes/Http/Handlers/Public/AjaxchatHandler.php
+++ b/classes/Http/Handlers/Public/AjaxchatHandler.php
@@ -1,34 +1,44 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Database;
 
 final class AjaxchatHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/ajaxchat.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db); // Legacy script expected database bootstrap side-effects.
+
+            if (!\defined('AJAX_CHAT_PATH')) {
+                error_log('AJAX_CHAT_PATH is not defined');
+                http_response_code(500);
+                echo 'Internal error';
+
+                return;
+            }
+
+            require_once AJAX_CHAT_PATH . 'lib' . DIRECTORY_SEPARATOR . 'custom.php';
+            require_once AJAX_CHAT_PATH . 'lib' . DIRECTORY_SEPARATOR . 'classes.php';
+
+            check_user_status();
+            new \CustomAJAXChat();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/AjaxchatHandler.php.bak
+++ b/classes/Http/Handlers/Public/AjaxchatHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class AjaxchatHandler
@@ -8,9 +10,25 @@ final class AjaxchatHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/ajaxchat.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/ajaxchat.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/AnnouncementHandler.php
+++ b/classes/Http/Handlers/Public/AnnouncementHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class AnnouncementHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        // TODO(2025): extract legacy block from public/announcement.php:1-220; dynamic sql_query/sqlesc chains need manual review.
         $target = __DIR__ . '/../../../../public/announcement.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class AnnouncementHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/AnnouncementHandler.php.bak
+++ b/classes/Http/Handlers/Public/AnnouncementHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class AnnouncementHandler
@@ -8,9 +10,25 @@ final class AnnouncementHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/announcement.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/announcement.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/CategoryidsHandler.php
+++ b/classes/Http/Handlers/Public/CategoryidsHandler.php
@@ -1,34 +1,90 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Database;
 
 final class CategoryidsHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/categoryids.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+
+            $user = check_user_status();
+            $parents = genrelist(true);
+            $baseUrl = (string) $config->get('paths.baseurl');
+
+            $countRows = $db->fetchAll('SELECT category, COUNT(id) AS count FROM torrents GROUP BY category');
+            $counts = [];
+            foreach ($countRows as $row) {
+                if (!isset($row['category'])) {
+                    continue;
+                }
+                $categoryId = (int) $row['category'];
+                $counts[$categoryId] = (int) ($row['count'] ?? 0);
+            }
+
+            $heading = "
+        <tr>
+            <th class='has-text-centered w-25'>" . _('Cat ID') . "</th>
+            <th class='has-text-centered'>" . _('Cat Name') . "</th>
+            <th class='has-text-centered w-25'>" . _('Torrents Uploaded') . '</th>
+        </tr>';
+            $body = '';
+
+            foreach ($parents as $parent) {
+                if (!$user['hidden'] && (int) ($parent['hidden'] ?? 0) === 1) {
+                    continue;
+                }
+
+                $children = $parent['children'] ?? [];
+                if (!\is_array($children)) {
+                    continue;
+                }
+
+                foreach ($children as $child) {
+                    if (!$user['hidden'] && (int) ($child['hidden'] ?? 0) === 1) {
+                        continue;
+                    }
+
+                    $childId = (int) ($child['id'] ?? 0);
+                    $count = $counts[$childId] ?? 0;
+                    $body .= "
+        <tr>
+            <td class='has-text-centered'>{$childId}</td>
+            <td><a href='{$baseUrl}/browse.php?cats[]={$childId}'>{$parent['name']}::{$child['name']}</a></td>
+            <td class='has-text-centered'>{$count}</td>
+        </tr>";
+                }
+            }
+
+            $HTMLOUT = "
+    <h1 class='has-text-centered'>" . _("Category ID's") . '</h1>';
+            $HTMLOUT .= main_table($body, $heading, 'w-50 has-text-centered');
+            $title = _("Category ID's");
+            $breadcrumbs = [
+                sprintf("<a href='%s'>%s</a>", $_SERVER['PHP_SELF'] ?? '', $title),
+            ];
+
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/CategoryidsHandler.php.bak
+++ b/classes/Http/Handlers/Public/CategoryidsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class CategoryidsHandler
@@ -8,9 +10,25 @@ final class CategoryidsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/categoryids.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/categoryids.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/RssPdoDemoHandler.php
+++ b/classes/Http/Handlers/Public/RssPdoDemoHandler.php
@@ -1,34 +1,53 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Database;
 
 final class RssPdoDemoHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/rss_pdo_demo.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var Database $db */
+            $db = $container->get(Database::class);
+            unset($db); // Intentional: demo handler retains bootstrap side-effects.
+
+            header('Content-Type: application/rss+xml; charset=UTF-8');
+
+            $channelTitle = 'Pu-239 RSS Demo';
+            $channelLink = 'https://example.com/';
+            $channelDesc = 'Demo feed without short open tags';
+
+            $escape = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+            echo '<' . '?xml version="1.0" encoding="UTF-8"?' . '>' . "\n";
+            echo "<rss version=\"2.0\">\n";
+            echo "  <channel>\n";
+            echo '    <title>' . $escape($channelTitle) . "</title>\n";
+            echo '    <link>' . $escape($channelLink) . "</link>\n";
+            echo '    <description>' . $escape($channelDesc) . "</description>\n";
+            echo "    <item>\n";
+            echo "      <title>Demo item</title>\n";
+            echo "      <link>https://example.com/demo</link>\n";
+            echo "      <guid isPermaLink=\"false\">demo-1</guid>\n";
+            echo '      <pubDate>' . gmdate('D, d M Y H:i:s') . " GMT</pubDate>\n";
+            echo "      <description>Minimal RSS item for Static Guard compliance.</description>\n";
+            echo "    </item>\n";
+            echo "  </channel>\n";
+            echo "</rss>\n";
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/RssPdoDemoHandler.php.bak
+++ b/classes/Http/Handlers/Public/RssPdoDemoHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class RssPdoDemoHandler
@@ -8,9 +10,25 @@ final class RssPdoDemoHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/rss_pdo_demo.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/rss_pdo_demo.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UsercommentHandler.php
+++ b/classes/Http/Handlers/Public/UsercommentHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,14 +10,17 @@ final class UsercommentHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-07 via handler-convert batch=80-5
+        // TODO(2025): extract legacy block from public/usercomment.php:1-260; includes CSRF + ExtendedPDO rewrite stubs.
         $target = __DIR__ . '/../../../../public/usercomment.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
             http_response_code(500);
             echo 'Service temporarily unavailable';
+
             return;
         }
+
         $out = (static function (string $file): string {
             ob_start();
             try {
@@ -25,10 +28,10 @@ final class UsercommentHandler
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
             }
+
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UsercommentHandler.php.bak
+++ b/classes/Http/Handlers/Public/UsercommentHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class UsercommentHandler
@@ -8,9 +10,25 @@ final class UsercommentHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/usercomment.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/usercomment.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/tools/handler_conversion_reports/AdduserHandler.md
+++ b/tools/handler_conversion_reports/AdduserHandler.md
@@ -1,0 +1,8 @@
+# AdduserHandler conversion (2025-10-07)
+
+- Status: Deferred (manual extraction required)
+- Notes:
+  - Legacy admin/adduser.php still contains merge conflict markers and inconsistent helper calls.
+  - Handler remains as buffered proxy with TODO for manual extraction.
+- TODOs:
+  - TODO(2025): extract legacy block from admin/adduser.php:1-200 (merge conflicts and inconsistent helpers)

--- a/tools/handler_conversion_reports/AjaxchatHandler.md
+++ b/tools/handler_conversion_reports/AjaxchatHandler.md
@@ -1,0 +1,8 @@
+# AjaxchatHandler Conversion Report
+- Source: `public/ajaxchat.php`
+- Converted: ✅ Yes
+- Todos: 0
+- Notes:
+  - Embedded bootstrap + bittorrent includes inside handler and resolved container dependencies.
+  - Added guard to ensure `AJAX_CHAT_PATH` is defined before loading chat classes.
+  - Instantiates `CustomAJAXChat` to preserve previous side-effects.

--- a/tools/handler_conversion_reports/AnnouncementHandler.md
+++ b/tools/handler_conversion_reports/AnnouncementHandler.md
@@ -1,0 +1,8 @@
+# AnnouncementHandler Conversion Report
+- Source: `public/announcement.php`
+- Converted: ❌ No
+- Todos: 1
+- Notes:
+  - Legacy script includes complex `sql_query` + `sqlesc` patterns with dynamic SQL fragments.
+  - Marked handler with TODO for manual extraction referencing `public/announcement.php:1-220`.
+  - Stub still proxies to legacy file until manual rewrite can safely replace dynamic workflows.

--- a/tools/handler_conversion_reports/CategoryidsHandler.md
+++ b/tools/handler_conversion_reports/CategoryidsHandler.md
@@ -1,0 +1,9 @@
+# CategoryidsHandler Conversion Report
+- Source: `public/categoryids.php`
+- Converted: ✅ Yes
+- Todos: 0
+- Notes:
+  - Wrapped legacy procedural body inside handler `handle()` with error handling.
+  - Introduced `ConfigRepository` and `Database` retrievals from the container.
+  - Replaced FluentPDO count aggregation with `Database::fetchAll` + local map.
+  - Preserved existing HTML layout and breadcrumb construction.

--- a/tools/handler_conversion_reports/CheatersHandler.md
+++ b/tools/handler_conversion_reports/CheatersHandler.md
@@ -1,0 +1,9 @@
+# CheatersHandler conversion (2025-10-07)
+
+- Status: Converted
+- Notes:
+  - Inlined admin/cheaters.php workflow with container-provided config, database, and cache services.
+  - Replaced raw IN() string assembly with Database::inClause bindings and preserved tooltip output formatting.
+  - Added TODO for CSRF hardening during POST actions.
+- TODOs:
+  - TODO(2025): csrf hardening for admin cheater actions

--- a/tools/handler_conversion_reports/DataresetHandler.md
+++ b/tools/handler_conversion_reports/DataresetHandler.md
@@ -1,0 +1,8 @@
+# DataresetHandler conversion (2025-10-07)
+
+- Status: Deferred (manual extraction required)
+- Notes:
+  - admin/datareset.php relies on removed $fluent queries, mixed service lookups, and unresolved message/torrent handling.
+  - Handler left as stub with explicit TODO for a curated rewrite.
+- TODOs:
+  - TODO(2025): extract legacy block from admin/datareset.php:1-200 (requires fluent query rewrite and service wiring)

--- a/tools/handler_conversion_reports/DeathrowHandler.md
+++ b/tools/handler_conversion_reports/DeathrowHandler.md
@@ -1,0 +1,8 @@
+# DeathrowHandler conversion (2025-10-07)
+
+- Status: Deferred (manual extraction required)
+- Notes:
+  - admin/deathrow.php mixes inline function declarations, $fluent ORM remnants, and multi-branch notification flows.
+  - Conversion postponed pending targeted refactor of notifier helpers and transaction boundaries.
+- TODOs:
+  - TODO(2025): extract legacy block from admin/deathrow.php:1-240 (custom helpers, $fluent usage, nested functions)

--- a/tools/handler_conversion_reports/FindnotconnectableHandler.md
+++ b/tools/handler_conversion_reports/FindnotconnectableHandler.md
@@ -1,0 +1,8 @@
+# FindnotconnectableHandler conversion (2025-10-07)
+
+- Status: Deferred (manual extraction required)
+- Notes:
+  - admin/findnotconnectable.php still depends on mysqli/sql_query patterns and manual HTML loops.
+  - Requires bespoke PDO migration and messaging audit before safe inline conversion.
+- TODOs:
+  - TODO(2025): extract legacy block from admin/findnotconnectable.php:1-220 (legacy mysqli/sql_query flow)

--- a/tools/handler_conversion_reports/RssPdoDemoHandler.md
+++ b/tools/handler_conversion_reports/RssPdoDemoHandler.md
@@ -1,0 +1,8 @@
+# RssPdoDemoHandler Conversion Report
+- Source: `public/rss_pdo_demo.php`
+- Converted: ✅ Yes
+- Todos: 0
+- Notes:
+  - Migrated static RSS demo output into handler context with bootstrap + container access.
+  - Retained database retrieval side-effect (unused) for parity with legacy script startup.
+  - Added local HTML escaping closure to mirror inline helper.

--- a/tools/handler_conversion_reports/UsercommentHandler.md
+++ b/tools/handler_conversion_reports/UsercommentHandler.md
@@ -1,0 +1,7 @@
+# UsercommentHandler Conversion Report
+- Source: `public/usercomment.php`
+- Converted: ❌ No
+- Todos: 1
+- Notes:
+  - Handler remains a legacy proxy because the source script still mixes placeholder ExtendedPDO calls and TODO blocks.
+  - Flagged manual follow-up referencing `public/usercomment.php:1-260` for CSRF + Database migration cleanup.

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -78,3 +78,13 @@ classes/Http/Handlers/Public/MoviesHandler.php,false,1,TODO(2025) multi-source c
 classes/Http/Handlers/Public/MybonusHandler.php,false,1,TODO(2025) complex bonus catalogue with fluent chains
 classes/Http/Handlers/Public/MytorrentsHandler.php,false,1,TODO(2025) torrent pager relies on fluent sorting helpers
 classes/Http/Handlers/Public/NeedseedHandler.php,false,1,TODO(2025) dual-mode needseed queries pending repository rewrite
+classes/Http/Handlers/Public/CategoryidsHandler.php,true,0,Extracted from public/categoryids.php; replaced FluentPDO usage with Database::fetchAll
+classes/Http/Handlers/Public/AnnouncementHandler.php,false,1,TODO(2025) dynamic announcement workflow requires manual Database migration
+classes/Http/Handlers/Public/RssPdoDemoHandler.php,true,0,Converted from public/rss_pdo_demo.php
+classes/Http/Handlers/Public/AjaxchatHandler.php,true,0,Extracted from public/ajaxchat.php; ensures AJAX_CHAT_PATH guard
+classes/Http/Handlers/Public/UsercommentHandler.php,false,1,TODO(2025) multi-branch comment controller retains legacy require
+classes/Http/Handlers/Admin/AdduserHandler.php,false,1,TODO(2025) admin/adduser.php merge conflicts block manual extraction
+classes/Http/Handlers/Admin/CheatersHandler.php,true,1,Converted admin/cheaters.php with Database::inClause bindings; TODO csrf hardening
+classes/Http/Handlers/Admin/DataresetHandler.php,false,1,TODO(2025) admin/datareset.php depends on removed $fluent queries
+classes/Http/Handlers/Admin/DeathrowHandler.php,false,1,TODO(2025) admin/deathrow.php requires bespoke notifier workflow port
+classes/Http/Handlers/Admin/FindnotconnectableHandler.php,false,1,TODO(2025) admin/findnotconnectable.php legacy mysqli/sql_query flow


### PR DESCRIPTION
## Summary
- inline the legacy `public/categoryids.php` logic into `CategoryidsHandler` with container-backed config/db access
- convert `RssPdoDemoHandler` and `AjaxchatHandler` to execute their legacy workflows directly inside the handler layer
- flag `AnnouncementHandler` and `UsercommentHandler` as TODO with references for manual extraction and add per-file conversion reports
- inline the admin `cheaters.php` workflow inside `CheatersHandler` with container-aware services and bound queries
- leave `Adduser`, `Datareset`, `Deathrow`, and `Findnotconnectable` handlers as TODO stubs with detailed follow-up reports referencing problematic legacy code paths

## Testing
- php -l classes/Http/Handlers/Admin/AdduserHandler.php
- php -l classes/Http/Handlers/Admin/CheatersHandler.php
- php -l classes/Http/Handlers/Admin/DataresetHandler.php
- php -l classes/Http/Handlers/Admin/DeathrowHandler.php
- php -l classes/Http/Handlers/Admin/FindnotconnectableHandler.php
- php -l classes/Http/Handlers/Public/CategoryidsHandler.php
- php -l classes/Http/Handlers/Public/AnnouncementHandler.php
- php -l classes/Http/Handlers/Public/RssPdoDemoHandler.php
- php -l classes/Http/Handlers/Public/AjaxchatHandler.php
- php -l classes/Http/Handlers/Public/UsercommentHandler.php

------
https://chatgpt.com/codex/tasks/task_e_68e495919bcc8325b7f308f31fdbeaff