### PR TITLE
Convert public handlers batch 90-5

### DIFF
--- a/classes/Http/Handlers/Public/TvshowsHandler.php
+++ b/classes/Http/Handlers/Public/TvshowsHandler.php
@@ -1,34 +1,247 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Image;
 
 final class TvshowsHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/tvshows.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $cache, $container, $fluent;
+
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Image $images */
+            $images = $container->get(Image::class);
+
+            $user = check_user_status();
+            $validSearch = [
+                'sn',
+                'sys',
+                'sye',
+                'srs',
+                'sre',
+            ];
+
+            $countQuery = $fluent->from('torrents AS t')
+                ->select(null)
+                ->select('COUNT(t.id) AS count')
+                ->where('t.category', $config->get('categories.tv'));
+
+            $selectQuery = $fluent->from('torrents AS t')
+                ->select(null)
+                ->select('t.id')
+                ->select('t.name')
+                ->select('t.poster')
+                ->select('t.imdb_id')
+                ->select('t.seeders')
+                ->select('t.leechers')
+                ->select('t.year')
+                ->select('t.rating')
+                ->where('t.category', $config->get('categories.tv'))
+                ->groupBy('t.imdb_id, t.id');
+
+            if (($user['hidden'] ?? 0) === 0) {
+                $countQuery->leftJoin('categories AS c ON t.category = c.id')
+                    ->where('c.hidden = 0');
+                $selectQuery->leftJoin('categories AS c ON t.category = c.id')
+                    ->where('c.hidden = 0');
+            }
+
+            $request = $_GET;
+            $selfUrl = $_SERVER['PHP_SELF'] ?? '';
+            $addParam = [];
+            foreach ($validSearch as $search) {
+                if (!empty($request[$search])) {
+                    $cleaned = searchfield($request[$search]);
+                    if ($search !== 'srs' && $search !== 'sre') {
+                        $addParam[] = sprintf('%s=%s', $search, urlencode($cleaned));
+                    }
+                }
+            }
+
+            if (!empty($request['sn'])) {
+                $countQuery->where('MATCH (t.name) AGAINST (? IN NATURAL LANGUAGE MODE)', searchfield($request['sn']));
+                $selectQuery->where('MATCH (t.name) AGAINST (? IN NATURAL LANGUAGE MODE)', searchfield($request['sn']));
+            }
+            if (!empty($request['sys'])) {
+                $countQuery->where('t.year >= ?', (int) $request['sys']);
+                $selectQuery->where('t.year >= ?', (int) $request['sys'])
+                    ->orderBy('t.year DESC');
+            }
+            if (!empty($request['sye'])) {
+                $countQuery->where('t.year <= ?', (int) $request['sye']);
+                $selectQuery->where('t.year <= ?', (int) $request['sye'])
+                    ->orderBy('t.year DESC');
+            }
+            if (!empty($request['srs'])) {
+                // TODO(2025): Confirm legacy query param key for rating lower bound from public/tvshows.php
+                $addParam[] = sprintf('%s=%s', 'srs', urlencode($request['srs']));
+                $countQuery->where('t.rating >= ?', (float) $request['srs']);
+                $selectQuery->where('t.rating >= ?', (float) $request['srs'])
+                    ->orderBy('t.rating DESC');
+            }
+            if (!empty($request['sre'])) {
+                // TODO(2025): Confirm legacy query param key for rating upper bound from public/tvshows.php
+                $addParam[] = sprintf('%s=%s', 'sre', urlencode($request['sre']));
+                $countQuery->where('t.rating <= ?', (float) $request['sre']);
+                $selectQuery->where('t.rating <= ?', (float) $request['sre'])
+                    ->orderBy('t.rating DESC');
+            }
+
+            $count = (int) $countQuery->fetch('count');
+            $perPage = 25;
+            $baseUrl = (string) $config->get('paths.baseurl');
+            $querySuffix = !empty($addParam) ? '?' . implode('&amp;', $addParam) . '&amp;' : '?';
+            $pager = pager($perPage, $count, sprintf('%s/tmovies.php%s', $baseUrl, $querySuffix));
+
+            $selectQuery->limit($pager['pdo']['limit'])
+                ->offset($pager['pdo']['offset'])
+                ->orderBy('t.added DESC');
+
+            $HTMLOUT = "
+    <h1 class='has-text-centered top20'>" . _('TV Shows') . '</h1>';
+
+            $body = "
+        <div class='masonry padding20'>";
+            foreach ($selectQuery as $torrent) {
+                $cast = $cache->get('cast_' . $torrent['imdb_id']);
+                if ($cast === false || $cast === null) {
+                    $cast = $fluent->from('person AS p')
+                        ->select(null)
+                        ->select('p.name')
+                        ->innerJoin('imdb_person AS i ON p.imdb_id = i.person_id')
+                        ->where('i.imdb_id = ?', str_replace('tt', '', $torrent['imdb_id']))
+                        ->where('i.type = "cast"')
+                        ->orderBy('p.name')
+                        ->limit(7)
+                        ->fetchAll();
+                    $cache->set('cast_' . $torrent['imdb_id'], $cast, 604800);
+                }
+
+                $casts[] = $cast;
+                $people = [];
+                foreach ($cast as $person) {
+                    $people[] = "<div class='size_2'><a href='{$baseUrl}/browse.php?sp=" . urlencode(htmlsafechars($person['name'])) . "'>" . format_comment($person['name']) . '</a></div>';
+                }
+
+                $name = "<a href='{$baseUrl}/browse.php?si={$torrent['imdb_id']}'>" . format_comment($torrent['name']) . '</a>';
+                $image = null;
+                if (empty($torrent['poster'])) {
+                    if (!empty($torrent['imdb_id'])) {
+                        $image = $images->find_images($torrent['imdb_id'], 'poster');
+                    }
+                    if (!empty($image)) {
+                        $image = url_proxy($image, true);
+                    } else {
+                        $image = $config->get('paths.images_baseurl') . 'noposter.png';
+                    }
+                } else {
+                    $image = url_proxy($torrent['poster'], true);
+                }
+
+                $percent = (float) $torrent['rating'] * 10;
+                $rating = "
+                <a href='{$baseUrl}/browse.php?srs={$torrent['rating']}&amp;sre={$torrent['rating']}'>
+                    <div>
+                        <div class='level-left size_3'>
+                            <div class='right5'>{$percent}%</div>
+                            <div class='star-ratings-css'>
+                                <div class='star-ratings-css-top' style='width: {$percent}%'><span>★</span><span>★</span><span>★</span><span>★</span><span>★</span></div>
+                                <div class='star-ratings-css-bottom'><span>★</span><span>★</span><span>★</span><span>★</span><span>★</span></div>
+                            </div>
+                        </div>
+                    </div>
+                </a>";
+
+                $seeders = "<a href='{$baseUrl}/peerlist.php?id={$torrent['seeders']}#seeders'>{$torrent['seeders']}</a>";
+                $leechers = "<a href='{$baseUrl}/peerlist.php?id={$torrent['leechers']}#leechers'>{$torrent['leechers']}</a>";
+                $year = "<a href='{$baseUrl}/browse.php?sys={$torrent['year']}&amp;sye={$torrent['year']}'>{$torrent['year']}</a>";
+
+                $body .= "
+                <div class='masonry-item padding10 bg-04 round10'>
+                    <div class='columns'>
+                        <div class='column'>
+                            <img src='{$image}' alt='" . htmlsafechars($torrent['name']) . "'>
+                        </div>
+                        <div class='column'>
+                            <div class='has-text-left size_4 torrent-name'>$name <span class='size_2'>({$year})</span></div>
+                            $rating
+                            <div class='size_2'>
+                                <span class='has-text-primary'>" . _('Peers') . ":</span>
+                                <span class='has-text-primary'> {$seeders} / {$leechers}</span>
+                            </div>" . implode("\n", $people) . '
+                        </div>
+                    </div>
+                </div>';
+            }
+            $body .= '
+        </div>';
+
+            $HTMLOUT .= main_div("
+            <form id='test1' method='get' action='{$baseUrl}/tmovies.php' enctype='multipart/form-data' accept-charset='utf-8'>
+                <div class='padding20'>
+                    <div class='padding10 w-100'>
+                        <div class='columns'>
+                            <div class='column'>
+                                <div class='has-text-centered bottom10'>" . _('Name') . "</div>
+                                <input id='search' name='sn' type='text' placeholder='" . _('Search by Name') . "' class='search w-100' value='" . (!empty($request['sn']) ? $request['sn'] : '') . "' onkeyup='autosearch()'>
+                            </div>
+                            <div class='column'>
+                                <div class='columns'>
+                                    <div class='column'>
+                                        <div class='has-text-centered bottom10'>" . _('Year') . "</div>
+                                        <input name='sys' type='number' min='1900' max='" . (date('Y') + 1) . "' placeholder='" . _('From Year Released') . "' class='search w-100' value='" . (!empty($request['sys']) ? $request['sys'] : '') . "'>
+                                    </div>
+                                    <div class='column'>
+                                        <div class='has-text-centered bottom10'>" . _('Year') . "</div>
+                                        <input name='sye' type='number' min='1900' max='" . (date('Y') + 1) . "' placeholder='" . _('To Year Released') . "' class='search w-100' value='" . (!empty($request['sye']) ? $request['sye'] : '') . "'>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class='column'>
+                                <div class='columns'>
+                                    <div class='column'>
+                                        <div class='has-text-centered bottom10'>" . _('Rating') . "</div>
+                                        <input name='srs' type='number' min='0' max='10' step='0.1' placeholder='" . _('From IMDb Rating') . "' class='search w-100' value='" . (!empty($request['srs']) ? $request['srs'] : '') . "'>
+                                    </div>
+                                    <div class='column'>
+                                        <div class='has-text-centered bottom10'>" . _('Rating') . "</div>
+                                        <input name='sre' type='number' min='0' max='10' step='0.1' placeholder='" . _('To IMDb Rating') . "' class='search w-100' value='" . (!empty($request['sre']) ? $request['sre'] : '') . "'>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class='margin10 has-text-centered'>
+                        <input type='submit' value='" . _('Search!') . "' class='button is-small'>
+                    </div>
+                </div>
+            </form>");
+
+            $HTMLOUT .= "<div class='top20'>" . ($count > $perPage ? $pager['pagertop'] : '') . main_div($body, 'top20') . ($count > $perPage ? $pager['pagertop'] : '') . '</div>';
+
+            $title = _('Search TV Shows');
+            $breadcrumbs = [
+                "<a href='{$baseUrl}/browse.php'>" . _('Browse Torrents') . '</a>',
+                sprintf("<a href='%s'>%s</a>", $selfUrl, $title),
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs) . wrapper($HTMLOUT) . stdfoot();
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/TvshowsHandler.php.bak
+++ b/classes/Http/Handlers/Public/TvshowsHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class TvshowsHandler
@@ -8,9 +10,25 @@ final class TvshowsHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/tvshows.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/tvshows.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UpcomingHandler.php
+++ b/classes/Http/Handlers/Public/UpcomingHandler.php
@@ -1,34 +1,292 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
 
 namespace PU239\Http\Handlers\Public;
+
+use Pu239\Config\ConfigRepository;
+use Pu239\Session;
+use Pu239\Upcoming;
+use Rakit\Validation\Validator;
 
 final class UpcomingHandler
 {
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
-        $target = __DIR__ . '/../../../../public/upcoming.php';
-        if (!is_file($target)) {
-            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
-            http_response_code(500);
-            echo 'Service temporarily unavailable';
-            return;
-        }
-        $out = (static function (string $file): string {
-            ob_start();
-            try {
-                require $file;
-            } catch (\Throwable $e) {
-                error_log('Legacy stub error: ' . $e->getMessage());
-            }
-            return (string) ob_get_clean();
-        })($target);
+        // AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
+        try {
+            require_once \dirname(__DIR__, 4) . '/bootstrap_web.php';
+            require_once \dirname(__DIR__, 4) . '/include/bittorrent.php';
 
-        // Optional: allow middleware or further processing here
-        echo $out;
+            global $container;
+            /** @var ConfigRepository $config */
+            $config = $container->get(ConfigRepository::class);
+            /** @var Upcoming $cooker */
+            $cooker = $container->get(Upcoming::class);
+            /** @var Session $session */
+            $session = $container->get(Session::class);
+
+            $user = check_user_status();
+
+            $stdfoot = [
+                'js' => [
+                    get_file_name('imdb_js'),
+                    get_file_name('dragndrop_js'),
+                ],
+            ];
+            $hasAccess = has_access($user['class'], UC_USER, 'internal') || has_access($user['class'], UC_STAFF, '');
+            $session->set('post_data', $_POST);
+
+            $request = $_GET;
+            $self = $_SERVER['PHP_SELF'] ?? '';
+            $postData = $session->get('post_data');
+            $viewAll = $add = $edit = $delete = false;
+            $id = 0;
+            if (isset($request['action'])) {
+                switch ($request['action']) {
+                    case 'view_all':
+                        $viewAll = true;
+                        break;
+                    case 'add_recipe':
+                        $add = true;
+                        break;
+                    case 'edit_recipe':
+                        $edit = true;
+                        $id = isset($request['id']) ? (int) $request['id'] : 0;
+                        $postData = $cooker->get($id);
+                        break;
+                    case 'delete_recipe':
+                        $delete = true;
+                        $id = isset($request['id']) ? (int) $request['id'] : 0;
+                        break;
+                }
+            }
+
+            if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
+                // TODO(2025): add CSRF verification for upcoming handler form
+                /** @var Validator $validator */
+                $validator = $container->get(Validator::class);
+                $validation = $validator->validate($_POST, [
+                    'type' => 'required|numeric',
+                    'name' => 'required|regex:/[A-Za-z0-9\:_\-\s]/',
+                    'poster' => 'required|url:http,https',
+                    'status' => 'required|in:sourcing,ftping,encoding,remuxing,uploaded',
+                    'url' => 'required|url:http,https',
+                    'expected' => 'required|date:Y-m-d\TH:i',
+                    'id' => 'numeric',
+                ]);
+                if ($validation->fails()) {
+                    $errors = $validation->errors();
+                    stderr(_('Error'), $errors->firstOfAll()['name']);
+                    app_halt('Exit called');
+                }
+
+                $values = [
+                    'category' => (int) ($_POST['type'] ?? 0),
+                    'name' => htmlsafechars($_POST['name'] ?? ''),
+                    'poster' => htmlsafechars($_POST['poster'] ?? ''),
+                    'status' => htmlsafechars($_POST['status'] ?? ''),
+                    'url' => htmlsafechars($_POST['url'] ?? ''),
+                    'expected' => date('Y-m-d H:i:s', strtotime((string) ($_POST['expected'] ?? 'now'))),
+                    'userid' => $user['id'],
+                    'show_index' => 1,
+                ];
+                if ($add) {
+                    if ($cooker->insert($values)) {
+                        $session->unset('post_data');
+                        $session->set('is-success', _fe('Recipe: {0} Added', format_comment($_POST['name'] ?? '')));
+                        header('Location: ' . $self);
+                        app_halt('Exit called');
+                    }
+                } elseif ($edit) {
+                    if ($cooker->update($values, (int) ($_POST['id'] ?? 0))) {
+                        $session->set('is-success', _fe('Recipe: {0} Updated', format_comment($_POST['name'] ?? '')));
+                        header('Location: ' . $self);
+                        app_halt('Exit called');
+                    }
+                }
+            }
+
+            $HTMLOUT = $addNew = $update = '';
+            $today = date('Y-m-d\TH:i', TIME_NOW);
+            $futureDate = empty($postData['expected'])
+                ? date('Y-m-d\TH:i', strtotime('+7 day'))
+                : date('Y-m-d\TH:i', strtotime((string) $postData['expected']));
+
+            $form = "
+                <div class='columns is-marginless is-paddingless'>
+                    <div class='column is-one-quarter has-text-left'>" . _('Category') . "</div>
+                    <div class='column'>
+                        " . category_dropdown($config->get('categories.movie')) . "
+                    </div>
+                </div>
+                <div class='columns is-marginless is-paddingless'>
+                    <div class='column is-one-quarter has-text-left'>" . _('Upcoming') . "</div>
+                    <div class='column'>
+                        <input type='text' class='w-100' name='name' autocomplete='on' value='" . (!empty($postData['name']) ? htmlsafechars($postData['name']) : '') . "' required>
+                    </div>
+                </div>
+                <div class='columns is-marginless is-paddingless'>
+                    <div class='column is-one-quarter has-text-left'>" . _('Poster') . "</div>
+                    <div class='column'>
+                        <input type='url' id='image_url' placeholder='" . _('External Image URL') . "' class='w-100' onchange=\"return grab_url(event)\" value='" . (!empty($postData['poster']) ? htmlsafechars($postData['poster']) : '') . "'>
+                        <input type='url' id='poster' maxlength='255' name='poster' class='w-100 is-hidden' value='" . (!empty($postData['poster']) ? htmlsafechars($postData['poster']) : '') . "'>
+                        <div class='poster_container has-text-centered'></div>
+                        <div id='droppable' class='droppable bg-03 top20'>
+                            <span id='comment'>" . _('Drop images or click here to select images.') . "</span>
+                            <div id='loader' class='is-hidden'>
+                                <img src='{$config->get('paths.images_baseurl')}/forums/updating.svg' alt='Loading...'>
+                            </div>
+                        </div>
+                        <div class='output-wrapper output'></div>
+                    </div>
+                </div>
+                <div class='columns is-marginless is-paddingless'>
+                    <div class='column is-one-quarter has-text-left'>" . _('Status') . "</div>
+                    <div class='column'>
+                        <select name='status' class='w-100' required>
+                            <option value='' disabled selected>" . _('Select Status') . "</option>
+                            <option value='sourcing' " . (!empty($postData['status']) && $postData['status'] === 'sourcing' ? 'selected' : '') . '>' . _('Sourcing') . "</option>
+                            <option value='ftping' " . (!empty($postData['status']) && $postData['status'] === 'ftping' ? 'selected' : '') . '>' . _('FTPing') . "</option>
+                            <option value='encoding' " . (!empty($postData['status']) && $postData['status'] === 'encoding' ? 'selected' : '') . '>' . _('Encoding') . "</option>
+                            <option value='remuxing' " . (!empty($postData['status']) && $postData['status'] === 'remuxing' ? 'selected' : '') . '>' . _('Remuxing') . "</option>
+                            <option value='uploaded' " . (!empty($postData['status']) && $postData['status'] === 'uploaded' ? 'selected' : '') . '>' . _('Uploaded') . "</option>
+                        </select>
+                    </div>
+                </div>
+                <div class='columns is-marginless is-paddingless'>
+                    <div class='column is-one-quarter has-text-left'>" . _('IMDb Link') . "</div>
+                    <div class='column'>
+                        <input type='url' class='w-100' id='url' name='url' autocomplete='on' value='" . (!empty($postData['url']) ? htmlsafechars($postData['url']) : '') . "' required>
+                        <div id='imdb_outer'></div>
+                    </div>
+                </div>
+               <div class='columns is-marginless is-paddingless'>
+                    <div class='column is-one-quarter has-text-left'>" . _('Expected') . "</div>
+                    <div class='column'>
+                        <input type='datetime-local' class='w-100' name='expected' value='$futureDate' min='$today' required>
+                    </div>
+                </div>";
+
+            if ($hasAccess) {
+                if ($add) {
+                    $addNew = "
+            <h2 class='has-text-centered'>Add Recipe</h2>
+            <form class='form-inline table-wrapper' method='post' action='{$_SERVER['PHP_SELF']}?action=add_recipe' enctype='multipart/form-data' accept-charset='utf-8'>$form
+                <div class='has-text-centered'>
+                    <input type='submit' value='" . _('Add') . "' class='button is-small'>
+                </div>
+            </form>";
+                    $addNew = main_div($addNew, 'has-text-centered w-75 min-350', 'padding20');
+                } elseif ($edit && is_valid_id($id)) {
+                    $update = "
+            <h2 class='has-text-centered'>Edit Recipe</h2>
+            <form class='form-inline table-wrapper' method='post' action='{$_SERVER['PHP_SELF']}?action=edit_recipe' enctype='multipart/form-data' accept-charset='utf-8'>$form
+                <div class='has-text-centered'>
+                    <input type='hidden' name='id' value='{$id}'>
+                    <input type='submit' value='" . _('Update') . "' class='button is-small'>
+                </div>
+            </form>";
+                    $update = main_div($update, 'has-text-centered w-75 min-350', 'padding20');
+                } elseif ($delete && is_valid_id($id)) {
+                    if ($cooker->delete($id, $user['class'] >= UC_STAFF, $user['id']) === 1) {
+                        $session->set('is-success', _('Recipe Deleted'));
+                    } else {
+                        $session->set('is-warning', _('Recipe was NOT Deleted'));
+                    }
+                }
+            }
+
+            $count = $cooker->get_count(false, (bool) $user['hidden']);
+            $perPage = 25;
+            $pager = pager($perPage, $count, $self . '?');
+            $menuTop = $count > $perPage ? $pager['pagertop'] : '';
+            $menuBottom = $count > $perPage ? $pager['pagerbottom'] : '';
+
+            $recipes = $cooker->get_all($pager['pdo']['limit'], $pager['pdo']['offset'], 'expected', true, $viewAll, false, (bool) $user['hidden']);
+
+            $HTMLOUT .= "
+    <ul class='level-center bg-06 padding10'>
+        <li><a href='{$self}?action=add_recipe'>" . _('Add Recipe') . '</a></li>' . ($viewAll ? "
+        <li><a href='{$self}'>" . _('View Recipes in the Oven') . '</a></li>' : "
+        <li><a href='{$self}?action=view_all'>" . _('View All Recipes') . '</a></li>') . "
+    </ul>";
+
+            if ($hasAccess && has_access($user['class'], UC_STAFF, '')) {
+                $HTMLOUT .= "
+    <div class='level-center top20'>
+        <a class='button is-small' href='{$self}?action=add_recipe'>" . _('Add Recipe') . "</a>
+        <a class='button is-small margin10' href='{$self}?action=view_all'>" . _('View All Recipes') . "</a>
+        <a class='button is-small' href='{$config->get('paths.baseurl')}/uploadapp.php'>" . _('Upload Applications') . "</a>
+    </div>";
+            }
+
+            if (!empty($session->get('is-success'))) {
+                $HTMLOUT .= main_div($session->get('is-success'), 'padding20 has-text-centered', 'bg-success');
+                $session->unset('is-success');
+            }
+            if (!empty($session->get('is-warning'))) {
+                $HTMLOUT .= main_div($session->get('is-warning'), 'padding20 has-text-centered', 'bg-warning');
+                $session->unset('is-warning');
+            }
+
+            if (!empty($addNew)) {
+                $HTMLOUT .= $addNew;
+            }
+            if (!empty($update)) {
+                $HTMLOUT .= $update;
+            }
+
+            if (!empty($recipes)) {
+                $tableRows = '';
+                foreach ($recipes as $recipe) {
+                    $poster = !empty($recipe['poster']) ? "<img src='" . htmlsafechars(url_proxy($recipe['poster'], true)) . "' alt='Poster'>" : '';
+                    $expected = get_date(strtotime((string) $recipe['expected']), 'LONG', 1, 0);
+                    $actions = '';
+                    if ($hasAccess) {
+                        $actions = "
+                            <div class='buttons'>
+                                <a class='button is-small' href='{$self}?action=edit_recipe&amp;id={$recipe['id']}'>" . _('Edit') . "</a>
+                                <a class='button is-small is-danger' href='{$self}?action=delete_recipe&amp;id={$recipe['id']}'>" . _('Delete') . "</a>
+                            </div>";
+                    }
+
+                    $tableRows .= "
+                        <tr>
+                            <td class='w-10'>{$poster}</td>
+                            <td class='w-20'>" . htmlsafechars($recipe['name']) . "</td>
+                            <td class='w-10'>" . htmlsafechars($recipe['status']) . "</td>
+                            <td class='w-20'><a href='{$recipe['url']}' target='_blank' rel='noopener noreferrer'>" . _('View on IMDb') . "</a></td>
+                            <td class='w-20'>{$expected}</td>
+                            <td class='w-20'>{$actions}</td>
+                        </tr>";
+                }
+                $HTMLOUT .= $menuTop;
+                $HTMLOUT .= main_table($tableRows, "
+                    <tr>
+                        <th class='w-10'>" . _('Poster') . "</th>
+                        <th class='w-20'>" . _('Name') . "</th>
+                        <th class='w-10'>" . _('Status') . "</th>
+                        <th class='w-20'>" . _('IMDb') . "</th>
+                        <th class='w-20'>" . _('Expected') . "</th>
+                        <th class='w-20'>" . _('Actions') . "</th>
+                    </tr>");
+                $HTMLOUT .= $menuBottom;
+            } else {
+                $HTMLOUT .= main_div(_('There are no upcoming recipes at this time.'), 'padding20 has-text-centered');
+            }
+
+            $title = _('Upcoming Releases');
+            $breadcrumbs = [
+                sprintf("<a href='%s'>%s</a>", $self, $title),
+            ];
+            echo stdhead($title, [], 'page-wrapper', $breadcrumbs, $stdfoot) . wrapper($HTMLOUT) . stdfoot($stdfoot);
+        } catch (\Throwable $e) {
+            error_log('Converted handler error: ' . $e->getMessage());
+            http_response_code(500);
+            echo 'Internal error';
+        }
     }
 }

