### PR TITLE
chore: ignore build artifacts and untrack generated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 .idea
 .php_cs.cache
 config/config.php
-node_modules/
-vendor/
+/node_modules
+/vendor
 cache/goaccess.html
+/public/build
+/public/hot
+/public/storage
+/.vite
+/.cache
+/storage/*.key
+/storage/app/public/*
+/resources/**/*.min.js
+/resources/**/*.min.css


### PR DESCRIPTION
## Summary
- extend the root .gitignore to cover build outputs and generated resources
- ensure generated build artifacts are no longer tracked by git

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69093e7e0b148325bc5bb68aa1e2a698