--- a/classes/Http/Handlers/Public/UpcomingHandler.php.bak
+++ b/classes/Http/Handlers/Public/UpcomingHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class UpcomingHandler
@@ -8,9 +10,25 @@ final class UpcomingHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/upcoming.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/upcoming.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UploadHandler.php
+++ b/classes/Http/Handlers/Public/UploadHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,7 +10,7 @@ final class UploadHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
+        // STUB_UPGRADED preserved: complex legacy include
         $target = __DIR__ . '/../../../../public/upload.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
@@ -21,6 +21,7 @@ final class UploadHandler
         $out = (static function (string $file): string {
             ob_start();
             try {
+                // TODO(2025): extract legacy block for manual conversion from public/upload.php:1-400
                 require $file;
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
@@ -28,7 +29,6 @@ final class UploadHandler
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UploadHandler.php.bak
+++ b/classes/Http/Handlers/Public/UploadHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class UploadHandler
@@ -8,9 +10,25 @@ final class UploadHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/upload.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/upload.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UploadappHandler.php
+++ b/classes/Http/Handlers/Public/UploadappHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,7 +10,6 @@ final class UploadappHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
         $target = __DIR__ . '/../../../../public/uploadapp.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
@@ -21,6 +20,7 @@ final class UploadappHandler
         $out = (static function (string $file): string {
             ob_start();
             try {
+                // TODO(2025): extract legacy block for manual conversion from public/uploadapp.php:1-320
                 require $file;
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
@@ -28,7 +28,6 @@ final class UploadappHandler
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UploadappHandler.php.bak
+++ b/classes/Http/Handlers/Public/UploadappHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class UploadappHandler
@@ -8,9 +10,25 @@ final class UploadappHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/uploadapp.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/uploadapp.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UserBlocksHandler.php
+++ b/classes/Http/Handlers/Public/UserBlocksHandler.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// Generated: STUB_UPGRADED
+// AUTO_CONVERT_ATTEMPTED: 2025-10-08 via handler-convert batch=90-5
 
 namespace PU239\Http\Handlers\Public;
 
@@ -10,7 +10,6 @@ final class UserBlocksHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // STUB_UPGRADED: safe buffered execution
         $target = __DIR__ . '/../../../../public/user_blocks.php';
         if (!is_file($target)) {
             error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
@@ -21,6 +20,7 @@ final class UserBlocksHandler
         $out = (static function (string $file): string {
             ob_start();
             try {
+                // TODO(2025): extract legacy block for manual conversion from public/user_blocks.php:1-320
                 require $file;
             } catch (\Throwable $e) {
                 error_log('Legacy stub error: ' . $e->getMessage());
@@ -28,7 +28,6 @@ final class UserBlocksHandler
             return (string) ob_get_clean();
         })($target);
 
-        // Optional: allow middleware or further processing here
         echo $out;
     }
 }

--- a/classes/Http/Handlers/Public/UserBlocksHandler.php.bak
+++ b/classes/Http/Handlers/Public/UserBlocksHandler.php.bak
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+// Generated: STUB_UPGRADED
+
 namespace PU239\Http\Handlers\Public;
 
 final class UserBlocksHandler
@@ -8,9 +10,25 @@ final class UserBlocksHandler
     /** @param array<string,mixed> $meta */
     public function handle(array $meta = []): void
     {
-        // Temporary: execute legacy script inside isolated scope
-        (static function (): void {
-            require __DIR__ . '/../../../../public/user_blocks.php';
-        })();
+        // STUB_UPGRADED: safe buffered execution
+        $target = __DIR__ . '/../../../../public/user_blocks.php';
+        if (!is_file($target)) {
+            error_log(sprintf('STUB MISSING: %s requires %s', __FILE__, $target));
+            http_response_code(500);
+            echo 'Service temporarily unavailable';
+            return;
+        }
+        $out = (static function (string $file): string {
+            ob_start();
+            try {
+                require $file;
+            } catch (\Throwable $e) {
+                error_log('Legacy stub error: ' . $e->getMessage());
+            }
+            return (string) ob_get_clean();
+        })($target);
+
+        // Optional: allow middleware or further processing here
+        echo $out;
     }
 }

--- a/tools/conversion_report/classes_Http_Handlers_Public_TvshowsHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_TvshowsHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/TvshowsHandler.php
+
+- Legacy source: public/tvshows.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/bittorrent.php
+- Config mappings: `$config->get('paths.baseurl')`, `$config->get('paths.images_baseurl')`, `$config->get('categories.tv')`
+- Database usage: Relies on legacy `$fluent` query builder for torrents and cast lookups (left intact for safety)
+- TODOs introduced: 2 (rating filter query param verification)
+- Notes: Embedded search/pager rendering and poster lookup via Image service; retained cache usage for cast listings.

--- a/tools/conversion_report/classes_Http_Handlers_Public_UpcomingHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_UpcomingHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/UpcomingHandler.php
+
+- Legacy source: public/upcoming.php
+- Container/bootstrap dependencies: bootstrap_web.php, include/bittorrent.php
+- Config mappings: `$config->get('paths.baseurl')`, `$config->get('categories.movie')`, `$config->get('paths.images_baseurl')`
+- Database usage: Delegated to `Upcoming` service for CRUD; pager uses existing helpers
+- TODOs introduced: 1 (CSRF protection reminder for POST actions)
+- Notes: Preserved session-driven form repopulation and staff controls; normalized self URL handling to avoid notices.

--- a/tools/conversion_report/classes_Http_Handlers_Public_UploadHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_UploadHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/UploadHandler.php
+
+- Legacy source: public/upload.php
+- Container/bootstrap dependencies: N/A (stub preserved pending manual extraction)
+- Config mappings: TODO — legacy script uses extensive `$config` and `$fluent` interactions
+- Database usage: TODO — heavy form processing with multiple queries; left to legacy include
+- TODOs introduced: 1 (manual extraction reminder in stub)
+- Notes: Marked for manual conversion due to complex uploader form logic, cache usage, and numerous service dependencies.

--- a/tools/conversion_report/classes_Http_Handlers_Public_UploadappHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_UploadappHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/UploadappHandler.php
+
+- Legacy source: public/uploadapp.php
+- Container/bootstrap dependencies: N/A (stub preserved pending manual extraction)
+- Config mappings: TODO — relies on `$config->get()` within legacy script
+- Database usage: TODO — manual review needed for insert/builders and notification fan-out
+- TODOs introduced: 1 (manual extraction reminder in stub)
+- Notes: Deferred conversion because the application workflow includes validation, messaging, and audit hooks that require manual porting.

--- a/tools/conversion_report/classes_Http_Handlers_Public_UserBlocksHandler.php.md
+++ b/tools/conversion_report/classes_Http_Handlers_Public_UserBlocksHandler.php.md
@@ -1,0 +1,8 @@
+# Conversion Report: classes/Http/Handlers/Public/UserBlocksHandler.php
+
+- Legacy source: public/user_blocks.php
+- Container/bootstrap dependencies: N/A (stub preserved pending manual extraction)
+- Config mappings: TODO — legacy script reads numerous config flags and bitmask constants
+- Database usage: TODO — heavy POST processing and bitfield updates remain in legacy include
+- TODOs introduced: 1 (manual extraction reminder in stub)
+- Notes: Deferred due to extensive block toggling logic and dependency on global `$BLOCKS` definitions.

--- a/tools/handler_convert_report.csv
+++ b/tools/handler_convert_report.csv
@@ -88,3 +88,8 @@ classes/Http/Handlers/Admin/CheatersHandler.php,true,1,Converted admin/cheaters.
 classes/Http/Handlers/Admin/DataresetHandler.php,false,1,TODO(2025) admin/datareset.php depends on removed $fluent queries
 classes/Http/Handlers/Admin/DeathrowHandler.php,false,1,TODO(2025) admin/deathrow.php requires bespoke notifier workflow port
 classes/Http/Handlers/Admin/FindnotconnectableHandler.php,false,1,TODO(2025) admin/findnotconnectable.php legacy mysqli/sql_query flow
+classes/Http/Handlers/Public/TvshowsHandler.php,true,2,Extracted from public/tvshows.php; verify rating query params
+classes/Http/Handlers/Public/UpcomingHandler.php,true,1,Extracted from public/upcoming.php; CSRF handling pending
+classes/Http/Handlers/Public/UploadHandler.php,false,1,TODO(2025) legacy script complex public/upload.php:1-400
+classes/Http/Handlers/Public/UploadappHandler.php,false,1,TODO(2025) legacy script complex public/uploadapp.php:1-320
+classes/Http/Handlers/Public/UserBlocksHandler.php,false,1,TODO(2025) legacy script complex public/user_blocks.php:1-320


### PR DESCRIPTION
## Summary
- inline the legacy public/tvshows.php workflow inside TvshowsHandler with container-config access and retained fluent queries
- embed public/upcoming.php logic into UpcomingHandler while preserving validation/session behaviours and documenting CSRF follow-up
- defer complex upload, uploadapp, and user_blocks stubs to manual conversion with TODO markers and per-file reports

## Testing
- php -l classes/Http/Handlers/Public/TvshowsHandler.php
- php -l classes/Http/Handlers/Public/UpcomingHandler.php
- php -l classes/Http/Handlers/Public/UploadHandler.php
- php -l classes/Http/Handlers/Public/UploadappHandler.php
- php -l classes/Http/Handlers/Public/UserBlocksHandler.php


------
https://chatgpt.com/codex/tasks/task_e_68e5ddd450108325bb06900c99caeff8